### PR TITLE
🐛 Pin node 22.4 in actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['18', '20', '22']
+        node: ['18', '20', '22.4.x']
     name: Testing on node ${{ matrix.node }}
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Addresses the recent node bug described here: https://github.com/npm/cli/issues/7657