### PR TITLE
feat: allow user options to apply to mystParser

### DIFF
--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -116,7 +116,7 @@ export function mystParse(content: string, opts?: Options) {
  */
 export const mystParser: Plugin<[Options?], string, GenericParent> =
   function mystParser(opts?: Options) {
-    this.Parser = (content: string, _file: VFile) => {
+    this.Parser = (content: string) => {
       return mystParse(content, opts);
     };
   };

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -117,7 +117,7 @@ export function mystParse(content: string, opts?: Options) {
 export const mystParser: Plugin<[Options?], string, GenericParent> = function mystParser(
   opts?: Options,
 ) {
-    this.Parser = (content: string) => {
-      return mystParse(content, opts);
-    };
+  this.Parser = (content: string) => {
+    return mystParse(content, opts);
   };
+};

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -114,8 +114,9 @@ export function mystParse(content: string, opts?: Options) {
 /**
  * MyST Parser as a Unified Plugin
  */
-export const mystParser: Plugin<[Options?], string, GenericParent> =
-  function mystParser(opts?: Options) {
+export const mystParser: Plugin<[Options?], string, GenericParent> = function mystParser(
+  opts?: Options,
+) {
     this.Parser = (content: string) => {
       return mystParse(content, opts);
     };

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -114,8 +114,8 @@ export function mystParse(content: string, opts?: Options) {
 /**
  * MyST Parser as a Unified Plugin
  */
-export const mystParser: Plugin<[Options?], string, GenericParent> = function mystParser() {
-  this.Parser = (content: string, opts?: Options) => {
+export const mystParser: Plugin<[Options?], string, GenericParent> = function mystParser(opts?: Options) {
+  this.Parser = (content: string, _file: VFile) => {
     return mystParse(content, opts);
   };
 };

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -114,8 +114,9 @@ export function mystParse(content: string, opts?: Options) {
 /**
  * MyST Parser as a Unified Plugin
  */
-export const mystParser: Plugin<[Options?], string, GenericParent> = function mystParser(opts?: Options) {
-  this.Parser = (content: string, _file: VFile) => {
-    return mystParse(content, opts);
+export const mystParser: Plugin<[Options?], string, GenericParent> =
+  function mystParser(opts?: Options) {
+    this.Parser = (content: string, _file: VFile) => {
+      return mystParse(content, opts);
+    };
   };
-};


### PR DESCRIPTION
when using myst-parser as a unified plugin, any options supplied by the user were not actually being used. This fixes that problem