### PR TITLE
🐈 Concatenate list fields when extending project frontmatter

### DIFF
--- a/.changeset/tough-crabs-watch.md
+++ b/.changeset/tough-crabs-watch.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Extend (and deduplicate) lists when extending project frontmatter

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -73,6 +73,17 @@ Each entry listed under `extends` may be a relative path to a file or a URL. URL
 
 Composing files together this way allows you to have a single source of truth for project frontmatter that may be reused across multiple projects, for example math macros or funding information.
 
+When using `extends` to compose configuration files, list-type fields are combined, rather than replaced. This means, for example, you may define a single export in one file:
+
+```yaml
+version: 1
+project:
+  export:
+    format: meca
+```
+
+Then, any `myst.yml` file that extends this file will have a `meca` export in addition to any other exports it defines. This behavior applies to the list fields: `tags`, `keywords`, `exports`, `downloads`, `funding`, `resources`, `requirements`, `bibliography`, `editors`, and `reviewers`. The fields `exports` and `downloads` are deduplicated by `id`, so if you wish to override a value from an inherited configuration you may assign it the same `id`. Other fields cannot be overridden; instead, shared configurations should be as granular and shareable as possible.
+
 +++
 
 ## Available frontmatter fields

--- a/packages/myst-frontmatter/src/downloads/downloads.yml
+++ b/packages/myst-frontmatter/src/downloads/downloads.yml
@@ -72,3 +72,27 @@ cases:
           title: My File
           static: true
           filename: file.md
+  - title: duplicate id errors
+    raw:
+      downloads:
+        - url: my-file.pdf
+        - id: my-file
+        - id: my-file
+    normalized:
+      downloads:
+        - url: my-file.pdf
+        - id: my-file
+        - id: my-file
+    errors: 1
+  - title: duplicate url errors
+    raw:
+      downloads:
+        - url: my-file.pdf
+        - url: my-file.pdf
+        - id: my-file
+    normalized:
+      downloads:
+        - url: my-file.pdf
+        - url: my-file.pdf
+        - id: my-file
+    errors: 1

--- a/packages/myst-frontmatter/src/exports/exports.yml
+++ b/packages/myst-frontmatter/src/exports/exports.yml
@@ -486,3 +486,17 @@ cases:
       exports:
         - format: pdf
           id: my-pdf
+  - title: duplicate id errors
+    raw:
+      exports:
+        - format: pdf
+          id: my-pdf
+        - format: typst
+          id: my-pdf
+    normalized:
+      exports:
+        - format: pdf
+          id: my-pdf
+        - format: typst
+          id: my-pdf
+    errors: 1

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
@@ -228,28 +228,28 @@ export function fillProjectFrontmatter(
       ];
     }
     if (filler.exports || base.exports) {
-      const allExports = [...(base.exports ?? [])];
+      frontmatter.exports = [];
       const ids = base.exports?.map(({ id }) => id) ?? [];
       filler.exports?.forEach((exp) => {
         if (!exp.id || !ids.includes(exp.id)) {
-          allExports.push(exp);
+          frontmatter.exports?.push(exp);
         }
       });
-      frontmatter.exports = allExports;
+      frontmatter.exports?.push(...(base.exports ?? []));
     }
     if (filler.downloads || base.downloads) {
-      const allDownloads = [...(base.downloads ?? [])];
+      frontmatter.downloads = [];
       const ids = base.downloads?.map(({ id }) => id).filter(Boolean) ?? [];
       const urls = base.downloads?.map(({ url }) => url).filter(Boolean) ?? [];
       filler.downloads?.forEach((download) => {
         if (download.id && !ids.includes(download.id)) {
-          allDownloads.push(download);
+          frontmatter.downloads?.push(download);
         }
         if (download.url && !urls.includes(download.url)) {
-          allDownloads.push(download);
+          frontmatter.downloads?.push(download);
         }
       });
-      frontmatter.downloads = allDownloads;
+      frontmatter.downloads?.push(...(base.downloads ?? []));
     }
   }
 

--- a/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
+++ b/packages/myst-frontmatter/src/utils/fillPageFrontmatter.ts
@@ -81,6 +81,27 @@ export function fillSiteFrontmatter(
     ].forEach((auth) => {
       if (auth.id) contributorIds.add(auth.id);
     });
