### PR TITLE
📂 Drop folders in `pattern` expansion

### DIFF
--- a/.changeset/fuzzy-games-call.md
+++ b/.changeset/fuzzy-games-call.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Change pattern expansion to a flat list of files

--- a/packages/myst-cli/src/project/fromPath.ts
+++ b/packages/myst-cli/src/project/fromPath.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_INDEX_FILENAMES,
   getIgnoreFiles,
   pagesFromSphinxTOC,
-  sortByNumber,
+  comparePaths,
 } from './fromTOC.js';
 import type {
   PageLevels,
@@ -43,7 +43,8 @@ function projectPagesFromPath(
     .filter((file) => !shouldIgnoreFile(session, file))
     .map((file) => join(path, file))
     .filter((file) => !ignore || !ignore.includes(file))
-    .sort(sortByNumber);
+    .sort(comparePaths);
+
   if (session.configFiles.filter((file) => contents.includes(join(path, file))).length) {
     session.log.debug(`🔍 Found config file, ignoring subdirectory: ${path}`);
     return [];
@@ -77,7 +78,7 @@ function projectPagesFromPath(
     });
   const folders = contents
     .filter((file) => isDirectory(file))
-    .sort(sortByNumber)
+    .sort(comparePaths)
     .map((dir) => {
       const projectFolder: LocalProjectFolder = { title: fileInfo(dir, pageSlugs).title, level };
       const pages = projectPagesFromPath(session, dir, nextLevel(level), pageSlugs, opts);

--- a/packages/myst-cli/src/project/toc.spec.ts
+++ b/packages/myst-cli/src/project/toc.spec.ts
@@ -861,11 +861,11 @@ describe('pagesFromSphinxTOC', () => {
       pages: [
         { slug: 'x', file: 'x.md', level: 1 },
         { title: 'Project', level: 1 },
+        { slug: 'index', file: 'project/index.md', level: 2 },
         { slug: 'a', file: 'project/a.md', level: 2 },
         { slug: 'b', file: 'project/b.md', level: 2 },
         { slug: 'c', file: 'project/c.md', level: 2 },
         { slug: 'd', file: 'project/d.md', level: 2 },
-        { slug: 'index', file: 'project/index.md', level: 2 },
         { title: 'Section', level: 1 },
         { slug: 'y', file: 'section/y.md', level: 2 },
         { slug: 'z', file: 'section/z.md', level: 2 },

--- a/packages/myst-toc/src/toc.ts
+++ b/packages/myst-toc/src/toc.ts
@@ -129,7 +129,7 @@ export function validatePatternEntry(
     entry,
     {
       required: ['pattern'],
-      optional: [...COMMON_ENTRY_KEYS, 'children'],
+      optional: [...COMMON_ENTRY_KEYS],
     },
     opts,
   );


### PR DESCRIPTION
This PR addresses #1323 by:

1. Simplifying patterns to only generate `file` entries
2. Drop support for `pattern` entries with `children` -- in the schema, `pattern` entries can only be leaves.