### PR TITLE
#️⃣ Fix HTML tags in inline contexts

### DIFF
--- a/.changeset/modern-wombats-boil.md
+++ b/.changeset/modern-wombats-boil.md
@@ -1,5 +1,5 @@
 ---
-"myst-transforms": patch
+'myst-transforms': patch
 ---
 
 Fix conversion of hast fragments to mdast fragments

--- a/.changeset/modern-wombats-boil.md
+++ b/.changeset/modern-wombats-boil.md
@@ -1,0 +1,5 @@
+---
+"myst-transforms": patch
+---
+
+Fix conversion of hast fragments to mdast fragments

--- a/packages/myst-transforms/src/html.spec.ts
+++ b/packages/myst-transforms/src/html.spec.ts
@@ -427,7 +427,7 @@ describe('Test reconstructHtmlTransform', () => {
     htmlTransform(mdast);
     expect(mdast).toEqual({
       type: 'root',
-      children: [{ type: 'paragraph', children: [{ type: 'image', url: 'test.mp4' }] }],
+      children: [{ type: 'image', url: 'test.mp4' }],
     });
   });
   test('more open tags than close tags', async () => {

--- a/packages/myst-transforms/src/html.ts
+++ b/packages/myst-transforms/src/html.ts
@@ -176,7 +176,7 @@ export function htmlTransform(tree: GenericParent, opts?: HtmlTransformOptions) 
         n.tagName = '_brKeep';
       });
     }
-    const mdast = unified().use(rehypeRemark, { handlers }).runSync(hast);
+    const mdast = unified().use(rehypeRemark, { handlers, document: false }).runSync(hast);
     node.type = 'htmlParsed';
     node.children = mdast.children as Parent[];
     visit(node, (n: any) => delete n.position);

--- a/packages/myst-transforms/src/html.ts
+++ b/packages/myst-transforms/src/html.ts
@@ -141,6 +141,9 @@ const defaultHtmlToMdastOptions: Record<keyof HtmlTransformOptions, any> = {
     sub(h: H, node: any) {
       return h(node, 'subscript', all(h, node));
     },
+    kbd(h: H, node: any) {
+      return h(node, 'keyboard', all(h, node));
+    },
     cite(h: H, node: any) {
       const attrs = addClassAndIdentifier(node);
       return attrs.label ? h(node, 'cite', attrs, all(h, node)) : all(h, node);

--- a/packages/myst-transforms/tests/html.yml
+++ b/packages/myst-transforms/tests/html.yml
@@ -150,3 +150,16 @@ cases:
               children:
                 - type: inlineCode
                   value: foo
+  - title: kbd tag
+    before:
+      type: root
+      children:
+        - type: html
+          value: <kbd>Shift</kbd>
+    after:
+      type: root
+      children:
+        - type: keyboard
+          children:
+            - type: text
+              value: Shift

--- a/packages/myst-transforms/tests/html.yml
+++ b/packages/myst-transforms/tests/html.yml
@@ -42,11 +42,9 @@ cases:
     after:
       type: root
       children:
-        - type: paragraph
-          children:
-            - type: image
-              url: example.jpg
-              title: example
+        - type: image
+          url: example.jpg
+          title: example
   - title: table
     before:
       type: root
@@ -132,3 +130,23 @@ cases:
     after:
       type: root
       children: []
+
+  - title: inline elements
+    before:
+      type: root
+      children:
+        - type: list
+          children:
+            - type: listItem
+              children:
+                - type: html
+                  value: <code>foo</code>
+    after:
+      type: root
+      children:
+        - type: list
+          children:
+            - type: listItem
+              children:
+                - type: inlineCode
+                  value: foo


### PR DESCRIPTION
Previously we were converting HAST to MDAST as full-documents, which was introducing paragraphs. 

`hast-util-from-util` always creates a `root` node, and `hast-util-to-mdast` introduces paragraphs for phrasing content inside a `root` node.

HTML nodes are `StaticPhrasingContent`, so we should already be e.g. inside a paragraph if we need one and thus can remove this wrapping? @rowanc1 you have touched this logic most recently.

Fixes #1400