### PR TITLE
📖 Enable RTD again

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+build:
+  os: ubuntu-lts-latest
+  tools:
+    nodejs: "20"
+  commands:
+    - npm install
+    - npm run build
+    - npm run --workspace packages/mystmd link
+    - myst --version
+    - cd docs && myst build --html
+    - mkdir -p $READTHEDOCS_OUTPUT
+    - cp -a docs/_build/* $READTHEDOCS_OUTPUT/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,9 @@ build:
   tools:
     nodejs: "20"
   commands:
+    - npm install react@rc
     - npm install
+    - npm list
     - npm run build
     - npm run --workspace packages/mystmd link
     - myst --version


### PR DESCRIPTION
Let's keep this in draft so we can explore how to fix the RTD issues. Quick comment @rowanc1 can you keep the RTD project alive so that it can run on PRs. It is fine if it fails on main/other PRs due to a lack of `.readthedocs.yaml` file, it's just that it would be good to have it here so that we can explore all of the issues and potential solutions across the `myst-theme` repo (i.e. open a similar branch there and point `packages.json` to the repo branch where we can explore potential fixes)

TODO:
- [x] Write todo
- [ ] The landing page of the preview is broken, due to some kind of javascript error
  @choldgraf Can you comment with a screenshot of this? 
- [ ] Bare links need to redirect to `.html` files: `myst-to-react` issue
  - Temporary solution would be to have the hosting provider do the redirect, but that is not ideal because local navigation of the static site through `index.html` is still broken
- [ ] Overwrite `robots.txt`
  - Maybe this is to be done on the RTD settings?
- [ ] Handle hydration issues: `myst-to-react` issue
- [ ] Add `flyout` menu support

Closes #1133 
