### PR TITLE
:computer: Add support for IPC-backed plugins

### DIFF
--- a/docs/executable-plugins.md
+++ b/docs/executable-plugins.md
@@ -17,14 +17,18 @@ First, we'll declare the plugin _specification_ that allows MyST to discover the
 :::{literalinclude} unsplash.py
 :caption: a plugin to add an `unsplash-py` directive that includes a beautiful, random picture based on a query string.
 :::
-this code should be referenced from your `myst.yml` under the `projects.plugins`:
+this file should be executable, e.g.
+```{code} shell
+chmod +x ./unsplash.py
+```
+and should be referenced from your `myst.yml` under the `projects.plugins`:
 
 ```{code} yaml
 :filename: myst.yml
 project:
   plugins:
     - type: executable
-      path: unsplash.mjs
+      path: unsplash.py
 ```
 
 then start or build your document using `myst start` or `myst build`, and you will see that the plugin is loaded.

--- a/docs/executable-plugins.md
+++ b/docs/executable-plugins.md
@@ -1,0 +1,88 @@
+---
+title: Executable Plugins
+description: Plugins built as stand-alone applications can be written in languages such as Python, and may be more familiar to some developers.
+---
+
+MyST is able to invoke plugins written in different languages through standard IO protocols. Executable MyST plugins are treated as a [](wiki:Black_box), whereby MyST only sees the data it passes to the plugin, and the response from the plugin itself.
+
+
+## Defining a new directive
+
+:::{note}
+There are many different ways to create an executable plugin. Here we'll use Python to implement an `unsplash-py` directive, but any programming language that can read and write from stdin, stdout, and stderr, and define a commandline interface would work.
+:::
+
+First, we'll declare the plugin _specification_ that allows MyST to discover the directives, transforms, and/or roles that the plugin implements. This specification looks very similar to [the definition of a JavaScript plugin](javascript-plugins.md#unsplash-js-source), except the implementation logic (e.g. the directive `run` method) is not defined.
+
+:::{literalinclude} unsplash.py
+:caption: a plugin to add an `unsplash-py` directive that includes a beautiful, random picture based on a query string.
+:::
+this code should be referenced from your `myst.yml` under the `projects.plugins`:
+
+```{code} yaml
+:filename: myst.yml
+project:
+  plugins:
+    - type: executable
+      path: unsplash.mjs
+```
+
+then start or build your document using `myst start` or `myst build`, and you will see that the plugin is loaded.
+
+```text
+myst start
+...
+🔌 unsplash images (unsplash.py) loaded: 1 directive
+...
+```
+
+you can now use the directive, for example:
+
+```markdown
+:::{unsplash-py} misty,mountains
+:::
+```
+
+:::{unsplash-py} misty,mountains
+:size: 600x250
+:::
+
+If you change the source code you will have to stop and re-start the server to see the results.
+
+The types are defined in `myst-common` ([npm](https://www.npmjs.com/package/myst-common), [github](https://github.com/executablebooks/mystmd/tree/main/packages/myst-common)) with the [`DirectiveSpec`](https://github.com/executablebooks/mystmd/blob/9965925030c3fab6f34c20d11eeee7ffdafa73df/packages/myst-common/src/types.ts#L68-L77) and [`RoleSpec`](https://github.com/executablebooks/mystmd/blob/9965925030c3fab6f34c20d11eeee7ffdafa73df/packages/myst-common/src/types.ts#L79-L85) being the main types to implement.
+
+## Implementing a custom transform
+
+Directives can be used to extend MyST with rich structured content. However, sometimes we want to _modify_ the existing behavior of MyST. One of the ways to do this is by writing a custom transform. In this section, we'll implement a transform that replaces **bold** text with _emphasis_.
+
+First, let's define the transform
+:::{literalinclude} markup.py
+:caption: A plugin to add a transform that replaces strong nodes with emphasis nodes.
+:::
+this code should be referenced from your `myst.yml` under the `projects.plugins`:
+
+```{code} yaml
+:filename: myst.yml
+project:
+  plugins:
+    - type: executable
+      path: markup.mjs
+```
+
+then start or build your document using `myst start` or `myst build`, and you will see that the plugin is loaded.
+
+```text
+myst start
+...
+🔌 Strong to emphasis (markup.py) loaded: 1 directive
+...
+```
+
+you can now use the directive, for example:
+
+```markdown
+I am **special bold text (python)**, whilst I am **normal bold text**
+```
+
+I am **special bold text (python)**, whilst I am **normal bold text**
+

--- a/docs/javascript-plugins.md
+++ b/docs/javascript-plugins.md
@@ -1,0 +1,122 @@
+---
+title: JavaScript Plugins
+description: Plugins implemented in JavaScript are easily used across different projects, as they do not require any additional programs to be installed.
+---
+
+JavaScript plugins are native MyST plugins, which are loaded as modules into the MyST engine. Transforms defined in these modules have access to helpful AST manipulation routines made available by MyST. Edits to JavaScript plugins have no effect during execution of a MyST build, instead the build must be restarted.
+
+## Defining a new directive
+
+To create a plugin, you will need a single Javascript file[^esm] that exports one or more of the objects above. For example, a simple directive that pulls a random image from [Unsplash](https://unsplash.com/) can be created with a single file that exports an `unsplash` directive.
+
+[^esm]: The format of the Javascript should be an ECMAScript modules, not CommonJS. This means it uses `import` statements rather than `require()` and is the most modern style of Javascript.
+
+:::{literalinclude} unsplash.mjs
+:name: unsplash-js-source
+:caption: A plugin to add an `unsplash` directive that includes a beautiful, random picture based on a query string.
+:::
+
+This code should be referenced from your `myst.yml` under the `projects.plugins`:
+
+```{code} yaml
+:filename: myst.yml
+project:
+  plugins:
+    - type: javascript
+      path: unsplash.mjs
+```
+
+Then start or build your document using `myst start` or `myst build`, and you will see that the plugin is loaded.
+
+```text
+myst start
+...
+🔌 Unsplash Images (unsplash.mjs) loaded: 1 directive
+...
+```
+
+You can now use the directive, for example:
+
+```markdown
+:::{unsplash} misty,mountains
+:::
+```
+
+:::{unsplash} misty,mountains
+:size: 600x250
+:::
+
+If you change the source code you will have to stop and re-start the server to see the results.
+
+The types are defined in `myst-common` ([npm](https://www.npmjs.com/package/myst-common), [github](https://github.com/executablebooks/mystmd/tree/main/packages/myst-common)) with the [`DirectiveSpec`](https://github.com/executablebooks/mystmd/blob/9965925030c3fab6f34c20d11eeee7ffdafa73df/packages/myst-common/src/types.ts#L68-L77) and [`RoleSpec`](https://github.com/executablebooks/mystmd/blob/9965925030c3fab6f34c20d11eeee7ffdafa73df/packages/myst-common/src/types.ts#L79-L85) being the main types to implement.
+
+
+## Implementing a custom transform
+
+Directives can be used to extend MyST with rich structured content. However, sometimes we want to _modify_ the existing behavior of MyST. One of the ways to do this is by writing a custom transform. In this section, we'll implement a transform that replaces **bold** text with _emphasis_.
+
+First, let's define the transform
+:::{literalinclude} markup.mjs
+:caption: A plugin to add a transform that replaces strong nodes with emphasis nodes.
+:::
+this code should be referenced from your `myst.yml` under the `projects.plugins`:
+
+```{code} yaml
+:filename: myst.yml
+project:
+  plugins:
+    - type: javascript
+      path: markup.mjs
+```
+
+then start or build your document using `myst start` or `myst build`, and you will see that the plugin is loaded.
+
+```text
+myst start
+...
+🔌 Strong to emphasis (markup.mjs) loaded: 1 directive
+...
+```
+
+you can now use the directive, for example:
+
+```markdown
+I am **special bold text**, whilst I am **normal bold text**
+```
+
+I am **special bold text**, whilst I am **normal bold text**
+
+
+## Examples of plugins
+
+The documentation you're reading now defines several of its own plugins to extend MyST functionality.
+These are all registered in the documentation's [myst.yml configuration](myst.yml) with syntax like below:
+
+
+```{literalinclude} myst.yml
+:start-at: plugins
+:end-before: error_rules
+```
+
+Each plugin is defined as a `.mjs` file in the same folder as the documentation's MyST content.
+Below is the contents of each file for reference.
+
+::::{dropdown} Plugin: Latex rendering
+```{literalinclude} latex.mjs
+```
+::::
+
+::::{dropdown} Plugin: Display an image
+```{literalinclude} unsplash.mjs
+```
+::::
+
+::::{dropdown} Plugin: Custom directive for documenting roles and directives
+```{literalinclude} directives.mjs
+```
+::::
+
+::::{dropdown} Plugin: Render web template options as a table
+```{literalinclude} templates.mjs
+```
+::::

--- a/docs/markup.mjs
+++ b/docs/markup.mjs
@@ -1,0 +1,21 @@
+const plugin = {
+  name: 'Strong to emphasis',
+  transforms: [
+    {
+      name: 'transform-typography',
+      doc: 'An example transform that rewrites bold text as text with emphasis.',
+      stage: 'document',
+      plugin: (_, utils) => (node) => {
+        utils.selectAll('strong', node).forEach((strongNode) => {
+          const childTextNodes = utils.selectAll('text', strongNode);
+          const childText = childTextNodes.map((child) => child.value).join('');
+          if (childText === 'special bold text') {
+            strongNode['type'] = 'emphasis';
+          }
+        });
+      },
+    },
+  ],
+};
+
+export default plugin;

--- a/docs/markup.py
+++ b/docs/markup.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+
+
+plugin = {
+    "name": "Strong to emphasis",
+    "transforms": [
+        {
+            "name": "transform-typography",
+            "doc": "An example transform that rewrites bold text as text with emphasis.",
+            "stage": "document"
+            }
+    ],
+}
+
+def find_all_by_type(node: dict, type_: str):
+    """Simple node visitor that matches a particular node type
+
+    :param parent: starting node
+    :param type_: type of the node to search for
+    """
+    if node["type"] == type_:
+        yield node
+
+
+    if "children" not in node:
+        return
+    for next_node in node["children"]:      
+        yield from find_all_by_type(next_node, type_)
+
+
+def declare_result(content):
+    """Declare result as JSON to stdout
+
+    :param content: content to declare as the result
+    """
+
+    # Format result and write to stdout
+    json.dump(content, sys.stdout, indent=2)
+    # Successfully exit
+    raise SystemExit(0)
+
+
+def run_transform(name, data):
+    """Execute a transform with the given name and data
+
+    :param name: name of the transform to run
+    :param data: AST of the document upon which the transform is being run
+    """
+    assert name == "transform-typography"
+    for strong_node in find_all_by_type(data, "strong"):
+        child_text_nodes = find_all_by_type(strong_node, "text")
+        child_text = "".join([node['value'] for node in child_text_nodes])
+
+        # Only transform nodes whose text reads "special bold text (python)"
+        if child_text == "special bold text (python)":
+            strong_node["type"] = "emphasis"
+    
+    return data
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--role")
+    group.add_argument("--directive")
+    group.add_argument("--transform")
+    args = parser.parse_args()
+
+    if args.directive:
+        raise NotImplementedError
+    elif args.transform:
+        data = json.load(sys.stdin)
+        declare_result(run_transform(args.transform, data))
+    elif args.role:
+        raise NotImplementedError
+    else:
+        declare_result(plugin)
+

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -51,6 +51,12 @@ project:
     - unsplash.mjs
     - latex.mjs
     - templates.mjs
+    - type: executable
+      path: unsplash.py
+    - type: executable
+      path: markup.py
+    - type: javascript
+      path: markup.mjs
   error_rules:
     - rule: link-resolves
       severity: ignore
@@ -63,7 +69,7 @@ project:
         - /jtex/create-a-beamer-template
         - /jtex/contribute-a-template
   toc:
-    - file: index
+    - file: index.md
     - title: Quickstart Tutorials
       children:
         - file: quickstart.md
@@ -122,8 +128,10 @@ project:
         - file: creating-word-documents.md
         - file: creating-jats-xml.md
     - title: Extensions
+      file: plugins.md
       children:
-        - file: plugins.md
+        - file: javascript-plugins.md
+        - file: executable-plugins.md
     - title: Reference
       children:
         - file: background.md

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -36,79 +36,19 @@ renderers
 : For example, do something special for node in HTML, React, Microsoft Word, or LaTeX.
 :::
 
-## Creating a Plugin
+## Building a Plugin
 
-To create a plugin, you will need a single Javascript file[^esm] that exports one or more of the objects above. For example, a simple directive that pulls a random image from [Unsplash](https://unsplash.com/) can be created with a single file that exports an `unsplash` directive.
+There are two ways to implement a plugin in MyST
 
-[^esm]: The format of the Javascript should be an ECMAScript modules, not CommonJS. This means it uses `import` statements rather than `require()` and is the most modern style of Javascript.
+:::{card} JavaScript Plugins
+:link: ./javascript-plugins.md
 
-:::{literalinclude} unsplash.mjs
-:caption: A plugin to add an `unsplash` directive that includes a beautiful, random picture based on a query string.
+Plugins written in JavaScript with access to helpful AST manipulation routines.
 :::
 
-This code should be referenced from your `myst.yml` under the `projects.plugins`:
+:::{card} Executable Plugins
+:link: ./executable-plugins.md
 
-```{code} yaml
-:filename: myst.yml
-project:
-  plugins:
-    - unsplash.mjs
-```
-
-Then start or build your document using `myst start` or `myst build`, and you will see that the plugin is loaded.
-
-```text
-myst start
-...
-🔌 Unsplash Images (unsplash.mjs) loaded: 1 directive
-...
-```
-
-You can now use the directive, for example:
-
-```markdown
-:::{unsplash} misty,mountains
-:::
-```
-
-:::{unsplash} misty,mountains
-:size: 600x250
+Plugins written in other languages which communicate with MyST over stdin and stdout.
 :::
 
-If you change the source code you will have to stop and re-start the server to see the results.
-
-The types are defined in `myst-common` ([npm](https://www.npmjs.com/package/myst-common), [github](https://github.com/executablebooks/mystmd/tree/main/packages/myst-common)) with the [`DirectiveSpec`](https://github.com/executablebooks/mystmd/blob/9965925030c3fab6f34c20d11eeee7ffdafa73df/packages/myst-common/src/types.ts#L68-L77) and [`RoleSpec`](https://github.com/executablebooks/mystmd/blob/9965925030c3fab6f34c20d11eeee7ffdafa73df/packages/myst-common/src/types.ts#L79-L85) being the main types to implement.
-
-## Examples of plugins
-
-The documentation you're reading now defines several of its own plugins to extend MyST functionality.
-These are all registered in the documentation's [myst.yml configuration](myst.yml) with syntax like below:
-
-
-```{literalinclude} myst.yml
-:start-at: plugins
-:end-before: error_rules
-```
-
-Each plugin is defined as a `.mjs` file in the same folder as the documentation's MyST content.
-Below is the contents of each file for reference.
-
-::::{dropdown} Plugin: Latex rendering
-```{literalinclude} latex.mjs
-```
-::::
-
-::::{dropdown} Plugin: Display an image
-```{literalinclude} unsplash.mjs
-```
-::::
-
-::::{dropdown} Plugin: Custom directive for documenting roles and directives
-```{literalinclude} directives.mjs
-```
-::::
-
-::::{dropdown} Plugin: Render web template options as a table
-```{literalinclude} templates.mjs
-```
-::::

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -38,7 +38,7 @@ renderers
 
 ## Building a Plugin
 
-There are two ways to implement a plugin in MyST
+There are two ways to implement a plugin in MyST: JavaScript plugins, and executable plugins. The easiest way to get started in writing a custom plugin is to build a [JavaScript plugin](./javascript-plugins.md), but writing an executable plugin might be a better choice if you unfamiliar with JavaScript but are confident in a non-JS language e.g. Python.
 
 :::{card} JavaScript Plugins
 :link: ./javascript-plugins.md

--- a/docs/unsplash.py
+++ b/docs/unsplash.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+
+
+plugin = {
+    "name": "Unsplash Images",
+    "directives": [
+        {
+            "name": "unsplash-py",
+            "doc": "An example directive for showing a nice random image at a custom size.",
+            "alias": ["random-pic-py"],
+            "arg": {
+                "type": "string",
+                "doc": "The kinds of images to search for, e.g., `fruit`",
+            },
+            "options": {
+                "size": {
+                    "type": "string",
+                    "doc": "Size of the image, for example, `500x200`.",
+                },
+            },
+        }
+    ],
+}
+
+
+def declare_result(content):
+    """Declare result as JSON to stdout
+
+    :param content: content to declare as the result
+    """
+
+    # Format result and write to stdout
+    json.dump(content, sys.stdout, indent=2)
+    # Successfully exit
+    raise SystemExit(0)
+
+
+def run_directive(name, data):
+    """Execute a directive with the given name and data
+
+    :param name: name of the directive to run
+    :param data: data of the directive to run
+    """
+    assert name == "unsplash-py"
+
+    query = data["arg"]
+    size = data["options"].get("size", "500x200")
+    url = f"https://source.unsplash.com/random/{size}/?{query}"
+    # Insert an image of a landscape
+    img = {
+        "type": "image",
+        "url": url,
+    }
+    return [img]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--role")
+    group.add_argument("--directive")
+    group.add_argument("--transform")
+    args = parser.parse_args()
+
+    if args.directive:
+        data = json.load(sys.stdin)
+        declare_result(run_directive(args.directive, data))
+    elif args.transform:
+        raise NotImplementedError
+    elif args.role:
+        raise NotImplementedError
+    else:
+        declare_result(plugin)

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -384,10 +384,15 @@ async function resolveProjectConfigPaths(
   }
   if (projectConfig.plugins) {
     resolvedFields.plugins = await Promise.all(
-      projectConfig.plugins.map(async (file) => {
-        const resolved = await resolutionFn(session, path, file);
-        if (fs.existsSync(resolved)) return resolved;
-        return file;
+      projectConfig.plugins.map(async (info) => {
+        const resolved = await resolutionFn(session, path, info.path, {
+          allowRemote: info.type !== 'executable',
+        });
+        if (fs.existsSync(resolved)) {
+          return { ...info, path: resolved };
+        } else {
+          return info;
+        }
       }),
     );
   }

--- a/packages/myst-cli/src/executablePlugin.ts
+++ b/packages/myst-cli/src/executablePlugin.ts
@@ -1,0 +1,173 @@
+import type { ISession } from './session/types.js';
+import {
+  type MystPlugin,
+  type DirectiveSpec,
+  type RoleSpec,
+  type TransformSpec,
+  type GenericNode,
+} from 'myst-common';
+import { spawn, spawnSync } from 'node:child_process';
+
+type DirectiveJSONSpec = Omit<DirectiveSpec, 'run' | 'validate'>;
+type RoleJSONSpec = Omit<RoleSpec, 'run' | 'validate'>;
+type TransformJSONSpec = Omit<TransformSpec, 'plugin'>;
+type ExecutableSpec = Omit<MystPlugin, 'directives' | 'roles' | 'transforms'> & {
+  directives?: DirectiveJSONSpec[];
+  roles?: RoleJSONSpec[];
+  transforms?: TransformJSONSpec[];
+};
+
+function executeSyncParser(
+  session: ISession,
+  name: string,
+  data: Record<string, unknown>,
+  path: string,
+  kind: string,
+): GenericNode[] {
+  const { stdout, status, stderr } = spawnSync(path, [`--${kind}`, name], {
+    input: JSON.stringify(data),
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  if (status) {
+    throw new Error(
+      `Non-zero error code after running executable "${path}" during execution of ${kind} '${name}'\n\n${stderr}`,
+    );
+  } else {
+    if (stderr.length) {
+      session.log.debug(`\n\n${stderr}\n\n`);
+    }
+    return JSON.parse(stdout);
+  }
+}
+
+async function executeAsyncParser(
+  session: ISession,
+  name: string,
+  data: Record<string, unknown>,
+  path: string,
+  kind: string,
+) {
+  const proc = spawn(path, [`--${kind}`, name]);
+
+  // Pass in the data
+  proc.stdin.write(JSON.stringify(data));
+  proc.stdin.end();
+
+  // Read out the stdout in chunks
+  const stdoutBuffers: Buffer[] = [];
+  proc.stdout.on('data', (chunk) => {
+    stdoutBuffers.push(chunk);
+  });
+  // Read out the stderr in chunks
+  const stderrBuffers: Buffer[] = [];
+  proc.stderr.on('data', (chunk) => {
+    stderrBuffers.push(chunk);
+  });
+
+  // Await exit
+  const exitCode = await new Promise((resolve) => {
+    proc.on('close', (code) => resolve(code));
+  });
+
+  // Did the process fail?
+  if (exitCode) {
+    const stderr = Buffer.concat(stderrBuffers).toString();
+    throw new Error(
+      `Non-zero error code after running executable "${path}" during execution of ${kind} '${name}'\n\n${stderr}`,
+    );
+  } else if (stderrBuffers.length) {
+    const stderr = Buffer.concat(stderrBuffers).toString();
+    // Log the error
+    session.log.debug(`\n\n${stderr}\n\n`);
+  }
+
+  // Concatenate the responses
+  const stdout = Buffer.concat(stdoutBuffers).toString();
+  return JSON.parse(stdout);
+}
+
+function wrapDirective(
+  session: ISession,
+  directive: DirectiveJSONSpec,
+  path: string,
+): DirectiveSpec {
+  return {
+    ...directive,
+    run: (data) => {
+      return executeSyncParser(session, directive.name, data, path, 'directive');
+    },
+  };
+}
+
+function wrapRole(session: ISession, role: RoleJSONSpec, path: string): RoleSpec {
+  return {
+    ...role,
+    run: (data) => {
+      return executeSyncParser(session, role.name, data, path, 'role');
+    },
+  };
+}
+
+function wrapTransform(
+  session: ISession,
+  transform: TransformJSONSpec,
+  path: string,
+): TransformSpec {
+  return {
+    ...transform,
+    plugin: () => {
+      return async (node) => {
+        // Modify the tree in-place
+        const result = await executeAsyncParser(session, transform.name, node, path, 'transform');
+        Object.assign(node, result);
+      };
+    },
+  };
+}
+
+export async function loadExecutablePlugin(
+  session: ISession,
+  path: string,
+): Promise<MystPlugin | undefined> {
+  const proc = spawn(path, []);
+  // Read out the stdout in chunks
+  const stdoutBuffers: Buffer[] = [];
+  proc.stdout.on('data', (chunk) => {
+    stdoutBuffers.push(chunk);
+  });
+  // Read out the stderr in chunks
+  const stderrBuffers: Buffer[] = [];
+  proc.stderr.on('data', (chunk) => {
+    stderrBuffers.push(chunk);
+  });
+
+  // Await exit
+  const exitCode = await new Promise((resolve) => {
+    proc.on('close', (code) => resolve(code));
+  });
+
+  if (exitCode) {
+    // Log the error
+    const stderr = Buffer.concat(stderrBuffers).toString();
+    session.log.debug(`\n\n${stderr}\n\n`);
+
+    return undefined;
+  }
+
+  // Concatenate the responses
+  const stdout = Buffer.concat(stdoutBuffers).toString();
+
+  // Return the wrapped specification
+  const spec: ExecutableSpec = JSON.parse(stdout);
+  return {
+    ...spec,
+    directives: (spec.directives ?? []).map((directive: DirectiveJSONSpec) =>
+      wrapDirective(session, directive, path),
+    ),
+    roles: (spec.roles ?? []).map((role: RoleJSONSpec) => wrapRole(session, role, path)),
+    transforms: (spec.transforms ?? []).map((transform: TransformJSONSpec) =>
+      wrapTransform(session, transform, path),
+    ),
+  };
+}

--- a/packages/myst-cli/src/plugins.ts
+++ b/packages/myst-cli/src/plugins.ts
@@ -2,7 +2,9 @@ import fs from 'node:fs';
 import type { ISession } from './session/types.js';
 import { selectors } from './store/index.js';
 import { RuleId, plural, type MystPlugin } from 'myst-common';
+import type { PluginInfo } from 'myst-config';
 import { addWarningForFile } from './utils/addWarningForFile.js';
+import { loadExecutablePlugin } from './executablePlugin.js';
 
 /**
  * Load user-defined plugin modules declared in the project frontmatter
@@ -10,20 +12,25 @@ import { addWarningForFile } from './utils/addWarningForFile.js';
  * @param session session with logging
  */
 export async function loadPlugins(session: ISession): Promise<MystPlugin> {
-  let configPlugins: string[] = [];
+  let rawConfigPlugins: PluginInfo[] = [];
   const state = session.store.getState();
   const projConfig = selectors.selectCurrentProjectConfig(state);
-  if (projConfig?.plugins) configPlugins.push(...projConfig.plugins);
+  if (projConfig?.plugins) rawConfigPlugins.push(...projConfig.plugins);
   const siteConfig = selectors.selectCurrentSiteConfig(state);
   if (siteConfig?.projects) {
     siteConfig.projects
       .filter((project): project is { path: string } => !!project.path)
       .forEach((project) => {
         const siteProjConfig = selectors.selectLocalProjectConfig(state, project.path);
-        if (siteProjConfig?.plugins) configPlugins.push(...siteProjConfig.plugins);
+        if (siteProjConfig?.plugins) rawConfigPlugins.push(...siteProjConfig.plugins);
       });
   }
-  configPlugins = [...new Set(configPlugins)];
+
+  // Deduplicate by path
+  const configPlugins: PluginInfo[] = [
+    ...new Map(rawConfigPlugins.map((info) => [info.path, info])).values(),
+  ];
+
   const plugins: MystPlugin = {
     directives: [],
     roles: [],
@@ -32,32 +39,76 @@ export async function loadPlugins(session: ISession): Promise<MystPlugin> {
   if (configPlugins.length === 0) {
     return plugins;
   }
-  session.log.debug(`Loading plugins: "${configPlugins.join('", "')}"`);
+  session.log.debug(
+    `Loading plugins: "${configPlugins.map((info) => `${info.path} (${info.type})`).join('", "')}"`,
+  );
   const modules = await Promise.all(
-    configPlugins.map(async (filename) => {
-      if (!fs.statSync(filename).isFile || !filename.endsWith('.mjs')) {
-        addWarningForFile(
-          session,
-          filename,
-          `Unknown plugin "${filename}", it must be an mjs file`,
-          'error',
-          {
-            ruleId: RuleId.pluginLoads,
-          },
-        );
-        return null;
+    configPlugins.map(async (info) => {
+      const { type, path } = info;
+      switch (type) {
+        case 'executable':
+          // Ensure the plugin is a file
+          if (!fs.statSync(path).isFile) {
+            addWarningForFile(
+              session,
+              path,
+              `Unknown plugin "${path}", it must be an executable file`,
+              'error',
+              {
+                ruleId: RuleId.pluginLoads,
+              },
+            );
+            return null;
+          }
+          // Ensure the plugin is executable
+          try {
+            fs.accessSync(path, fs.constants.X_OK);
+          } catch (err) {
+            addWarningForFile(session, path, `Plugin "${path}" is not executable`, 'error', {
+              ruleId: RuleId.pluginLoads,
+            });
+            return null;
+          }
+          const plugin = await loadExecutablePlugin(session, info.path);
+          if (plugin === undefined) {
+            addWarningForFile(
+              session,
+              path,
+              `Non-zero exit code after querying executable "${path}" for plugin specification`,
+              'error',
+              {
+                ruleId: RuleId.pluginLoads,
+              },
+            );
+
+            return null;
+          }
+          return { path, module: { plugin } };
+        case 'javascript':
+          if (!fs.statSync(path).isFile || !path.endsWith('.mjs')) {
+            addWarningForFile(
+              session,
+              path,
+              `Unknown plugin "${path}", it must be an mjs file`,
+              'error',
+              {
+                ruleId: RuleId.pluginLoads,
+              },
+            );
+            return null;
+          }
+          let module: any;
+          try {
+            module = await import(path);
+          } catch (error) {
+            session.log.debug(`\n\n${(error as Error)?.stack}\n\n`);
+            addWarningForFile(session, path, `Error reading plugin: ${error}`, 'error', {
+              ruleId: RuleId.pluginLoads,
+            });
+            return null;
+          }
+          return { path, module };
       }
-      let module: any;
-      try {
-        module = await import(filename);
-      } catch (error) {
-        session.log.debug(`\n\n${(error as Error)?.stack}\n\n`);
-        addWarningForFile(session, filename, `Error reading plugin: ${error}`, 'error', {
-          ruleId: RuleId.pluginLoads,
-        });
-        return null;
-      }
-      return { filename, module };
     }),
   );
   modules.forEach((pluginLoader) => {
@@ -67,7 +118,7 @@ export async function loadPlugins(session: ISession): Promise<MystPlugin> {
     const roles = plugin.roles || pluginLoader.module.roles;
     const transforms = plugin.transforms || pluginLoader.module.transforms;
     session.log.info(
-      `🔌 ${plugin?.name ?? 'Unnamed Plugin'} (${pluginLoader.filename}) loaded: ${plural(
+      `🔌 ${plugin?.name ?? 'Unnamed Plugin'} (${pluginLoader.path}) loaded: ${plural(
         '%s directive(s)',
         directives,
       )}, ${plural('%s role(s)', roles)}, ${plural('%s transform(s)', transforms)}`,

--- a/packages/myst-common/src/ruleids.ts
+++ b/packages/myst-common/src/ruleids.ts
@@ -100,6 +100,7 @@ export enum RuleId {
   staticActionFileCopied = 'static-action-file-copied',
   // Plugins
   pluginLoads = 'plugin-loads',
+  pluginExecutionFailed = 'plugin-execution-failed',
   // Container rules
   containerChildrenValid = 'container-children-valid',
 }

--- a/packages/myst-config/src/project/types.ts
+++ b/packages/myst-config/src/project/types.ts
@@ -3,10 +3,20 @@ import type { ErrorRule } from '../errorRules/types.js';
 
 export const VERSION = 1;
 
+export enum PluginTypes {
+  javascript = 'javascript',
+  executable = 'executable',
+}
+
+export type PluginInfo = {
+  type: PluginTypes;
+  path: string;
+};
+
 export type ProjectConfig = ProjectFrontmatter & {
   remote?: string;
   index?: string;
   exclude?: string[];
-  plugins?: string[];
+  plugins?: PluginInfo[];
   error_rules?: ErrorRule[];
 };

--- a/packages/myst-config/src/project/validators.ts
+++ b/packages/myst-config/src/project/validators.ts
@@ -43,27 +43,27 @@ export function validatePluginInfo(input: any, opts: ValidationOptions): PluginI
   return { type, path };
 }
 
-function validateProjectConfigKeys(value: Record<string, any>, opts: ValidationOptions) {
-  const output: ProjectConfig = validateProjectFrontmatterKeys(value, opts);
-  if (defined(value.remote)) {
-    output.remote = validateString(value.remote, incrementOptions('remote', opts));
+function validateProjectConfigKeys(input: Record<string, any>, opts: ValidationOptions) {
+  const output: ProjectConfig = validateProjectFrontmatterKeys(input, opts);
+  if (defined(input.remote)) {
+    output.remote = validateString(input.remote, incrementOptions('remote', opts));
   }
-  if (defined(value.index)) {
+  if (defined(input.index)) {
     // TODO: Warn if these files don't exist
-    output.index = validateString(value.index, incrementOptions('index', opts));
+    output.index = validateString(input.index, incrementOptions('index', opts));
   }
-  if (defined(value.exclude)) {
+  if (defined(input.exclude)) {
     output.exclude = validateList(
-      value.exclude,
+      input.exclude,
       { coerce: true, ...incrementOptions('exclude', opts) },
       (value, index: number) => {
         return validateString(value, incrementOptions(`exclude.${index}`, opts));
       },
     );
   }
-  if (defined(value.plugins)) {
+  if (defined(input.plugins)) {
     output.plugins = validateList(
-      value.plugins,
+      input.plugins,
       incrementOptions('plugins', opts),
       (file, index: number) => {
         return validatePluginInfo(file, incrementOptions(`plugins.${index}`, opts));
@@ -71,8 +71,8 @@ function validateProjectConfigKeys(value: Record<string, any>, opts: ValidationO
     );
   }
 
-  if (defined(value.error_rules)) {
-    const error_rules = validateErrorRuleList(value.error_rules, opts);
+  if (defined(input.error_rules)) {
+    const error_rules = validateErrorRuleList(input.error_rules, opts);
     if (error_rules) output.error_rules = error_rules;
   }
   return output;


### PR DESCRIPTION
This PR fixes #1298 in a different way to #1325 by adding a new "executable" type of plugin (the approach taken in https://gist.github.com/agoose77/66700b2a172b4c11d4801f742534e4f7). Unlike #1325, this PR adds support for Python via an IPC mechanism (stdout, stdin).

#1325 and this PR are _not_ mutually exclusive; #1325 adds support for an in-process Python executor, which supports sharing stateful proxies between JS and Python. This PR, meanwhile, is fully decoupled and allows for further languages. Note that, unlike #1325, we do not vendor Python, so it is possible that users may define plugins whose environment is not sufficiently reproducible and thus see build errors.

> [!NOTE]
> #1325 will need to be rebased and updated to use this new mechanism for declaring plugin _types_.

To implement such a plugin, the executable needs to support the following invocation modes:
- `proc`
  Return the "spec" of the plugin, i.e. the implementation-free `plugin` block
- `proc --directive <DIRECTIVE>`
  Execute the implementation of a directive `<DIRECTIVE>`
- `proc --role <ROLE>`
  Execute the implementation of a role `<DIRECTIVE>`
- `proc --transform <TRANSFORM>`
  Execute the implementation of a transform `<DIRECTIVE>`
whereby the auxillary data for these executions is provided via `stdin`, the results read out from `stdout`, and error/debug information read from `stderr`.

Right now, I didn't add the `validate` method. We could; it's not much extra work. But do we need it? An example of a directive and transform is given in the docs of this PR.

> [!CAUTION]
> Syntax Changes from this PR in `myst.yml`:
> <table><tr><td>
>
> ```yaml
> project:
>   plugins:
>     - test.mjs
> ```
>  
> </td><td>
> 
> ```yaml
> project:
>   plugins:
>     - type: javascript
>       path: test.mjs
>     - type: executable
>       path: python.py
> ```
> </td></tr></table>
> N.b. this change is opt-in; existing `plugin` declarations will work just fine.