### PR TITLE
✍️ Keep all contributors/affiliations until final page resolution

### DIFF
--- a/.changeset/eight-gifts-live.md
+++ b/.changeset/eight-gifts-live.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Keep all contributors/affiliations until final page resolution

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
@@ -124,12 +124,12 @@ export function fillSiteFrontmatter(
       affiliationIds.add(aff);
     });
   });
-  base.affiliations?.forEach((aff) => {
+  frontmatter.affiliations?.forEach((aff) => {
     if (aff.id) affiliationIds.add(aff.id);
   });
 
   if (!trimUnused) {
-    filler.affiliations?.forEach((aff) => {
+    [...(base.affiliations ?? []), ...(filler.affiliations ?? [])].forEach((aff) => {
       if (aff.id) affiliationIds.add(aff.id);
     });
   }

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
@@ -21,7 +21,13 @@ export function fillPageFrontmatter(
   projectFrontmatter: ProjectFrontmatter,
   opts: ValidationOptions,
 ): PageFrontmatter {
-  return fillProjectFrontmatter(pageFrontmatter, projectFrontmatter, opts, USE_PROJECT_FALLBACK);
+  return fillProjectFrontmatter(
+    pageFrontmatter,
+    projectFrontmatter,
+    opts,
+    USE_PROJECT_FALLBACK,
+    true,
+  );
 }
 
 export function fillSiteFrontmatter(
@@ -29,6 +35,7 @@ export function fillSiteFrontmatter(
   filler: SiteFrontmatter,
   opts: ValidationOptions,
   keys?: string[],
+  trimUnused?: boolean,
 ) {
   const frontmatter = fillMissingKeys(base, filler, keys ?? Object.keys(filler));
 
@@ -64,6 +71,17 @@ export function fillSiteFrontmatter(
   frontmatter.editors?.forEach((editor) => {
     contributorIds.add(editor);
   });
+
+  if (!trimUnused) {
+    [
+      ...(base.authors ?? []),
+      ...(filler.authors ?? []),
+      ...(base.contributors ?? []),
+      ...(filler.contributors ?? []),
+    ].forEach((auth) => {
+      if (auth.id) contributorIds.add(auth.id);
+    });
+  }
 
   if (frontmatter.authors?.length || contributorIds.size) {
     // Gather all people from page/project authors/contributors
@@ -106,9 +124,15 @@ export function fillSiteFrontmatter(
       affiliationIds.add(aff);
     });
   });
-  frontmatter.affiliations?.forEach((aff) => {
+  base.affiliations?.forEach((aff) => {
     if (aff.id) affiliationIds.add(aff.id);
   });
+
+  if (!trimUnused) {
+    filler.affiliations?.forEach((aff) => {
+      if (aff.id) affiliationIds.add(aff.id);
+    });
+  }
 
   if (affiliationIds.size) {
     const affiliations = [...(base.affiliations ?? []), ...(filler.affiliations ?? [])];
@@ -137,12 +161,14 @@ export function fillProjectFrontmatter(
   filler: ProjectFrontmatter,
   opts: ValidationOptions,
   keys?: string[],
+  trimUnused?: boolean,
 ) {
   const frontmatter: ProjectFrontmatter = fillSiteFrontmatter(
     base,
     filler,
     opts,
     keys ?? Object.keys(filler),
+    trimUnused,
   );
 
   if (filler.numbering || base.numbering) {


### PR DESCRIPTION
This addresses https://github.com/jupyter-book/mystmd/issues/1362

Previously, when extending from multiple config files, the contributors and affiliations are lost if they are not used on any of the intermediate steps.

With this PR, all contributors and affiliations are persisted right until the final page resolution, when unused affiliations/contributors are removed.