+    [...(base.affiliations ?? []), ...(filler.affiliations ?? [])].forEach((aff) => {
+      if (aff.id) affiliationIds.add(aff.id);
+    });
+    if (filler.tags || base.tags) {
+      frontmatter.tags = [...new Set([...(filler.tags ?? []), ...(base.tags ?? [])])];
+    }
+    if (filler.reviewers || base.reviewers) {
+      frontmatter.reviewers = [
+        ...new Set([...(filler.reviewers ?? []), ...(base.reviewers ?? [])]),
+      ];
+    }
+    if (filler.editors || base.editors) {
+      frontmatter.editors = [...new Set([...(filler.editors ?? []), ...(base.editors ?? [])])];
+    }
+    if (filler.keywords || base.keywords) {
+      frontmatter.keywords = [...new Set([...(filler.keywords ?? []), ...(base.keywords ?? [])])];
+    }
+    if (filler.funding || base.funding) {
+      // This does nothing to deduplicate repeated awards
+      frontmatter.funding = [...(filler.funding ?? []), ...(base.funding ?? [])];
+    }
   }
 
   if (frontmatter.authors?.length || contributorIds.size) {
@@ -127,12 +148,6 @@ export function fillSiteFrontmatter(
   frontmatter.affiliations?.forEach((aff) => {
     if (aff.id) affiliationIds.add(aff.id);
   });
-
-  if (!trimUnused) {
-    [...(base.affiliations ?? []), ...(filler.affiliations ?? [])].forEach((aff) => {
-      if (aff.id) affiliationIds.add(aff.id);
-    });
-  }
 
   if (affiliationIds.size) {
     const affiliations = [...(base.affiliations ?? []), ...(filler.affiliations ?? [])];
@@ -194,6 +209,48 @@ export function fillProjectFrontmatter(
       ...(filler.settings ?? {}),
       ...(base.settings ?? {}),
     };
+  }
+
+  if (!trimUnused) {
+    if (filler.bibliography || base.bibliography) {
+      frontmatter.bibliography = [
+        ...new Set([...(filler.bibliography ?? []), ...(base.bibliography ?? [])]),
+      ];
+    }
+    if (filler.requirements || base.requirements) {
+      frontmatter.requirements = [
+        ...new Set([...(filler.requirements ?? []), ...(base.requirements ?? [])]),
+      ];
+    }
+    if (filler.resources || base.resources) {
+      frontmatter.resources = [
+        ...new Set([...(filler.resources ?? []), ...(base.resources ?? [])]),
+      ];
+    }
+    if (filler.exports || base.exports) {
+      const allExports = [...(base.exports ?? [])];
+      const ids = base.exports?.map(({ id }) => id) ?? [];
+      filler.exports?.forEach((exp) => {
+        if (!exp.id || !ids.includes(exp.id)) {
+          allExports.push(exp);
+        }
+      });
+      frontmatter.exports = allExports;
+    }
+    if (filler.downloads || base.downloads) {
+      const allDownloads = [...(base.downloads ?? [])];
+      const ids = base.downloads?.map(({ id }) => id).filter(Boolean) ?? [];
+      const urls = base.downloads?.map(({ url }) => url).filter(Boolean) ?? [];
+      filler.downloads?.forEach((download) => {
+        if (download.id && !ids.includes(download.id)) {
+          allDownloads.push(download);
+        }
+        if (download.url && !urls.includes(download.url)) {
+          allDownloads.push(download);
+        }
+      });
+      frontmatter.downloads = allDownloads;
+    }
   }
 
   return frontmatter;


### PR DESCRIPTION
# Background

We added the ability to compose yaml files when constructing your `myst.yml` file: https://github.com/jupyter-book/mystmd/pull/1215. This allows shared config, reducing duplication (and errors) across articles and just making authors' lives easier.

However, the original behavior was for fields to replace previous values. So if you define `keywords` in your `myst.yml`, any `keywords` defined in configuration files that the `myst.yml` `extends` are lost. Since then, we realized this meant `options` were not composed, so an option in your `myst.yml` could replace an inherited, totally unrelated option. This was fixed here: https://github.com/jupyter-book/mystmd/pull/1309. There were also some cases where contributors could be lost, addressed here: https://github.com/jupyter-book/mystmd/pull/1390.

These led to a further issue where we discussed allowing users to prescribe inheritance pattern for specific fields: https://github.com/jupyter-book/mystmd/issues/1312.

# PR Description

Recently, another issue came up (whoops, there's not actually an `issue` 😬): Inheriting one `export` from a shared config while also defining another `export` in your `myst.yml`. The new export would just clobber the shared export. This PR addresses this by _extending_ list fields when composing project configurations, rather than _replacing_.

Affected fields include:
- tags
- reviewers
- editors
- keywords
- bibliography
- requirements
- resources
- funding
- exports
- downloads

`exports` and `downloads` are deduplicated by `id` so you may replace an entry from an inherited config by redefining an entry with the same id. All the other fields just combine inherited and new values.

**Note:** When `page` frontmatter inherits `project` frontmatter, the old behavior remains; lists are not extended.

# Discussion

Overall, I think this behavior makes more sense and improves on the current behavior. For example:
- a shared config may define a few `keywords`. Then, if you have additional `keywords`, you do not need to rewrite the entire list
- a shared config may come bundled with `bibliography`/`requirements`/`resources` files. If you are providing additional files in these categories, you do not need to re-list the others.
- etc!

This also encourages authors to ensure shared config files actually contain content that "should" be shared (and on the flip side, discourages authors from inheriting just some other random `myst.yml` and accidentally pulling in unwanted data).

However, there is still an argument that this behavior is too prescriptive, e.g. if I inherit a config with any `keywords`, I _cannot_ get rid of those keywords. In that specific case, we are saying, "No, if you don't want those keywords, do not inherit that config!" The other option is giving the author control over inheritance; this is the same discussion we are already having in #1312.