### PR TITLE
:bookmark_tabs: Use `glossarium` to support glossaries in `typst`

### DIFF
--- a/.changeset/tasty-tips-wonder.md
+++ b/.changeset/tasty-tips-wonder.md
@@ -1,0 +1,5 @@
+---
+"myst-to-typst": patch
+---
+
+Fix glossary rendering

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -249,6 +249,9 @@ const handlers: Record<string, Handler> = {
     });
     state.renderChildren(node);
   },
+  glossary(node, state) {
+    state.renderChildren(node)
+  },
   link: linkHandler,
   admonition(node: Admonition, state) {
     state.useMacro(admonition);
@@ -295,6 +298,10 @@ const handlers: Record<string, Handler> = {
   legend: captionHandler,
   captionNumber: () => undefined,
   crossReference(node, state, parent) {
+    if (node.kind === "definitionTerm") {
+      state.renderChildren(node);
+      return;
+    }
     // Look up reference and add the text
     // const usedTemplate = node.template?.includes('%s') ? node.template : undefined;
     // const text = (usedTemplate ?? toText(node))?.replace(/\s/g, '~') || '%s';

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -66,7 +66,7 @@ const blockquote = `#let blockquote(node, color: gray) = {
 const INDENT = '  ';
 
 function identifierToTerm(identifier: string): string {
-  // Try and strip off the term- prefix, as we're using #gls() for now 
+  // Try and strip off the term- prefix, as we're using #gls() for now
   // which makes it obvious that we have a term
   const match = identifier.match(/term-(.*)/);
   // Fall back to full identifier (in case this changes in future)
@@ -287,9 +287,11 @@ const handlers: Record<string, Handler> = {
 
       state.write(`),\n`);
     }
-    state.write(`
-    )
-)`);
+    state.write(
+      `    )
+)
+`,
+    );
   },
   link: linkHandler,
   admonition(node: Admonition, state) {

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -65,6 +65,14 @@ const blockquote = `#let blockquote(node, color: gray) = {
 
 const INDENT = '  ';
 
+function identifierToTerm(identifier: string): string {
+  // Try and strip off the term- prefix, as we're using #gls() for now 
+  // which makes it obvious that we have a term
+  const match = identifier.match(/term-(.*)/);
+  // Fall back to full identifier (in case this changes in future)
+  return match?.[1] ?? identifier;
+}
+
 const linkHandler = (node: any, state: ITypstSerializer) => {
   const href = node.url;
   state.write('#link("');
@@ -250,7 +258,38 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node);
   },
   glossary(node, state) {
-    state.renderChildren(node)
+    state.useMacro(`
+#import "@preview/glossarium:0.4.1": make-glossary, print-glossary, gls, glspl 
+#show: make-glossary
+`);
+    state.write(`#print-glossary(
+    disable-back-references: true,
+    (
+`);
+
+    const definitionList = node.children[0];
+    for (let i = 0; i < definitionList.children.length - 1; i += 2) {
+      const termNode = definitionList.children[i];
+      const definitionNode = definitionList.children[i + 1];
+
+      state.write(`        (`);
+
+      const term = identifierToTerm(termNode.identifier);
+      state.write(`key: "${term}"`);
+
+      state.write(`, short: [`);
+      state.renderChildren(termNode);
+      state.write(`]`);
+
+      state.write(`, desc: [`);
+      state.renderChildren(definitionNode);
+      state.write(`]`);
+
+      state.write(`),\n`);
+    }
+    state.write(`
+    )
+)`);
   },
   link: linkHandler,
   admonition(node: Admonition, state) {
@@ -298,8 +337,9 @@ const handlers: Record<string, Handler> = {
   legend: captionHandler,
   captionNumber: () => undefined,
   crossReference(node, state, parent) {
-    if (node.kind === "definitionTerm") {
-      state.renderChildren(node);
+    if (node.kind === 'definitionTerm') {
+      const term = identifierToTerm(node.identifier);
+      state.write(`#gls("${term}")`);
       return;
     }
     // Look up reference and add the text

--- a/packages/myst-to-typst/tests/glossary.yml
+++ b/packages/myst-to-typst/tests/glossary.yml
@@ -1,0 +1,50 @@
+title: myst-to-typst glossary
+cases:
+  - title: reference single term
+    mdast:
+      type: root
+      children:
+        - type: glossary
+          children:
+            - type: definitionList
+              children:
+                - type: definitionTerm
+                  children:
+                    - type: text
+                      value: foo
+                  label: foo
+                  identifier: term-foo
+                - type: definitionDescription
+                  children:
+                    - type: text
+                      value: A foo
+                - type: definitionTerm
+                  children:
+                    - type: text
+                      value: bar
+                  label: bar
+                  identifier: term-bar
+                - type: definitionDescription
+                  children:
+                    - type: text
+                      value: A bar
+        - type: paragraph
+          children:
+            - type: crossReference
+              label: foo
+              identifier: term-foo
+              kind: definitionTerm
+              children:
+                - type: text
+                  value: foo
+              template: '{name}'
+              resolved: true
+    typst: |-
+      #print-glossary(
+          disable-back-references: true,
+          (
+              (key: "foo", short: [foo], desc: [A foo]),
+              (key: "bar", short: [bar], desc: [A bar]),
+          )
+      )
+      #gls("foo")


### PR DESCRIPTION
This PR adds a glossary handler to the `myst-to-typst` package. I would like to have used the existing `definitionList` handling logic, but it's not possible to naively label the keys. Glossarium works around this by embedding each entry in a figure.

Right now this generates `#gls("term")` syntax instead of `@term`. This should be pretty simple to do, we just need to normalise the identifier. 

This PR encodes the assumption that the `identifier` of a term starts with `term`. Can we assume this? There is a fallback in any case.

Fixes #944