### PR TITLE
Proposal: markdown-it-htmyst

### DIFF
--- a/packages/markdown-it-htmyst/package.json
+++ b/packages/markdown-it-htmyst/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "markdown-it-myst",
+  "name": "markdown-it-htmyst",
   "version": "0.1.3",
   "sideEffects": false,
   "license": "MIT",
-  "description": "markdown-it tokenizer for MyST roles and directives",
-  "author": "Franklin Koch <franklin@curvenote.com>",
-  "homepage": "https://github.com/executablebooks/mystjs/tree/main/packages/markdown-it-myst",
+  "description": "markdown-it HTML hinter for MyST roles and directives",
+  "author": "Tavin Cole <7685034+tavin@users.noreply.github.com>",
+  "homepage": "https://github.com/executablebooks/mystjs/tree/main/packages/markdown-it-htmyst",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
@@ -30,7 +30,7 @@
     "build:esm": "tsc --project ./tsconfig.json --module es2015   --outDir dist/esm",
     "build:cjs": "tsc --project ./tsconfig.json --module commonjs --outDir dist/cjs",
     "declarations": "tsc --project ./tsconfig.json --declaration --emitDeclarationOnly --declarationMap --outDir dist/types",
-    "bundle": "esbuild dist/cjs/index.js --bundle --format=cjs --outfile=dist/markdown-it-myst.js",
+    "bundle": "esbuild dist/cjs/index.js --bundle --format=cjs --outfile=dist/markdown-it-htmyst.js",
     "build": "npm-run-all -l clean -p build:cjs build:esm declarations -s bundle",
     "lint": "eslint \"src/**/!(*.spec).ts\" -c ./.eslintrc.js",
     "lint:format": "npx prettier --check \"src/**/*.ts\"",
@@ -41,19 +41,6 @@
     "url": "https://github.com/executablebooks/mystjs/issues"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0",
-    "markdown-it": "^13.0.1",
-    "vfile": "^5.3.7"
-  },
-  "devDependencies": {
-    "@types/jest": "^28.1.6",
-    "eslint": "^8.21.0",
-    "eslint-config-curvenote": "latest",
-    "jest": "28.1.3",
-    "npm-run-all": "^4.1.5",
-    "prettier": "latest",
-    "rimraf": "^3.0.2",
-    "ts-jest": "^28.0.7",
-    "typescript": "latest"
+    "markdown-it": "^13.0.1"
   }
 }

--- a/packages/markdown-it-htmyst/src/admonition.ts
+++ b/packages/markdown-it-htmyst/src/admonition.ts
@@ -1,0 +1,75 @@
+import type StateCore from 'markdown-it/lib/rules_core/state_core';
+import type Token from 'markdown-it/lib/token';
+
+import {
+  findTokenPair,
+  ARG_OPEN,
+  ARG_CLOSE,
+  BODY_OPEN,
+  BODY_CLOSE,
+} from './util';
+
+const ADMONITIONS = [
+  'admonition',
+  'attention',
+  'caution',
+  'danger',
+  'error',
+  'hint',
+  'important',
+  'note',
+  'seealso',
+  'tip',
+  'warning',
+];
+
+/**
+ * Enrich admonition directives with markup tags.
+ *
+ * @return true if new tokens are inserted into the array
+ */
+export function admonitionDecorator(state: StateCore, tokens: Token[]): boolean {
+
+  let kind = tokens[0].info;
+
+  if (!ADMONITIONS.includes(kind)) return false;
+
+  let ins = false;
+  let [...arg] = findTokenPair(tokens, [ARG_OPEN, ARG_CLOSE], 1);
+
+  if (arg[1] === undefined) {
+    const title = new state.Token('inline', '', 0);
+    title.content = kind.replace(/^./, char => char.toUpperCase());
+    title.children = [];
+    tokens.splice(1, 0, new state.Token(ARG_OPEN, 'p', 1),
+                  title, new state.Token(ARG_CLOSE, 'p', -1));
+    arg = [1, 3];
+    ins = true;
+  }
+
+  let [...body] = findTokenPair(tokens, [BODY_OPEN, BODY_CLOSE], 1);
+
+  tokens.at(0).attrSet('class', `admonition ${kind}`);
+  tokens.at(arg[0]).attrSet('class', 'admonition-title');
+
+  [0, -1].map(tokens.at, tokens).forEach(token => {
+    token.hidden = false;
+    token.block = true;
+    token.tag = 'aside';
+  });
+
+  arg.map(tokens.at, tokens).forEach(token => {
+    token.hidden = false;
+    token.block = true;
+    token.tag = 'p';
+  });
+
+  body.map(tokens.at, tokens).forEach(token => {
+    token.hidden = false;
+    token.block = true;
+    token.tag = 'div';
+  });
+
+  return ins;
+}
+

