### PR TITLE
🚨 Do not warn on uppercase image extensions

### DIFF
--- a/.changeset/late-ladybugs-raise.md
+++ b/.changeset/late-ladybugs-raise.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Do not warn on uppercase image extensions

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -408,7 +408,7 @@ export async function transformImageFormats(
   // Build a lookup of {[extension]: [list of images]} for extensions not in validExts
   const invalidImages: Record<string, GenericNode[]> = {};
   images.forEach((image) => {
-    const ext = path.extname(image.url);
+    const ext = path.extname(image.url).toLowerCase();
     if (validExts.includes(ext as ImageExtensions)) return;
     if (invalidImages[ext]) {
       invalidImages[ext].push(image);
@@ -653,7 +653,7 @@ function isValidImageNode(node: GenericNode, validExts: ImageExtensions[]) {
   return (
     node.type === 'image' &&
     node.url &&
-    validExts.includes(path.extname(node.url) as ImageExtensions)
+    validExts.includes(path.extname(node.url).toLowerCase() as ImageExtensions)
   );
 }
 


### PR DESCRIPTION
This should not error; uppercase image extensions are fine:

![image](https://github.com/user-attachments/assets/f81afa83-7bf6-41f1-ad5f-e198d98e910a)
