### PR TITLE
💇‍♀️ Allow parts in project frontmatter

### DIFF
--- a/.changeset/silly-rivers-obey.md
+++ b/.changeset/silly-rivers-obey.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Allow parts in project frontmatter

--- a/docs/document-parts.md
+++ b/docs/document-parts.md
@@ -1,9 +1,9 @@
 ---
 title: Document Parts
-description: Parts allow you to specify special parts of your document, like abstract, keypoints acknowledgements.
+description: Parts allow you to specify special parts of your document, like abstract, key points, and acknowledgements.
 ---
 
-Document parts allow you to add metadata to your documents with specific components of your page, for example, abstract, dedication, or acknowledgments. Many templates put these in specific places.
+Document parts allow you to add metadata to your documents with specific components of your page or project, for example, abstract, dedication, or acknowledgments. Many templates put these in specific places.
 
 There are three ways that you can define parts of a document: (1) in your page frontmatter; (2) implicitly using a section heading; and (3) on a block using a `part` or `tag` annotation. These are all based on a part name, which is case insensitive.
 
@@ -60,8 +60,7 @@ If you have a custom part name for a template, you can nest it under `parts:`, w
 title: My document
 parts:
   special_part: |
-    This is a multi-line
-    abstract, with _markdown_!
+    This is another _special_ part!
 ---
 ```
 
@@ -94,4 +93,27 @@ When using a Jupyter Notebook, you can add a `tag` to the cell with the part nam
 This is my abstract block.
 
 +++
+```
+
+(parts:project)=
+
+## Parts in `myst.yml` Project configuration
+
+You may also specify `parts` in the project configuration of your `myst.yml` file. These are defined exactly the same as [`parts` defined in page frontmatter](#parts:frontmatter).
+
+```yaml
+version: 1
+project:
+  abstract:  |
+    This is a multi-line
+    abstract, with _markdown_!
+  parts:
+    special_part: |
+      This is another _special_ part!
+```
+
+Project-level `parts` are useful, for example, if you have an abstract, acknowledgments, or other part that applies to your entire project and doesn't make sense attached to an individual page.
+
+```{caution}
+Project-level `parts` are a new feature and may not yet be respected by your chosen MyST template or export format. If the project `part` is not behaving as you expect, try moving it to page frontmatter for now.
 ```

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -127,6 +127,9 @@ The following table lists the available frontmatter fields, a brief description 
 * - `banner`
   - a link to a local or remote image
   - page & project
+* - `parts`
+  - a dictionary of arbitrary content parts, not part of the main article, for example `abstract`, `data_availability` see [](./document-parts.md).
+  - page & project
 * - `date`
   - a valid date formatted string
   - page can override project
@@ -187,9 +190,6 @@ The following table lists the available frontmatter fields, a brief description 
 * - `numbering`
   - object for customizing content numbering (see [](#numbering))
   - page can override project
-* - `parts`
-  - a dictionary of arbitrary content parts, not part of the main article, for example `abstract`, `data_availability` see [](./document-parts.md).
-  - page only
 * - `options`
   - a dictionary of arbitrary options validated and consumed by templates, for example, during site or PDF build
   - page can override project

--- a/packages/myst-frontmatter/src/page/types.ts
+++ b/packages/myst-frontmatter/src/page/types.ts
@@ -3,16 +3,6 @@ import type { KernelSpec } from '../kernelspec/types.js';
 import type { ProjectAndPageFrontmatter } from '../project/types.js';
 import { PROJECT_AND_PAGE_FRONTMATTER_KEYS } from '../project/types.js';
 
-export const PAGE_KNOWN_PARTS = [
-  'abstract',
-  'summary',
-  'keypoints',
-  'dedication',
-  'epigraph',
-  'data_availability',
-  'acknowledgments',
-];
-
 export const PAGE_FRONTMATTER_KEYS = [
   ...PROJECT_AND_PAGE_FRONTMATTER_KEYS,
   // These keys only exist on the page
@@ -20,9 +10,7 @@ export const PAGE_FRONTMATTER_KEYS = [
   'kernelspec',
   'jupytext',
   'tags',
-  'parts',
   'content_includes_title',
-  ...PAGE_KNOWN_PARTS,
 ];
 
 export type PageFrontmatter = ProjectAndPageFrontmatter & {
@@ -30,7 +18,6 @@ export type PageFrontmatter = ProjectAndPageFrontmatter & {
   kernelspec?: KernelSpec;
   jupytext?: Jupytext;
   tags?: string[];
-  parts?: Record<string, string[]>;
   /** Flag if frontmatter title is duplicated in content
    *
    * Set during initial file/frontmatter load

--- a/packages/myst-frontmatter/src/project/project.yml
+++ b/packages/myst-frontmatter/src/project/project.yml
@@ -181,3 +181,19 @@ cases:
       copyright: {}
     normalized: {}
     errors: 1
+  - title: parts are validated
+    raw:
+      abstract: |-
+        Just an example part!
+      data_availability: Example
+      parts:
+        example_part: |-
+          Another example part!
+    normalized:
+      parts:
+        abstract:
+          - Just an example part!
+        data_availability:
+          - Example
+        example_part:
+          - Another example part!

--- a/packages/myst-frontmatter/src/project/types.ts
+++ b/packages/myst-frontmatter/src/project/types.ts
@@ -10,6 +10,16 @@ import type { SiteFrontmatter } from '../site/types.js';
 import { SITE_FRONTMATTER_KEYS } from '../site/types.js';
 import type { ExpandedThebeFrontmatter } from '../thebe/types.js';
 
+export const PAGE_KNOWN_PARTS = [
+  'abstract',
+  'summary',
+  'keypoints',
+  'dedication',
+  'epigraph',
+  'data_availability',
+  'acknowledgments',
+];
+
 export const PROJECT_AND_PAGE_FRONTMATTER_KEYS = [
   'date',
   'doi',
@@ -28,6 +38,8 @@ export const PROJECT_AND_PAGE_FRONTMATTER_KEYS = [
   'exports',
   'downloads',
   'settings', // We maybe want to move this into site frontmatter in the future
+  'parts',
+  ...PAGE_KNOWN_PARTS,
   // Do not add any project specific keys here!
   ...SITE_FRONTMATTER_KEYS,
 ];
@@ -64,6 +76,7 @@ export type ProjectAndPageFrontmatter = SiteFrontmatter & {
   exports?: Export[];
   downloads?: Download[];
   settings?: ProjectSettings;
+  parts?: Record<string, string[]>;
 };
 
 export type ProjectFrontmatter = ProjectAndPageFrontmatter & {

--- a/packages/myst-frontmatter/src/project/validators.ts
+++ b/packages/myst-frontmatter/src/project/validators.ts
@@ -10,6 +10,7 @@ import {
   validateObjectKeys,
   validateString,
   validateUrl,
+  validationError,
 } from 'simple-validators';
 import { validateTOC } from 'myst-toc';
 import { validateBiblio } from '../biblio/validators.js';
@@ -21,7 +22,7 @@ import { validateExternalReferences } from '../references/validators.js';
 import { validateSiteFrontmatterKeys } from '../site/validators.js';
 import { validateThebe } from '../thebe/validators.js';
 import { validateDoi } from '../utils/validators.js';
-import { PROJECT_FRONTMATTER_KEYS } from './types.js';
+import { PAGE_KNOWN_PARTS, PROJECT_FRONTMATTER_KEYS } from './types.js';
 import type { ProjectAndPageFrontmatter, ProjectFrontmatter } from './types.js';
 import { validateProjectAndPageSettings } from '../settings/validators.js';
 import { FRONTMATTER_ALIASES } from '../site/types.js';
@@ -131,6 +132,40 @@ export function validateProjectAndPageFrontmatterKeys(
       incrementOptions('settings', opts),
     );
     if (settings) output.settings = settings;
+  }
+  const partsOptions = incrementOptions('parts', opts);
+  let parts: Record<string, any> | undefined;
+  if (defined(value.parts)) {
+    parts = validateObjectKeys(
+      value.parts,
+      { optional: PAGE_KNOWN_PARTS, alias: FRONTMATTER_ALIASES },
+      { keepExtraKeys: true, suppressWarnings: true, ...partsOptions },
+    );
+  }
+  PAGE_KNOWN_PARTS.forEach((partKey) => {
+    if (defined(value[partKey])) {
+      parts ??= {};
+      if (parts[partKey]) {
+        validationError(`duplicate value for part ${partKey}`, partsOptions);
+      } else {
+        parts[partKey] = value[partKey];
+      }
+    }
+  });
+  if (parts) {
+    const partsEntries = Object.entries(parts)
+      .map(([k, v]) => {
+        return [
+          k,
+          validateList(v, { coerce: true, ...incrementOptions(k, partsOptions) }, (item, index) => {
+            return validateString(item, incrementOptions(`${k}.${index}`, partsOptions));
+          }),
+        ];
+      })
+      .filter((entry): entry is [string, string[]] => !!entry[1]?.length);
+    if (partsEntries.length > 0) {
+      output.parts = Object.fromEntries(partsEntries);
+    }
   }
   return output;
 }


### PR DESCRIPTION
MyST projects allow authors to define `parts` on each page, for example `abstract`, `acknowledgments`, etc. However, in many cases, these parts apply to the entire project, not a single page. For example, if my project is a scientific article with a myst page for each section, it doesn't really make any sense for the abstract to be defined on only one random page. See https://github.com/jupyter-book/mystmd/issues/1246

This PR lifts all the types / validation of `parts` from `page` frontmatter to `project` frontmatter, allowing authors to define parts directly in their `myst.yml`

Since this logic is inherited from project to page, the `page` behavior is unchanged. Also, the values are _not_ inherited from project to page, so if you define `parts.abstract` in your project, it will not be defined on each page.

This PR does not yet consume these new project parts, it just opens the door to define them. There will be significant future work determining how to use these parts; for example, in a pdf export, how do we reconcile multiple `abstracts` defined at different levels...?