--- a/packages/markdown-it-htmyst/src/index.ts
+++ b/packages/markdown-it-htmyst/src/index.ts
@@ -1,0 +1,57 @@
+import type MarkdownIt from 'markdown-it/lib';
+import type StateCore from 'markdown-it/lib/rules_core/state_core';
+import type Token from 'markdown-it/lib/token';
+
+import { admonitionDecorator } from './admonition';
+import { proofDecorator } from './proof';
+
+type Decorator = (state: StateCore, tokens: Token[]) => boolean | void;
+
+const DEFAULT_DECORATORS = [
+  admonitionDecorator,
+  proofDecorator,
+];
+
+/**
+ * Factory to implement the following rule:
+ *
+ * - Run through the parsed token array.
+ * - Find all slices from `parsed_directive_open` to `parsed_directive_close`.
+ * - Pass the slices through the decorators.
+ */
+function rule(decorators: Decorator[] = DEFAULT_DECORATORS) {
+
+  return (state: StateCore) => {
+    const tokens = state.tokens;
+    const stack = [];
+    for (let j = 0; j < tokens.length; ++j) {
+      if (tokens[j].type === 'parsed_directive_open') {
+        stack.push(j);
+      } else if (tokens[j].type === 'parsed_directive_close') {
+        let i = stack.pop()!;
+        // in principle we'd like a view of the array from i to j;
+        // hopefully all modern JS engines like V8 will optimize slice() as COW
+        const slice = tokens.slice(i, j + 1);
+        let subst = false;
+        for (let fn of decorators) {
+          subst = fn(state, slice) || subst;
+        }
+        if (subst) {
+          tokens.splice(i, j - i + 1, ...slice);
+          j = i + slice.length - 1;
+        }
+      }
+    }
+  };
+}
+
+/**
+ * A markdown-it plugin for adding markup to parsed myst directives.
+ */
+export function htmystPlugin(md: MarkdownIt, ...decorators: Decorator[]) {
+  md.core.ruler.after('run_directives', 'decorate_directives',
+                      decorators.length ? rule(decorators) : rule());
+}
+
+export default htmystPlugin;
+

