### PR TITLE
🎆 Fall back to 'convert' command for imagemagick

### DIFF
--- a/.changeset/early-colts-rhyme.md
+++ b/.changeset/early-colts-rhyme.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fall back to 'convert' command for imagemagick

--- a/packages/myst-cli/src/utils/imagemagick.ts
+++ b/packages/myst-cli/src/utils/imagemagick.ts
@@ -21,9 +21,9 @@ export function isImageMagickAvailable() {
 
 export function imageMagickCommand() {
   if (!magickCommandAvailable() && convertCommandAvailable()) {
-    return 'convert'
+    return 'convert';
   }
-  return 'magick'
+  return 'magick';
 }
 
 export function isWebpAvailable() {


### PR DESCRIPTION
In #1388 we switched our ImageMagick command from `convert` (used by ImageMagick >= 6) to `magick` (used by ImageMagick 7). However, some linux distributions including, most notably, Ubuntu 22.04 - `ubuntu-latest` on github actions, still use ImageMagick 6.

This PR updates the invocation of ImageMagic commands to still use `convert` if that command is available and `magick` is not (`magick` still remains the preferred default if both are available).