### PR TITLE
♹ Incremental `typst` improvements

### DIFF
--- a/.changeset/neat-adults-reflect.md
+++ b/.changeset/neat-adults-reflect.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Allow backticks in typst code, no other escapes

--- a/.changeset/slimy-timers-greet.md
+++ b/.changeset/slimy-timers-greet.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Improve typst figure/table formatting

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -238,9 +238,13 @@ const handlers: Record<string, Handler> = {
     const { width: nodeWidth, url: nodeSrc, align } = node;
     const src = nodeSrc;
     const width = getLatexImageWidth(nodeWidth);
-    const command = state.data.isInFigure ? 'image' : '#image';
-    state.write(`${command}("${src}", width: ${width})`);
-    state.closeBlock(node);
+    const command = state.data.isInTable || !state.data.isInFigure ? '#image' : 'image';
+    state.write(`${command}("${src}"`);
+    if (!state.data.isInTable) {
+      state.write(`, width: ${width}`);
+    }
+    state.write(')');
+    state.ensureNewLine(true);
   },
   container: containerHandler,
   caption: captionHandler,

--- a/packages/myst-to-typst/src/math.ts
+++ b/packages/myst-to-typst/src/math.ts
@@ -47,7 +47,7 @@ const math: Handler = (node, state) => {
   state.ensureNewLine();
   // Note: must have spaces $ math $ for the block!
   state.write(`$ ${value} $${node.label ? ` <${node.label}>` : ''}\n\n`);
-  state.closeBlock(node);
+  state.ensureNewLine(true);
 };
 
 const inlineMath: Handler = (node, state) => {

--- a/packages/myst-to-typst/src/table.ts
+++ b/packages/myst-to-typst/src/table.ts
@@ -22,6 +22,8 @@ function countHeaderRows(table: GenericNode) {
 }
 
 export const tableHandler: Handler = (node, state) => {
+  const prevState = state.data.isInTable;
+  state.data.isInTable = true;
   const command = state.data.isInFigure ? 'tablex' : '#tablex';
   const columns = countColumns(node);
   if (!columns) {
@@ -34,7 +36,9 @@ export const tableHandler: Handler = (node, state) => {
   state.useMacro('#import "@preview/tablex:0.0.7": tablex, cellx');
   state.write(`${command}(columns: ${columns}, header-rows: ${countHeaderRows(node)},\n`);
   state.renderChildren(node);
-  state.write(')\n');
+  state.write(')');
+  state.ensureNewLine();
+  state.data.isInTable = prevState;
 };
 
 export const tableRowHandler: Handler = (node, state) => {
@@ -52,7 +56,7 @@ export const tableCellHandler: Handler = (node, state) => {
     }
     state.write(')');
   }
-  state.write('[');
+  state.write('[\n');
   state.renderChildren(node);
-  state.write('],');
+  state.write('],\n');
 };

--- a/packages/myst-to-typst/src/types.ts
+++ b/packages/myst-to-typst/src/types.ts
@@ -23,6 +23,7 @@ export type Options = {
 export type StateData = {
   tableColumns?: number;
   isInFigure?: boolean;
+  isInTable?: boolean;
   longFigure?: boolean;
   nextCaptionNumbered?: boolean;
   nextHeadingIsFrameTitle?: boolean;

--- a/packages/myst-to-typst/src/types.ts
+++ b/packages/myst-to-typst/src/types.ts
@@ -52,5 +52,4 @@ export interface ITypstSerializer<D extends Record<string, any> = StateData> {
     env: string,
     opts?: { parameters?: string; arguments?: string[] },
   ) => void;
-  closeBlock: (node: any) => void;
 }

--- a/packages/myst-to-typst/src/utils.ts
+++ b/packages/myst-to-typst/src/utils.ts
@@ -188,7 +188,7 @@ export function hrefToLatexText(text: string) {
   return replaced;
 }
 
-export function stringToLatexText(text: string) {
+export function stringToTypstText(text: string) {
   const escaped = (text ?? '')
     .replace(/\\ /g, BACKSLASH_SPACE)
     .replace(/\\/g, BACKSLASH)
@@ -222,7 +222,7 @@ export function stringToLatexText(text: string) {
   return cleanWhitespaceChars(final, '~');
 }
 
-export function stringToLatexMath(text: string) {
+export function stringToTypstMath(text: string) {
   const replaced = Array.from(text ?? '').reduce((s, char) => {
     if (mathReplacements[char]) {
       const space = s.slice(-1) === ' ' ? '' : ' ';

--- a/packages/myst-to-typst/tests/code.yml
+++ b/packages/myst-to-typst/tests/code.yml
@@ -23,3 +23,59 @@ cases:
       # here is math
       1+2
       ```
+  - title: code block default with ticks
+    mdast:
+      type: root
+      children:
+        - type: mystDirective
+          name: code-block
+          args: python
+          class: my-class
+          value: |-
+            # ```
+            1+2
+          children:
+            - type: code
+              lang: python
+              class: my-class
+              value: |-
+                # ```
+                1+2
+    typst: |-
+      ````python
+      # ```
+      1+2
+      ````
+  - title: inline code
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'eqn: '
+            - type: inlineCode
+              value: a + b
+    typst: 'eqn: `a + b`'
+  - title: inline code with backtick
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'eqn: '
+            - type: inlineCode
+              value: a ` b
+    typst: 'eqn: ```a ` b```'
+  - title: inline code starting and ending with backtick
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'eqn: '
+            - type: inlineCode
+              value: '`a ` b``'
+    typst: 'eqn: ``` `a ` b`` ```'

--- a/packages/myst-to-typst/tests/code.yml
+++ b/packages/myst-to-typst/tests/code.yml
@@ -79,3 +79,14 @@ cases:
             - type: inlineCode
               value: '`a ` b``'
     typst: 'eqn: ``` `a ` b`` ```'
+  - title: inline code does not escape symbols
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'eqn: '
+            - type: inlineCode
+              value: '# _'
+    typst: 'eqn: `# _`'

--- a/packages/myst-to-typst/tests/figures.yml
+++ b/packages/myst-to-typst/tests/figures.yml
@@ -46,7 +46,9 @@ cases:
     typst: |-
       #figure(
         image("glacier.jpg", width: 62.5%),
-        caption: [A curious figure.],
+        caption: [
+      A curious figure.
+      ],
         kind: "figure",
         supplement: [Figure],
       ) <glacier>

--- a/packages/myst-to-typst/tests/tables.yml
+++ b/packages/myst-to-typst/tests/tables.yml
@@ -1,0 +1,169 @@
+title: myst-to-typst tables
+cases:
+  - title: basic table
+    mdast:
+      type: root
+      children:
+        - type: table
+          align: center
+          children:
+            - type: tableRow
+              children:
+                - type: tableCell
+                  header: true
+                  children:
+                    - type: text
+                      value: Head 1, Column 1
+                - type: tableCell
+                  header: true
+                  children:
+                    - type: text
+                      value: Head 1, Column 2
+            - type: tableRow
+              children:
+                - type: tableCell
+                  children:
+                    - type: text
+                      value: Row 1, Column 1
+                - type: tableCell
+                  children:
+                    - type: text
+                      value: Row 1, Column 2
+
+    typst: |-
+      #tablex(columns: 2, header-rows: 1,
+      [
+      Head 1, Column 1
+      ],
+      [
+      Head 1, Column 2
+      ],
+      [
+      Row 1, Column 1
+      ],
+      [
+      Row 1, Column 2
+      ],
+      )
+  - title: comment inside table
+    mdast:
+      type: root
+      children:
+        - type: table
+          align: center
+          children:
+            - type: tableRow
+              children:
+                - type: tableCell
+                  header: true
+                  children:
+                    - type: text
+                      value: Head 1, Column 1
+                - type: tableCell
+                  header: true
+                  children:
+                    - type: text
+                      value: Head 1, Column 2
+            - type: tableRow
+              children:
+                - type: tableCell
+                  children:
+                    - type: text
+                      value: Row 1, Column 1
+                    - type: comment
+                      value: my comment
+                - type: tableCell
+                  children:
+                    - type: text
+                      value: Row 1, Column 2
+
+    typst: |-
+      #tablex(columns: 2, header-rows: 1,
+      [
+      Head 1, Column 1
+      ],
+      [
+      Head 1, Column 2
+      ],
+      [
+      Row 1, Column 1
+      // my comment
+      ],
+      [
+      Row 1, Column 2
+      ],
+      )
+  - title: rowspan table
+    mdast:
+      type: root
+      children:
+        - type: table
+          align: center
+          children:
+            - type: tableRow
+              children:
+                - type: tableCell
+                  rowspan: 2
+                  children:
+                    - type: text
+                      value: Head 1, Column 1
+                - type: tableCell
+                  children:
+                    - type: text
+                      value: Head 1, Column 2
+            - type: tableRow
+              children:
+                - type: tableCell
+                  children:
+                    - type: text
+                      value: Row 1, Column 2
+
+    typst: |-
+      #tablex(columns: 2, header-rows: 0,
+      cellx(rowspan: 2, )[
+      Head 1, Column 1
+      ],
+      [
+      Head 1, Column 2
+      ],
+      [
+      Row 1, Column 2
+      ],
+      )
+  - title: colspan table
+    mdast:
+      type: root
+      children:
+        - type: table
+          align: center
+          children:
+            - type: tableRow
+              children:
+                - type: tableCell
+                  colspan: 2
+                  children:
+                    - type: text
+                      value: Head 1, Column 1
+            - type: tableRow
+              children:
+                - type: tableCell
+                  children:
+                    - type: text
+                      value: Row 1, Column 1
+                - type: tableCell
+                  children:
+                    - type: text
+                      value: Row 1, Column 2
+
+    typst: |-
+      #tablex(columns: 2, header-rows: 0,
+      cellx(colspan: 2, )[
+      Head 1, Column 1
+      ],
+      [
+      Row 1, Column 1
+      ],
+      [
+      Row 1, Column 2
+      ],
+      )


### PR DESCRIPTION
- code blocks no longer add `\` escapes. They also handle backticks correctly
- figures no longer include images from tables twice. Other formatting of the typst file is improved
- additional simplifications around typst serialization - explicitly add newlines as required, no longer use `closeBlock`