--- a/packages/markdown-it-htmyst/src/proof.ts
+++ b/packages/markdown-it-htmyst/src/proof.ts
@@ -1,0 +1,65 @@
+import type StateCore from 'markdown-it/lib/rules_core/state_core';
+import type Token from 'markdown-it/lib/token';
+
+import {
+  findTokenPair,
+  ARG_OPEN,
+  ARG_CLOSE,
+  BODY_OPEN,
+  BODY_CLOSE,
+} from './util';
+
+/**
+ * Enrich proof directives with markup tags.
+ *
+ * @return true if new tokens are inserted into the array
+ */
+export function proofDecorator(state: StateCore, tokens: Token[]): boolean {
+
+  let kind = tokens[0].info;
+
+  if (!kind.startsWith('prf:')) return false;
+
+  const title = new state.Token('inline', '', 0);
+  title.content = kind.replace(/^prf:(.)/, (_, char) => char.toUpperCase());
+  title.children = [];
+
+  let [...arg] = findTokenPair(tokens, [ARG_OPEN, ARG_CLOSE], 1);
+
+  if (arg[1] === undefined) {
+    tokens.splice(1, 0, new state.Token(ARG_OPEN, 'p', 1),
+                  title, new state.Token(ARG_CLOSE, 'p', -1));
+    arg = [1, 3];
+  } else {
+    title.content += ': ';
+    tokens.splice(arg[0] + 1, 0, title);
+    ++arg[1];
+  }
+
+  let [...body] = findTokenPair(tokens, [BODY_OPEN, BODY_CLOSE], 1);
+
+  tokens.at(0).attrSet('class', 'admonition');
+  tokens.at(0).attrJoin('class', kind.replace(':', '-'));
+  tokens.at(arg[0]).attrSet('class', 'admonition-title');
+
+  [0, -1].map(tokens.at, tokens).forEach(token => {
+    token.hidden = false;
+    token.block = true;
+    token.tag = 'aside';
+  });
+
+  arg.map(tokens.at, tokens).forEach(token => {
+    token.hidden = false;
+    token.block = true;
+    token.tag = 'p';
+  });
+
+  body.map(tokens.at, tokens).forEach(token => {
+    token.hidden = false;
+    token.block = true;
+    token.tag = 'div';
+  });
+
+  return true;
+}
+

--- a/packages/markdown-it-htmyst/src/util.ts
+++ b/packages/markdown-it-htmyst/src/util.ts
@@ -1,0 +1,36 @@
+import type Token from 'markdown-it/lib/token';
+
+export const ARG_OPEN = 'directive_arg_open';
+export const ARG_CLOSE = 'directive_arg_close';
+export const BODY_OPEN = 'directive_body_open';
+export const BODY_CLOSE = 'directive_body_close';
+
+/**
+ * Find open/close pairs in a token array.
+ */
+export function* findTokenPair(
+  tokens: Token[],
+  pair: [string, string],
+  from: number = 0
+): Generator<number> {
+
+  let pos = from - 1;
+  let depth = 0;
+
+  while (++pos < tokens.length) {
+    depth += tokens[pos].nesting;
+    if (depth == 1 && tokens[pos].type == pair[0]) {
+      yield pos;
+      break;
+    }
+  }
+
+  while (++pos < tokens.length) {
+    depth += tokens[pos].nesting;
+    if (depth == 0 && tokens[pos].type == pair[1]) {
+      yield pos;
+      break;
+    }
+  }
+}
+

--- a/packages/markdown-it-htmyst/tsconfig.json
+++ b/packages/markdown-it-htmyst/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    // module is overridden from the build:esm/build:cjs scripts
+    "module": "es2015",
+    "jsx": "react-jsx",
+    "lib": ["es2020"],
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "strict": true,
+    "strictNullChecks": false,
+    "moduleResolution": "node",
+    "sourceMap": false,
+    // outDir is overridden from the build:esm/build:cjs scripts
+    "outDir": "dist/types",
+    "baseUrl": "src",
+    "paths": {
+      "*": ["node_modules/*"]
+    },
+    // Type roots allows it to be included in a workspace
+    "typeRoots": [
+      "./types",
+      "./node_modules/@types",
+      "../../node_modules/@types",
+      "../../../node_modules/@types"
+    ],
+    "resolveJsonModule": true,
+    // Ignore node_modules, etc.
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["tests/**/*"]
+}


### PR DESCRIPTION
Hi @rowanc1 as a followup of sorts to https://github.com/executablebooks/markdown-it-docutils/issues/48 and https://github.com/executablebooks/mystjs/issues/181, I'd like to propose adding something like this to mystjs.

It's a first cut at what you said is the "best path".

The code I have so far supports admonitions and prf directives in a rudimentary way. Of course you also need a bit of CSS to see that.

Could we maybe discuss this in a bit more depth? I could find a way to demonstrate it. Right now I can personally confirm it solves the problem of rendering myst directives in e.g. wiki software that currently supports markdown-it... @sneakers-the-rat.