### PR TITLE
host for static file routes is no longer hardcoded as localhost

### DIFF
--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -104,7 +104,17 @@ export async function buildHtml(session: ISession, opts: any) {
   fs.mkdirSync(htmlDir, { recursive: true });
   const appServer = await startServer(session, { ...opts, buildStatic: true, baseurl });
   if (!appServer) return;
-  const host = `http://localhost:${appServer.port}`;
+
+  const host = process.env.HOST;
+  if (processEnvHost) {
+    session.log.info(`Building the site with a host of "${processEnvHost}"`);
+  } else {
+    session.log.info(
+      'Building the base site.\nTo set a host use "HOST" environment variable.',
+    );
+  }
+  const host = `http://${processEnvHost}:${appServer.port}`;
+
   const routes = await currentSiteRoutes(session, host, baseurl, opts);
 
   // Fetch all HTML pages and assets by the template


### PR DESCRIPTION
Modification to:
mystmd/packages/myst-cli/src/build/html/index.ts

Builds host variable from env variable HOST in accordance with documentation and option to honor HOST with --keep-host option