### PR TITLE
🖊 Add support for white-labelling to MyST CLI

### DIFF
--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -270,7 +270,9 @@ export async function build(session: ISession, files: string[], opts: BuildOpts)
     } else {
       session.log.info(`🌎 Building ${readableName()} site`);
       if (watch) {
-        session.log.warn(`Site content will not be watched and updated; use '${binaryName()} start' instead`);
+        session.log.warn(
+          `Site content will not be watched and updated; use '${binaryName()} start' instead`,
+        );
       }
       if (opts.html) {
         buildLog.buildHtml = true;

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -15,6 +15,7 @@ import { localArticleExport } from './utils/localArticleExport.js';
 import type { CollectionOptions } from './utils/collectExportOptions.js';
 import { collectExportOptions, resolveExportListArticles } from './utils/collectExportOptions.js';
 import { buildHtml } from './html/index.js';
+import { binaryName, readableName } from '../utils/whiteLabelling.js';
 
 type FormatBuildOpts = {
   /** Options to decide what to build */
@@ -252,7 +253,7 @@ export async function build(session: ISession, files: string[], opts: BuildOpts)
       } else {
         session.log.info(
           chalk.dim(
-            'You may need to specify either:\n  - an export format, e.g. `myst build --pdf`\n  - a file to export, e.g. `myst build my-file.md`',
+            `You may need to specify either:\n  - an export format, e.g. \`${binaryName()} build --pdf\`\n  - a file to export, e.g. \`${binaryName()} build my-file.md\``,
           ),
         );
       }
@@ -265,11 +266,11 @@ export async function build(session: ISession, files: string[], opts: BuildOpts)
     const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
     if (!siteConfig) {
       session.log.info('🌎 No site configuration found.');
-      session.log.debug(`To build a site, first run 'myst init --site'`);
+      session.log.debug(`To build a site, first run '${binaryName()} init --site'`);
     } else {
-      session.log.info(`🌎 Building MyST site`);
+      session.log.info(`🌎 Building ${readableName()} site`);
       if (watch) {
-        session.log.warn(`Site content will not be watched and updated; use 'myst start' instead`);
+        session.log.warn(`Site content will not be watched and updated; use '${binaryName()} start' instead`);
       }
       if (opts.html) {
         buildLog.buildHtml = true;

--- a/packages/myst-cli/src/cli/build.ts
+++ b/packages/myst-cli/src/cli/build.ts
@@ -20,6 +20,8 @@ import {
   makeMaxSizeWebpOption,
   makeDOIBibOption,
 } from './options.js';
+import { readableName } from '../utils/whiteLabelling.js';
+
 
 export function makeBuildCommand() {
   const command = new Command('build')
@@ -33,7 +35,7 @@ export function makeBuildCommand() {
     .addOption(makeMdOption('Build MD output'))
     .addOption(makeJatsOption('Build JATS xml output'))
     .addOption(makeMecaOptions('Build MECA zip output'))
-    .addOption(makeSiteOption('Build MyST site content'))
+    .addOption(makeSiteOption(`Build ${readableName()} site content`))
     .addOption(makeHtmlOption('Build static HTML site content'))
     .addOption(makeAllOption('Build all exports'))
     .addOption(makeDOIBibOption())

--- a/packages/myst-cli/src/cli/build.ts
+++ b/packages/myst-cli/src/cli/build.ts
@@ -22,7 +22,6 @@ import {
 } from './options.js';
 import { readableName } from '../utils/whiteLabelling.js';
 
-
 export function makeBuildCommand() {
   const command = new Command('build')
     .description('Build PDF, LaTeX, Word and website exports from MyST files')

--- a/packages/myst-cli/src/cli/clean.ts
+++ b/packages/myst-cli/src/cli/clean.ts
@@ -18,6 +18,7 @@ import {
   makeExportsOption,
   makeTemplatesOption,
 } from './options.js';
+import { readableName } from '../utils/whiteLabelling.js';
 
 export function makeCleanCommand() {
   const command = new Command('clean')
@@ -30,7 +31,7 @@ export function makeCleanCommand() {
     .addOption(makeMdOption('Clean MD output'))
     .addOption(makeJatsOption('Clean JATS xml output'))
     .addOption(makeMecaOptions('Clean MECA zip output'))
-    .addOption(makeSiteOption('Clean MyST site content'))
+    .addOption(makeSiteOption(`Clean ${readableName()} site content`))
     .addOption(makeHtmlOption('Clean static HTML site content'))
     .addOption(makeExecuteOption('Clean execute cache'))
     .addOption(makeTempOption())
@@ -39,7 +40,7 @@ export function makeCleanCommand() {
     .addOption(makeExportsOption())
     .addOption(makeTemplatesOption())
     .addOption(
-      makeAllOption('Delete all exports, site content, templates, and temp files created by MyST'),
+      makeAllOption(`Delete all exports, site content, templates, and temp files created by ${readableName()}`),
     )
     .addOption(makeYesOption());
   return command;

--- a/packages/myst-cli/src/cli/clean.ts
+++ b/packages/myst-cli/src/cli/clean.ts
@@ -40,7 +40,9 @@ export function makeCleanCommand() {
     .addOption(makeExportsOption())
     .addOption(makeTemplatesOption())
     .addOption(
-      makeAllOption(`Delete all exports, site content, templates, and temp files created by ${readableName()}`),
+      makeAllOption(
+        `Delete all exports, site content, templates, and temp files created by ${readableName()}`,
+      ),
     )
     .addOption(makeYesOption());
   return command;

--- a/packages/myst-cli/src/init/init.ts
+++ b/packages/myst-cli/src/init/init.ts
@@ -16,10 +16,16 @@ import { upgradeJupyterBook } from './jupyter-book/upgrade.js';
 import { fsExists } from '../utils/fsExists.js';
 
 const VERSION_CONFIG = '# See docs at: https://mystmd.org/guide/frontmatter\nversion: 1\n';
-import { binaryName, homeURL, readableName } from '../utils/whiteLabelling.js';
+import { binaryName, homeURL, readableName, baseConfigs } from '../utils/whiteLabelling.js';
+
+const extendsConfigItems = baseConfigs().map(item => `
+    - ${item}`).join("");
+const extendsConfig = extendsConfigItems ? `
+  # ${readableName()} base configuration
+  extends:${extendsConfigItems}` : "";
 
 function createProjectConfig({ github }: { github?: string } = {}) {
-  return `project:
+  return `project:${extendsConfig}
   id: ${uuid()}
   # title:
   # description:

--- a/packages/myst-cli/src/init/init.ts
+++ b/packages/myst-cli/src/init/init.ts
@@ -16,19 +16,7 @@ import { upgradeJupyterBook } from './jupyter-book/upgrade.js';
 import { fsExists } from '../utils/fsExists.js';
 
 const VERSION_CONFIG = '# See docs at: https://mystmd.org/guide/frontmatter\nversion: 1\n';
-import { binaryName, homeURL, readableName, baseConfigs } from '../utils/whiteLabelling.js';
-
-const extendsConfigItems = baseConfigs()
-  .map(
-    (item) => `
-    - ${item}`,
-  )
-  .join('');
-const extendsConfig = extendsConfigItems
-  ? `
-# ${readableName()} base configuration
-extend:${extendsConfigItems}`
-  : '';
+import { binaryName, homeURL, readableName } from '../utils/whiteLabelling.js';
 
 function createProjectConfig({ github }: { github?: string } = {}) {
   return `project:

--- a/packages/myst-cli/src/init/init.ts
+++ b/packages/myst-cli/src/init/init.ts
@@ -18,11 +18,17 @@ import { fsExists } from '../utils/fsExists.js';
 const VERSION_CONFIG = '# See docs at: https://mystmd.org/guide/frontmatter\nversion: 1\n';
 import { binaryName, homeURL, readableName, baseConfigs } from '../utils/whiteLabelling.js';
 
-const extendsConfigItems = baseConfigs().map(item => `
-    - ${item}`).join("");
-const extendsConfig = extendsConfigItems ? `
+const extendsConfigItems = baseConfigs()
+  .map(
+    (item) => `
+    - ${item}`,
+  )
+  .join('');
+const extendsConfig = extendsConfigItems
+  ? `
   # ${readableName()} base configuration
-  extends:${extendsConfigItems}` : "";
+  extends:${extendsConfigItems}`
+  : '';
 
 function createProjectConfig({ github }: { github?: string } = {}) {
   return `project:${extendsConfig}

--- a/packages/myst-cli/src/init/init.ts
+++ b/packages/myst-cli/src/init/init.ts
@@ -26,12 +26,12 @@ const extendsConfigItems = baseConfigs()
   .join('');
 const extendsConfig = extendsConfigItems
   ? `
-  # ${readableName()} base configuration
-  extends:${extendsConfigItems}`
+# ${readableName()} base configuration
+extend:${extendsConfigItems}`
   : '';
 
 function createProjectConfig({ github }: { github?: string } = {}) {
-  return `project:${extendsConfig}
+  return `project:
   id: ${uuid()}
   # title:
   # description:

--- a/packages/myst-cli/src/init/init.ts
+++ b/packages/myst-cli/src/init/init.ts
@@ -16,7 +16,7 @@ import { upgradeJupyterBook } from './jupyter-book/upgrade.js';
 import { fsExists } from '../utils/fsExists.js';
 
 const VERSION_CONFIG = '# See docs at: https://mystmd.org/guide/frontmatter\nversion: 1\n';
-import { binaryName, helpURL, readableName } from '../utils/whiteLabelling.js';
+import { binaryName, homeURL, readableName } from '../utils/whiteLabelling.js';
 
 function createProjectConfig({ github }: { github?: string } = {}) {
   return `project:
@@ -57,7 +57,7 @@ You can use ${readableName()} to:
  - create interactive ${chalk.bold.magenta('websites')} from markdown and Jupyter Notebooks 📈
  - ${chalk.bold.magenta('build & export')} professional PDFs and Word documents 📄
 
-Learn more about this CLI and MyST Markdown at: ${chalk.bold(helpURL())}
+Learn more about this CLI and MyST Markdown at: ${chalk.bold(homeURL())}
 
 `;
 

--- a/packages/myst-cli/src/init/init.ts
+++ b/packages/myst-cli/src/init/init.ts
@@ -16,6 +16,7 @@ import { upgradeJupyterBook } from './jupyter-book/upgrade.js';
 import { fsExists } from '../utils/fsExists.js';
 
 const VERSION_CONFIG = '# See docs at: https://mystmd.org/guide/frontmatter\nversion: 1\n';
+import { binaryName, helpURL, readableName } from '../utils/whiteLabelling.js';
 
 function createProjectConfig({ github }: { github?: string } = {}) {
   return `project:
@@ -25,7 +26,7 @@ function createProjectConfig({ github }: { github?: string } = {}) {
   # keywords: []
   # authors: []
   ${github ? `github: ${github}` : '# github:'}
-  # To autogenerate a Table of Contents, run "myst init --write-toc"
+  # To autogenerate a Table of Contents, run "${binaryName()} init --write-toc"
 `;
 }
 const SITE_CONFIG = `site:
@@ -35,7 +36,7 @@ const SITE_CONFIG = `site:
   #   logo: site_logo.png
 `;
 
-const GITIGNORE = `# MyST build outputs
+const GITIGNORE = `# ${readableName()} build outputs
 /_build/`;
 
 export type InitOptions = {
@@ -47,16 +48,16 @@ export type InitOptions = {
 };
 
 const WELCOME = () => `
-${chalk.bold.yellowBright.italic('Welcome to the MyST Markdown CLI!!')} 🎉 🚀
+${chalk.bold.yellowBright.italic(`Welcome to the ${readableName()} CLI!`)} 🎉 🚀
 
-${chalk.bold.green('myst init')} walks you through creating a ${chalk.bold.blue('myst.yml')} file.
+${chalk.bold.green(`${binaryName()} init`)} walks you through creating a ${chalk.bold.blue('myst.yml')} file.
 
-You can use myst to:
+You can use ${readableName()} to:
 
  - create interactive ${chalk.bold.magenta('websites')} from markdown and Jupyter Notebooks 📈
  - ${chalk.bold.magenta('build & export')} professional PDFs and Word documents 📄
 
-Learn more about this CLI and MyST Markdown at: ${chalk.bold('https://mystmd.org')}
+Learn more about this CLI and MyST Markdown at: ${chalk.bold(helpURL())}
 
 `;
 
@@ -92,7 +93,7 @@ export async function init(session: ISession, opts: InitOptions) {
       // Do we have mention of `/?_build`?
       //eslint-disable-next-line
       if (lines.some((line) => /^\/?_build([#\/].*)?$/.test(line))) {
-        session.log.info(`✅ .gitignore exists and already ignores MyST outputs`);
+        session.log.info(`✅ .gitignore exists and already ignores ${readableName()} outputs`);
       } else {
         session.log.info(`💾 Updating .gitignore`);
         await fs.promises.writeFile('.gitignore', `${contents}\n/_build/`);
@@ -196,17 +197,17 @@ export async function init(session: ISession, opts: InitOptions) {
   const promptStart = await inquirer.prompt([
     {
       name: 'start',
-      message: `Would you like to run ${chalk.green('myst start')} now?`,
+      message: `Would you like to run ${chalk.green(`${binaryName()} start`)} now?`,
       type: 'confirm',
       default: true,
     },
   ]);
   if (!promptStart.start) {
     session.log.info(
-      chalk.dim('\nYou can start the myst web server later with:'),
-      chalk.bold('myst start'),
+      chalk.dim(`\nYou can start the ${readableName()} web server later with:`),
+      chalk.bold(`${binaryName()} start`),
       chalk.dim('\nYou can build all content with:'),
-      chalk.bold('myst build --all'),
+      chalk.bold(`${binaryName()} build --all`),
     );
     return;
   }

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -16,6 +16,8 @@ import { projectFromPath } from './fromPath.js';
 import { projectFromTOC, projectFromSphinxTOC, getIgnoreFiles } from './fromTOC.js';
 import type { LocalProject, LocalProjectPage } from './types.js';
 import { writeTOCToConfigFile } from './toTOC.js';
+import { binaryName, readableName } from '../utils/whiteLabelling.js';
+
 /**
  * Load project structure from disk
  *
@@ -47,7 +49,7 @@ export async function loadProjectFromDisk(
     addWarningForFile(
       session,
       projectConfigFile,
-      `Loading project from path with no config file: ${path}\nConsider running "myst init --project" in that directory`,
+      `Loading project from path with no config file: ${path}\nConsider running "${binaryName()} init --project" in that directory`,
       'warn',
       { ruleId: RuleId.projectConfigExists },
     );
@@ -62,7 +64,7 @@ export async function loadProjectFromDisk(
       addWarningForFile(
         session,
         sphinxTOCFile,
-        `Ignoring legacy jupyterbook TOC in favor of myst.yml TOC: ${sphinxTOCFile}`,
+        `Ignoring legacy Jupyter Book TOC in favor of myst.yml TOC: ${sphinxTOCFile}`,
         'warn',
         {
           ruleId: RuleId.encounteredLegacyTOC,
@@ -77,8 +79,8 @@ export async function loadProjectFromDisk(
     if (!writeTOC) {
       // Do not warn if user is explicitly upgrading toc
       // TODO: Add this back as a warning rather than debug as we surface this feature more
-      session.log.debug(`Encountered legacy jupyterbook TOC: ${sphinxTOCFile}`);
-      session.log.debug('To upgrade to a MyST TOC, try running `myst init --write-toc`');
+      session.log.debug(`Encountered legacy Jupyter Book TOC: ${sphinxTOCFile}`);
+      session.log.debug(`To upgrade to a ${readableName()} TOC, try running \`${binaryName()} init --write-toc\``);
       // addWarningForFile(
       //   session,
       //   filename,
@@ -104,7 +106,7 @@ export async function loadProjectFromDisk(
   }
   if (writeTOC) {
     if (legacyToc) {
-      session.log.info(`⬆️ Upgrading legacy jupyterbook TOC to MyST: ${tocFile(path)}`);
+      session.log.info(`⬆️ Upgrading legacy Jupyter Book TOC to ${readableName()}: ${tocFile(path)}`);
     }
     session.log.info(`💾 Writing new TOC to: ${projectConfigFile}`);
     await writeTOCToConfigFile(newProject, projectConfigFile, projectConfigFile);

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -80,7 +80,9 @@ export async function loadProjectFromDisk(
       // Do not warn if user is explicitly upgrading toc
       // TODO: Add this back as a warning rather than debug as we surface this feature more
       session.log.debug(`Encountered legacy Jupyter Book TOC: ${sphinxTOCFile}`);
-      session.log.debug(`To upgrade to a ${readableName()} TOC, try running \`${binaryName()} init --write-toc\``);
+      session.log.debug(
+        `To upgrade to a ${readableName()} TOC, try running \`${binaryName()} init --write-toc\``,
+      );
       // addWarningForFile(
       //   session,
       //   filename,
@@ -106,7 +108,9 @@ export async function loadProjectFromDisk(
   }
   if (writeTOC) {
     if (legacyToc) {
-      session.log.info(`⬆️ Upgrading legacy Jupyter Book TOC to ${readableName()}: ${tocFile(path)}`);
+      session.log.info(
+        `⬆️ Upgrading legacy Jupyter Book TOC to ${readableName()}: ${tocFile(path)}`,
+      );
     }
     session.log.info(`💾 Writing new TOC to: ${projectConfigFile}`);
     await writeTOCToConfigFile(newProject, projectConfigFile, projectConfigFile);

--- a/packages/myst-cli/src/utils/index.ts
+++ b/packages/myst-cli/src/utils/index.ts
@@ -14,6 +14,7 @@ export * from './shouldIgnoreFile.js';
 export * from './toc.js';
 export * from './uniqueArray.js';
 export * from './github.js';
+export * from './whiteLabelling.js';
 
 export * as imagemagick from './imagemagick.js';
 export * as inkscape from './inkscape.js';

--- a/packages/myst-cli/src/utils/whiteLabelling.ts
+++ b/packages/myst-cli/src/utils/whiteLabelling.ts
@@ -1,5 +1,10 @@
 export function readableName(): string {
-  return (process.env.MYSTMD_READABLE_NAME ?? 'myst') as string;
+  if ('MYSTMD_READABLE_NAME' in process.env) {
+    const readableName = process.env.MYSTMD_READABLE_NAME as string;
+    return `${readableName} (via myst)`;
+  } else {
+    return 'myst';
+  }
 }
 
 export function binaryName(): string {
@@ -10,8 +15,14 @@ export function homeURL(): string {
   return (process.env.MYSTMD_HOME_URL ?? 'https://mystmd.org') as string;
 }
 
+export function baseConfigs(): string[] {
+  const rawConfigsString = (process.env.MYSTMD_BASE_CONFIGS ?? '') as string;
+  return rawConfigsString
+    .split(';')
+    .map((item) => item.trim())
+    .filter((item) => item.length);
+}
+
 export function isWhiteLabelled(): boolean {
-  return ['MYSTMD_READABLE_NAME', 'MYSTMD_BINARY_NAME', 'MYSTMD_HOME_URL'].some(
-    (name) => name in process.env,
-  );
+  return ['MYSTMD_READABLE_NAME', 'MYSTMD_BINARY_NAME'].some((name) => name in process.env);
 }

--- a/packages/myst-cli/src/utils/whiteLabelling.ts
+++ b/packages/myst-cli/src/utils/whiteLabelling.ts
@@ -1,11 +1,11 @@
 export function readableName(): string {
-  return (process.env.MYSTMD_READABLE_NAME ?? "myst") as string;
+  return (process.env.MYSTMD_READABLE_NAME ?? 'myst') as string;
 }
 
 export function binaryName(): string {
-  return (process.env.MYSTMD_BINARY_NAME ?? "myst") as string;
+  return (process.env.MYSTMD_BINARY_NAME ?? 'myst') as string;
 }
 
 export function homeURL(): string {
-  return (process.env.MYSTMD_HOME_URL ?? "https://mystmd.org") as string;
+  return (process.env.MYSTMD_HOME_URL ?? 'https://mystmd.org') as string;
 }

--- a/packages/myst-cli/src/utils/whiteLabelling.ts
+++ b/packages/myst-cli/src/utils/whiteLabelling.ts
@@ -1,7 +1,7 @@
 export function readableName(): string {
   if ('MYSTMD_READABLE_NAME' in process.env) {
-    const readableName = process.env.MYSTMD_READABLE_NAME as string;
-    return `${readableName} (via myst)`;
+    const name = process.env.MYSTMD_READABLE_NAME as string;
+    return `${name} (via myst)`;
   } else {
     return 'myst';
   }

--- a/packages/myst-cli/src/utils/whiteLabelling.ts
+++ b/packages/myst-cli/src/utils/whiteLabelling.ts
@@ -6,6 +6,6 @@ export function binaryName(): string {
   return (process.env.MYSTMD_BINARY_NAME ?? "myst") as string;
 }
 
-export function helpURL(): string {
-  return (process.env.MYSTMD_HELP_URL ?? "https://mystmd.org") as string;
+export function homeURL(): string {
+  return (process.env.MYSTMD_HOME_URL ?? "https://mystmd.org") as string;
 }

--- a/packages/myst-cli/src/utils/whiteLabelling.ts
+++ b/packages/myst-cli/src/utils/whiteLabelling.ts
@@ -1,0 +1,11 @@
+export function readableName(): string {
+  return (process.env.MYSTMD_READABLE_NAME ?? "myst") as string;
+}
+
+export function binaryName(): string {
+  return (process.env.MYSTMD_BINARY_NAME ?? "myst") as string;
+}
+
+export function helpURL(): string {
+  return (process.env.MYSTMD_HELP_URL ?? "https://mystmd.org") as string;
+}

--- a/packages/myst-cli/src/utils/whiteLabelling.ts
+++ b/packages/myst-cli/src/utils/whiteLabelling.ts
@@ -3,7 +3,7 @@ export function readableName(): string {
     const name = process.env.MYSTMD_READABLE_NAME as string;
     return `${name} (via myst)`;
   } else {
-    return 'myst';
+    return 'MyST';
   }
 }
 

--- a/packages/myst-cli/src/utils/whiteLabelling.ts
+++ b/packages/myst-cli/src/utils/whiteLabelling.ts
@@ -9,3 +9,9 @@ export function binaryName(): string {
 export function homeURL(): string {
   return (process.env.MYSTMD_HOME_URL ?? 'https://mystmd.org') as string;
 }
+
+export function isWhiteLabelled(): boolean {
+  return ['MYSTMD_READABLE_NAME', 'MYSTMD_BINARY_NAME', 'MYSTMD_HOME_URL'].some(
+    (name) => name in process.env,
+  );
+}

--- a/packages/myst-cli/src/utils/whiteLabelling.ts
+++ b/packages/myst-cli/src/utils/whiteLabelling.ts
@@ -15,14 +15,6 @@ export function homeURL(): string {
   return (process.env.MYSTMD_HOME_URL ?? 'https://mystmd.org') as string;
 }
 
-export function baseConfigs(): string[] {
-  const rawConfigsString = (process.env.MYSTMD_BASE_CONFIGS ?? '') as string;
-  return rawConfigsString
-    .split(';')
-    .map((item) => item.trim())
-    .filter((item) => item.length);
-}
-
 export function isWhiteLabelled(): boolean {
   return ['MYSTMD_READABLE_NAME', 'MYSTMD_BINARY_NAME'].some((name) => name in process.env);
 }

--- a/packages/mystmd/src/index.ts
+++ b/packages/mystmd/src/index.ts
@@ -7,6 +7,7 @@ import { makeCleanCLI } from './clean.js';
 import { makeInitCLI, addDefaultCommand } from './init.js';
 import { makeStartCLI } from './site.js';
 import { makeTemplatesCLI } from './templates.js';
+import chalk from 'chalk';
 import { readableName, isWhiteLabelled } from 'myst-cli';
 
 const program = new Command();

--- a/packages/mystmd/src/index.ts
+++ b/packages/mystmd/src/index.ts
@@ -13,7 +13,7 @@ const program = new Command();
 
 if (isWhiteLabelled()) {
   program.description(
-    `${readableName()} is powered by MyST-MD. See https://mystmd.org for more information.`,
+    `${readableName()} is powered by ${chalk.blue('mystmd')}. See https://mystmd.org for more information.`,
   );
 }
 

--- a/packages/mystmd/src/index.ts
+++ b/packages/mystmd/src/index.ts
@@ -7,6 +7,7 @@ import { makeCleanCLI } from './clean.js';
 import { makeInitCLI, addDefaultCommand } from './init.js';
 import { makeStartCLI } from './site.js';
 import { makeTemplatesCLI } from './templates.js';
+import { readableName } from 'myst-cli';
 
 const program = new Command();
 
@@ -15,7 +16,7 @@ program.addCommand(makeBuildCLI(program));
 program.addCommand(makeStartCLI(program));
 program.addCommand(makeCleanCLI(program));
 program.addCommand(makeTemplatesCLI(program));
-program.version(`v${version}`, '-v, --version', 'Print the current version of myst');
+program.version(`v${version}`, '-v, --version', `Print the current version of ${readableName()}`);
 program.option('-d, --debug', 'Log out any errors to the console');
 addDefaultCommand(program);
 program.parse(process.argv);

--- a/packages/mystmd/src/index.ts
+++ b/packages/mystmd/src/index.ts
@@ -7,9 +7,15 @@ import { makeCleanCLI } from './clean.js';
 import { makeInitCLI, addDefaultCommand } from './init.js';
 import { makeStartCLI } from './site.js';
 import { makeTemplatesCLI } from './templates.js';
-import { readableName } from 'myst-cli';
+import { readableName, isWhiteLabelled } from 'myst-cli';
 
 const program = new Command();
+
+if (isWhiteLabelled()) {
+  program.description(
+    `${readableName()} is powered by MyST-MD. See https://mystmd.org for more information.`,
+  );
+}
 
 program.addCommand(makeInitCLI(program));
 program.addCommand(makeBuildCLI(program));

--- a/packages/mystmd/src/init.ts
+++ b/packages/mystmd/src/init.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { Session, init, makeSiteOption } from 'myst-cli';
+import { Session, init, makeSiteOption, readableName } from 'myst-cli';
 import { clirun } from './clirun.js';
 import {
   makeProjectOption,
@@ -11,9 +11,9 @@ import {
 
 export function makeInitCLI(program: Command) {
   const command = new Command('init')
-    .description('Initialize a MyST project in the current directory')
-    .addOption(makeProjectOption('Initialize config for MyST project content'))
-    .addOption(makeSiteOption('Initialize config for MyST site'))
+    .description(`Initialize a ${readableName()} project in the current directory`)
+    .addOption(makeProjectOption(`Initialize config for ${readableName()} project content`))
+    .addOption(makeSiteOption(`Initialize config for ${readableName()} site`))
     .addOption(makeWriteTOCOption())
     .addOption(makeGithubPagesOption())
     .addOption(makeGithubCurvenoteOption())


### PR DESCRIPTION
The current plan for Jupyter Book is to have it be a thin white-labelled distribution of MyST-MD. The intention here is to avoid having to maintain a separate application with its own release cadence. Instead, we'll just re-skin MyST whilst making it clear that Jupyter Book _is_ MyST.

See also https://github.com/executablebooks/jupyter-book-myst/issues/3

This PR suggests one way to do this, by reading from the environment. Using this approach will require us to be careful in how we write our error messages. I added four functions:

- `binaryName()` - the name of the binary e.g. `myst` or `jupyter book`
- `readableName()` the human-readable name of the application, e.g. `myst` or `Jupyter Book (via MyST)`
- `homeURL()` - the URL of the application
- `baseConfigs` - a list of URLs / file paths of base configurations

These each return default values unless the corresponding 

- `MYSTMD_BINARY_NAME`
- `MYSTMD_READABLE_NAME`
- `MYSTMD_HOME_URL`
- `MYSTMD_CASE_CONFIGS`

are set.

N.B. we probably could have these be static and read the env var at import time ... but I don't know if that's a standard pattern.

An example using Jupyter Book:
```shell
❯ MYSTMD_HELP_URL="https://jupyterbook.org" MYSTMD_BINARY_NAME="jupyter book" MYSTMD_READABLE_NAME="Jupyter Book (myst)" npx myst init


Welcome to the Jupyter Book (myst) CLI! 🎉 🚀

jupyter book init walks you through creating a myst.yml file.

You can use Jupyter Book (myst) to:

 - create interactive websites from markdown and Jupyter Notebooks 📈
 - build & export professional PDFs and Word documents 📄

Learn more about this CLI and MyST Markdown at: https://jupyterbook.org


✅ .gitignore exists and already ignores Jupyter Book (myst) outputs
✅ Project already initialized with config file: myst.yml
✅ Site already initialized with config file: myst.yml

? Would you like to run jupyter book start now? (Y/n)
```

This PR also adds a whitelabelling indicator to `--help`:
```shell
❯ MYSTMD_HELP_URL="https://jupyterbook.org" MYSTMD_BINARY_NAME="jupyter book" MYSTMD_READABLE_NAME="Jupyter Book (myst)" npx myst --help
Usage: myst [options] [command]

Jupyter Book (myst) is powered by MyST-MD. See
https://mystmd.org for more information.

Options:
  -v, --version               Print the current version of Jupyter Book (myst)
  -d, --debug                 Log out any errors to the console
  -h, --help                  display help for command

Commands:
  init [options]              Initialize a Jupyter Book (myst) project in the current directory
  build [options] [files...]  Build PDF, LaTeX, Word and website exports from MyST files
  start [options]             Start the current project as a website
  clean [options] [files...]  Remove exports, temp files and installed templates
  templates                   List and download templates
```

Closes https://github.com/executablebooks/mystmd/issues/1365