### PR TITLE
🌐 Update deployment documentation to clarify deployment types

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,7 +7,7 @@ description: Deploy your MyST site to static HTML or a MyST-aware server.
 There are two different ways to host MyST websites online.
 
 - **As a static website**. An HTML file is generated for each page at once. The collection of HTML files and website assets can be served from static site hosts (like [GitHub Pages](https://docs.github.com/en/pages), [Netlify](https://netlify.com), and [ReadTheDocs](https://readthedocs.org)).
-- **As an application**. A MyST _server_ is run that dynamically generates pages when a user visits them. Your site can be served by a hosting provider that supports applications (like [Curvenote](https://curvenote.org) or [Vercel](https://vercel.com))
+- **As an application**. A MyST _server_ is run that dynamically generates pages when a user visits them. Your site can be served by a hosting provider that supports applications (like [Curvenote](https://curvenote.com) or [Vercel](https://vercel.com))
 
 The high-level differences between these approaches are outlined in [](#deployment-comparison).
 :::{table} High-Level Comparison of MyST Site Deployment Types

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,9 +4,10 @@ short_title: Deployment
 description: Deploy your MyST site to static HTML or a MyST-aware server.
 ---
 
-There are two different kinds of MyST website that can be deployed out of the box:
-- Statically generated sites, which can be served from static site hosts (like GitHub Pages).
-- Dynamically rendered sites, which use a MyST server.
+There are two different ways to host MyST websites online.
+
+- **As a static website**. An HTML file is generated for each page at once. The collection of HTML files and website assets can be served from static site hosts (like [GitHub Pages](https://docs.github.com/en/pages), [Netlify](https://netlify.com), and [ReadTheDocs](https://readthedocs.org)).
+- **As an application**. A MyST _server_ is run that dynamically generates pages when a user visits them. Your site can be served by a hosting provider that supports applications (like [Curvenote](https://curvenote.org) or [Vercel](https://vercel.com))
 
 The high-level differences between these approaches are outlined in [](#deployment-comparison).
 :::{table} High-Level Comparison of MyST Site Deployment Types

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,9 +4,32 @@ short_title: Deployment
 description: Deploy your MyST site to static HTML or a MyST-aware server.
 ---
 
-The default themes for MyST sites are applications that render structured data _dynamically_, and are not static HTML sites. This choice allows the websites to include many [performance enhancements](./accessibility-and-performance.md) such as pre-fetching for instant page-transitions, loading indicators, and smaller network payloads. However, these advantages require that your website either (a) requires a web server or service that understands MyST sites; or (b) is changed to an HTML export that does not include these features but does allow you to host static files on services like GitHub pages.
+There are two different kinds of MyST website that can be deployed out of the box:
+- Statically generated sites, which can be served from static site hosts (like GitHub Pages).
+- Dynamically rendered sites, which use a MyST server.
 
-## Creating Static HTML
+The high-level differences between these approaches are outlined in [](#deployment-comparison).
+:::{table} High-Level Comparison of MyST Site Deployment Types
+:label: deployment-comparison
+
+| Deployment Type | High Performance | Seamless Updates | Static Hosting |
+|:---------------:|:----------------:|:----------------:|:--------------:|
+|  Static website |         ❌        |         ❌        |        ✅       |
+|   MyST server   |         ✅        |         ✅        |        ❌       |
+:::
+
+The [default themes](website-templates.md#themes-bundled-with-myst) for MyST are designed to be MyST servers. Sites deployed in this manner benefit from [performance enhancements](./accessibility-and-performance.md) such as pre-fetching for instant page-transitions, loading indicators, and smaller network payloads. As the MyST themes receive new updates, it is easy to upgrade existing websites that have been deployed upon MyST servers, as the MyST site _content_ is only ever built once.
+
+%  - Static deployments are MPA (each page own HTML document), SSG (rendered ahead of time)
+%  - Servers are SPA (request JSON), SSR+hydration
+%- Term definitions?
+%  - SPA vs MPA
+%  - SSR vs CSR vs SSG
+
+However, commonly used website hosts like GitHub Pages and ReadTheDocs are _static website hosts_, meaning that they can only serve webpages that have been built ahead of time. Therefore, the choice between using a static website or a MyST server deployment often comes down to the type of website hosting that is available.
+
+## Static Websites
+### Creating Static HTML
 
 To create a static HTML export of your MyST site, build it as HTML:
 
@@ -14,8 +37,10 @@ To create a static HTML export of your MyST site, build it as HTML:
 myst build --html
 ```
 
-After the build process, you can see the folder in `_build/html`, which has all assets for your static website. You can verify that the site is working correctly by starting a static web-server, for example,\
-`npx serve _build/html`\
+After the build process, you can see the folder in `_build/html`, which has all assets for your static website. You can verify that the site is working correctly by starting a static web-server, for example,
+```shell
+npx serve _build/html
+```
 which will serve a static version of the site.
 
 :::{danger} Static sites should have an `index.html`
@@ -47,19 +72,39 @@ site:
 If you are using Git, add the `_build` folder to your `.gitignore` so that it is not tracked. This folder contains auto-generated assets that can easily be re-built -- for example in a Continuous Integration system like GitHub Actions.
 :::
 
-## Deployment Targets
+### Deploying to a Static Webhost
+The contents of the `_build/html` can be served from any static web server. The following articles outline the process of deploying your static site to well-known website providers:
 
 :::{card} GitHub Pages
 :link: ./deployment-github-pages.md
 Deploy as a static site to GitHub pages using an action.
 :::
 
+:::{card} Netlify
+:link: ./deployment-netlify.md
+Deploy to Netlify as static HTML, and pull-request previews.
+:::
+
+% TODO: ReadTheDocs
+
+## Dynamic MyST Sites
+
+### Creating Structured Site Data
+MyST servers consume _structured data_ that represents a MyST website. These data can be built using the `myst build` command,
+```shell
+myst build --site
+```
+which populates the `_build/site` directory with information about your website including the metadata, cross-references, static images, and [MyST AST](https://mystmd.org/spec).
+
+### Deploying to a MyST-Aware Server
+:::{note}
+At present, only [Curvenote](https://curvenote.com/) provides out-of-the-box support for deployment of MyST websites:
+:::
+
+% TODO: vercel/netlify server
+
 :::{card} Curvenote
 :link: ./deployment-curvenote.md
 Deploy to Curvenote as a dynamic site with a managed MyST theme.
 :::
 
-:::{card} Netlify
-:link: ./deployment-netlify.md
-Deploy to Netlify as static HTML, and pull-request previews.
-:::

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,9 +14,10 @@ The high-level differences between these approaches are outlined in [](#deployme
 :label: deployment-comparison
 
 | Deployment Type | High Performance | Seamless Updates | Static Hosting |
-|:---------------:|:----------------:|:----------------:|:--------------:|
-|  Static website |         ❌        |         ❌        |        ✅       |
-|   MyST server   |         ✅        |         ✅        |        ❌       |
+| :-------------: | :--------------: | :--------------: | :------------: |
+| Static website  |        ❌        |        ❌        |       ✅       |
+|   MyST server   |        ✅        |        ✅        |       ❌       |
+
 :::
 
 :::{note} MyST was designed to be deployed as an application
@@ -25,16 +26,17 @@ Deploying MyST as an application has many benefits. For example, [performance en
 The [default themes](website-templates.md#themes-bundled-with-myst) for MyST are designed to be MyST applications rather than static sites, but the core functionality is equally shared between the two options.
 :::
 
-%  - Static deployments are MPA (each page own HTML document), SSG (rendered ahead of time)
-%  - Servers are SPA (request JSON), SSR+hydration
+% - Static deployments are MPA (each page own HTML document), SSG (rendered ahead of time)
+% - Servers are SPA (request JSON), SSR+hydration
 %- Term definitions?
-%  - SPA vs MPA
-%  - SSR vs CSR vs SSG
+% - SPA vs MPA
+% - SSR vs CSR vs SSG
 
 The choice between static hosts and application-based hosts often comes down to the type of website hosting that is available, and the amount of complexity that you're willing to deal with in deploying your site.
 The sections below share a few considerations to help you make a decision.
 
 ## Static Websites
+
 ### Creating Static HTML
 
 To create a static HTML export of your MyST site, build it as HTML:
@@ -44,9 +46,11 @@ myst build --html
 ```
 
 After the build process, you can see the folder in `_build/html`, which has all assets for your static website. You can verify that the site is working correctly by starting a static web-server, for example,
+
 ```shell
 npx serve _build/html
 ```
+
 which will serve a static version of the site.
 
 :::{danger} Static sites should have an `index.html`
@@ -78,7 +82,8 @@ site:
 If you are using Git, add the `_build` folder to your `.gitignore` so that it is not tracked. This folder contains auto-generated assets that can easily be re-built -- for example in a Continuous Integration system like GitHub Actions.
 :::
 
-### Deploying to a Static Webhost
+### Deploying to a Static Web Server
+
 The contents of the `_build/html` can be served from any static web server. The following articles outline the process of deploying your static site to well-known website providers:
 
 :::{card} GitHub Pages
@@ -96,13 +101,17 @@ Deploy to Netlify as static HTML, and pull-request previews.
 ## Application Websites
 
 ### Creating Structured Site Data
+
 MyST servers consume _structured data_ that represents a MyST website. These data can be built using the `myst build` command,
+
 ```shell
 myst build --site
 ```
+
 which populates the `_build/site` directory with information about your website including the metadata, cross-references, static images, and [MyST AST](https://mystmd.org/spec).
 
 ### Deploying to a MyST-Aware Server
+
 :::{note}
 At present, only [Curvenote](https://curvenote.com/) provides out-of-the-box support for deployment of MyST websites:
 :::
@@ -113,4 +122,3 @@ At present, only [Curvenote](https://curvenote.com/) provides out-of-the-box sup
 :link: ./deployment-curvenote.md
 Deploy to Curvenote as a dynamic site with a managed MyST theme.
 :::
-

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -92,7 +92,7 @@ Deploy to Netlify as static HTML, and pull-request previews.
 
 % TODO: ReadTheDocs
 
-## Dynamic MyST Sites
+## Application Websites
 
 ### Creating Structured Site Data
 MyST servers consume _structured data_ that represents a MyST website. These data can be built using the `myst build` command,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,7 +31,8 @@ The [default themes](website-templates.md#themes-bundled-with-myst) for MyST are
 %  - SPA vs MPA
 %  - SSR vs CSR vs SSG
 
-However, commonly used website hosts like GitHub Pages and ReadTheDocs are _static website hosts_, meaning that they can only serve webpages that have been built ahead of time. Therefore, the choice between using a static website or a MyST server deployment often comes down to the type of website hosting that is available.
+The choice between static hosts and application-based hosts often comes down to the type of website hosting that is available, and the amount of complexity that you're willing to deal with in deploying your site.
+The sections below share a few considerations to help you make a decision.
 
 ## Static Websites
 ### Creating Static HTML

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,7 +19,11 @@ The high-level differences between these approaches are outlined in [](#deployme
 |   MyST server   |         ✅        |         ✅        |        ❌       |
 :::
 
-The [default themes](website-templates.md#themes-bundled-with-myst) for MyST are designed to be MyST servers. Sites deployed in this manner benefit from [performance enhancements](./accessibility-and-performance.md) such as pre-fetching for instant page-transitions, loading indicators, and smaller network payloads. As the MyST themes receive new updates, it is easy to upgrade existing websites that have been deployed upon MyST servers, as the MyST site _content_ is only ever built once.
+:::{note} MyST was designed to be deployed as an application
+Deploying MyST as an application has many benefits. For example, [performance enhancements](./accessibility-and-performance.md) (like pre-fetching for instant page-transitions, loading indicators, and smaller network payloads) and easier upgrades as new MyST versions are released.
+
+The [default themes](website-templates.md#themes-bundled-with-myst) for MyST are designed to be MyST applications rather than static sites, but the core functionality is equally shared between the two options.
+:::
 
 %  - Static deployments are MPA (each page own HTML document), SSG (rendered ahead of time)
 %  - Servers are SPA (request JSON), SSR+hydration


### PR DESCRIPTION
This PR attempts to clarify the different ways that a MyST site can be deployed (and why you'd pick one over the other).

Closes https://github.com/executablebooks/mystmd/issues/927

There's more to cover here, such as deploying a MyST _server_ to Vercel, but I think this is a good start for our JB MVP docs.