### PR TITLE
:1234: Support for scientific notation and decimal numbers in `si` role

### DIFF
--- a/packages/myst-parser/tests/roles/si.yml
+++ b/packages/myst-parser/tests/roles/si.yml
@@ -50,3 +50,39 @@ cases:
                   unit: Hz
                   units: [hertz]
                   value: 1.345e10 Hz
+
+  - title: negative decimal number parses
+    markdown: '{si}`-1.345e10 <\hertz>`'
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: mystRole
+              name: si
+              value: -1.345e10 <\hertz>
+              children:
+                - type: si
+                  alt: hertz
+                  number: '-1.345e10'
+                  unit: Hz
+                  units: [hertz]
+                  value: -1.345e10 Hz
+
+  - title: no-exponent decimal number parses
+    markdown: '{si}`1.345 <\hertz>`'
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: mystRole
+              name: si
+              value: 1.345 <\hertz>
+              children:
+                - type: si
+                  alt: hertz
+                  number: '1.345'
+                  unit: Hz
+                  units: [hertz]
+                  value: 1.345 Hz

--- a/packages/myst-parser/tests/roles/si.yml
+++ b/packages/myst-parser/tests/roles/si.yml
@@ -32,3 +32,22 @@ cases:
                   unit: Hz
                   units: [hertz]
                   value: 100 Hz
+
+
+  - title: decimal number parses
+    markdown: '{si}`1.345e10 <\hertz>`'
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: mystRole
+              name: si
+              value: 1.345e10 <\hertz>
+              children:
+                - type: si
+                  alt: hertz
+                  number: '1.345e10'
+                  unit: Hz
+                  units: [hertz]
+                  value: 1.345e10 Hz

--- a/packages/myst-parser/tests/roles/si.yml
+++ b/packages/myst-parser/tests/roles/si.yml
@@ -69,7 +69,7 @@ cases:
                   units: [hertz]
                   value: -1.345e10 Hz
 
-  - title: no-exponent decimal number parses
+  - title: decimal number parses
     markdown: '{si}`1.345 <\hertz>`'
     mdast:
       type: root
@@ -86,3 +86,54 @@ cases:
                   unit: Hz
                   units: [hertz]
                   value: 1.345 Hz
+
+  - title: exponent integer number parses
+    markdown: '{si}`1e45 <\hertz>`'
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: mystRole
+              name: si
+              value: 1e45 <\hertz>
+              children:
+                - type: si
+                  alt: hertz
+                  number: '1e45'
+                  unit: Hz
+                  units: [hertz]
+                  value: 1e45 Hz
+
+  - title: negative exponent grouped decimal number parses
+    markdown: '{si}`-1,008,000.342e45 <\hertz>`'
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: mystRole
+              name: si
+              value: -1,008,000.342e45 <\hertz>
+              children:
+                - type: si
+                  alt: hertz
+                  number: '-1,008,000.342e45'
+                  unit: Hz
+                  units: [hertz]
+                  value: -1,008,000.342e45 Hz
+
+  - title: wrongly grouped integer number errors
+    markdown: '{si}`-1.008.000,05 <\hertz>`'
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: mystRole
+              name: si
+              value: -1.008.000,05 <\hertz>
+              children:
+                - type: si
+                  error: true
+                  value: -1.008.000,05 <\hertz>

--- a/packages/myst-parser/tests/roles/si.yml
+++ b/packages/myst-parser/tests/roles/si.yml
@@ -33,7 +33,6 @@ cases:
                   units: [hertz]
                   value: 100 Hz
 
-
   - title: decimal number parses
     markdown: '{si}`1.345e10 <\hertz>`'
     mdast:

--- a/packages/myst-roles/src/si.ts
+++ b/packages/myst-roles/src/si.ts
@@ -9,7 +9,23 @@ export const siRole: RoleSpec = {
   },
   run(data: RoleData): GenericNode[] {
     const value = data.body as string;
-    const match = value.match(/(-?\d+(,\d+)*(\.\d+(e\d+)?)?)\s?<([\\a-zA-Z\s]+)>/);
+    const match = value.match(
+      /* In verbose regex, the following pattern looks like        e.g. -1000,000,000.192e24
+      ^
+      (-?               # Optional unary negative                  e.g. -
+          (             # <<< Decimal group
+          \d+             # Leading integers (1+)                  e.g.  1000
+              (,\d+)*     # Grouped runs of integers (0+)          e.g.     [,000,000]
+              (\.\d+)?    # Optional decimal with trailing integer e.g.             [.192]
+          )?            # Decimal is optional >>>
+          (e\d+)?       # Optional scientific exponent             e.g.                 [e24]
+      )
+      \s?
+      <([\\a-zA-Z\s]+)>
+      $
+       */
+      /^(-?(\d+(,\d+)*(\.\d+)?)?(e\d+)?)\s?<([\\a-zA-Z\s]+)>$/,
+    );
     if (!match) {
       return [{ type: 'si', error: true, value }];
     }

--- a/packages/myst-roles/src/si.ts
+++ b/packages/myst-roles/src/si.ts
@@ -9,11 +9,12 @@ export const siRole: RoleSpec = {
   },
   run(data: RoleData): GenericNode[] {
     const value = data.body as string;
-    const match = value.match(/([0-9]+)\s?<([\\a-zA-Z\s]+)>/);
+    const match = value.match(/(-?\d+(,\d+)*(\.\d+(e\d+)?)?)\s?<([\\a-zA-Z\s]+)>/);
     if (!match) {
       return [{ type: 'si', error: true, value }];
     }
-    const [, number, commands] = match;
+    const number = match[1];
+    const commands = match[match.length-1];
     const parsed = [...commands.matchAll(/\\([a-zA-Z]+)/g)];
     const units = parsed.filter((c) => !!c).map(([, c]) => c);
     const translated = units.map((c) => UNITS[c] ?? c);

--- a/packages/myst-roles/src/si.ts
+++ b/packages/myst-roles/src/si.ts
@@ -14,7 +14,7 @@ export const siRole: RoleSpec = {
       return [{ type: 'si', error: true, value }];
     }
     const number = match[1];
-    const commands = match[match.length-1];
+    const commands = match[match.length - 1];
     const parsed = [...commands.matchAll(/\\([a-zA-Z]+)/g)];
     const units = parsed.filter((c) => !!c).map(([, c]) => c);
     const translated = units.map((c) => UNITS[c] ?? c);


### PR DESCRIPTION
So far the `si` role only supported integer numbers. With this PR it becomes possible to use decimal and scientific "e" notation. Additionally a negative sign "-" at the start is also accepted