### PR TITLE
🚦 set CONTENT_CDN_HOST in env of development server

### DIFF
--- a/.changeset/sharp-wasps-tap.md
+++ b/.changeset/sharp-wasps-tap.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Set `CONTENT_CDN_HOST` when `HOST` environment variable is specified and default to `localhost` otherwise. Also improve log messages when `HOST` is provided.

--- a/packages/myst-cli/src/build/site/logger.ts
+++ b/packages/myst-cli/src/build/site/logger.ts
@@ -10,8 +10,12 @@ export function createServerLogger(session: ISession, ready: () => void): Logger
       if (line.includes('File changed: app/content')) return; // This is shown elsewhere
       if (line.includes('started at http://')) {
         const [, ipAndPort] = line.split('http://');
+        const host =
+          process.env.HOST && process.env.HOST.startsWith('http')
+            ? new URL(process.env.HOST).hostname
+            : process.env.HOST ?? 'localhost';
         const port = ipAndPort.split(':')[1].replace(/[^0-9]/g, '');
-        const local = `http://localhost:${port}`;
+        const local = `http://${host}:${port}`;
         ready();
         session.log.info(
           `\n🔌 Server started on port ${port}!  🥳 🎉\n\n\n\t👉  ${chalk.green(local)}  👈\n\n`,

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -142,6 +142,7 @@ export async function startServer(
         cwd: mystTemplate.templatePath,
         env: {
           ...process.env,
+          CONTENT_CDN_HOST: process.env.HOST ?? 'localhost',
           CONTENT_CDN_PORT: String(server.port),
           PORT: String(port),
           MODE: opts.buildStatic ? 'static' : 'app',

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -123,7 +123,7 @@ export async function startServer(
     });
   }
   if (opts.headless) {
-    const local = chalk.green(`http://localhost:${server.port}`);
+    const local = chalk.green(`http://${process.env.HOST ?? 'localhost'}:${server.port}`);
     session.log.info(
       `\n🔌 Content server started on port ${server.port}!  🥳 🎉\n\n\n\t👉  ${local}  👈\n\n`,
     );


### PR DESCRIPTION
These changes are to support the fix in https://github.com/executablebooks/myst-theme/pull/346 where url rewriting should honor the HOST variable used to start the `mystmd` development server.

This PR also changes the existing log messages to accurately report the usage of HOST rather than always citing `localhost`