### PR TITLE
:dart: Support `--execute` for building non-sites

### DIFF
--- a/.changeset/real-clouds-jam.md
+++ b/.changeset/real-clouds-jam.md
@@ -1,5 +1,5 @@
 ---
-"myst-cli": patch
+'myst-cli': patch
 ---
 
 Fix execution for non-site builds

--- a/.changeset/real-clouds-jam.md
+++ b/.changeset/real-clouds-jam.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Fix execution for non-site builds

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -85,7 +85,7 @@ export async function runWordExport(
   opts?: ExportFnOptions,
 ): Promise<ExportResults> {
   const { output, articles } = exportOptions;
-  const { clean, projectPath, extraLinkTransformers } = opts ?? {};
+  const { clean, projectPath, extraLinkTransformers, execute } = opts ?? {};
   // At this point, export options are resolved to contain one-and-only-one article
   const article = articles[0];
   if (!article?.file) return { tempFolders: [] };
@@ -100,6 +100,7 @@ export async function runWordExport(
     preFrontmatters: [
       filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
     ],
+    execute,
   });
   const mystTemplate = new MystTemplate(session, {
     kind: TemplateKind.docx,

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -28,7 +28,7 @@ export async function runJatsExport(
 ) {
   const toc = tic();
   const { output, articles, sub_articles } = exportOptions;
-  const { clean, projectPath, extraLinkTransformers } = opts ?? {};
+  const { clean, projectPath, extraLinkTransformers, execute } = opts ?? {};
   // At this point, export options are resolved to contain one-and-only-one article
   const article = articles[0];
   if (!article?.file) return { tempFolders: [] };
@@ -41,6 +41,7 @@ export async function runJatsExport(
       preFrontmatters: [
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
       ], // only apply to article, not sub_articles
+      execute,
     })
   ).map((content) => {
     const { kind, file, mdast, frontmatter, slug } = content;

--- a/packages/myst-cli/src/build/md/index.ts
+++ b/packages/myst-cli/src/build/md/index.ts
@@ -20,7 +20,7 @@ export async function runMdExport(
 ) {
   const toc = tic();
   const { output, articles } = exportOptions;
-  const { clean, projectPath, extraLinkTransformers } = opts ?? {};
+  const { clean, projectPath, extraLinkTransformers, execute } = opts ?? {};
   // At this point, export options are resolved to contain one-and-only-one article
   const article = articles[0];
   if (!article?.file) return { tempFolders: [] };
@@ -32,6 +32,7 @@ export async function runMdExport(
     preFrontmatters: [
       filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
     ],
+    execute,
   });
   await finalizeMdast(session, mdast, frontmatter, article.file, {
     imageWriteFolder: path.join(path.dirname(output), 'files'),

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -128,7 +128,7 @@ export async function localArticleToTexRaw(
   opts?: ExportFnOptions,
 ): Promise<ExportResults> {
   const { articles, output } = templateOptions;
-  const { projectPath, extraLinkTransformers } = opts ?? {};
+  const { projectPath, extraLinkTransformers, execute } = opts ?? {};
   const fileArticles = articlesWithFile(articles);
   const content = await getFileContent(
     session,
@@ -141,6 +141,7 @@ export async function localArticleToTexRaw(
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
       ),
+      execute,
     },
   );
 
@@ -192,7 +193,7 @@ export async function localArticleToTexTemplated(
   opts?: ExportFnOptions,
 ): Promise<ExportResults> {
   const { output, articles, template } = templateOptions;
-  const { projectPath, extraLinkTransformers, clean, ci } = opts ?? {};
+  const { projectPath, extraLinkTransformers, clean, ci, execute } = opts ?? {};
   const filesPath = path.join(path.dirname(output), 'files');
   const fileArticles = articlesWithFile(articles);
   const content = await getFileContent(
@@ -206,6 +207,7 @@ export async function localArticleToTexTemplated(
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
       ),
+      execute,
     },
   );
   const bibtexWritten = writeBibtexFromCitationRenderers(

--- a/packages/myst-cli/src/build/types.ts
+++ b/packages/myst-cli/src/build/types.ts
@@ -38,6 +38,7 @@ export type ExportFnOptions = {
   extraLinkTransformers?: LinkTransformer[];
   extraTransforms?: TransformFn[];
   ci?: boolean;
+  execute?: boolean;
 };
 
 export type ExportResults = {

--- a/packages/myst-cli/src/build/typst.ts
+++ b/packages/myst-cli/src/build/typst.ts
@@ -146,7 +146,7 @@ export async function localArticleToTypstRaw(
   opts?: ExportFnOptions,
 ): Promise<ExportResults> {
   const { articles, output } = templateOptions;
-  const { projectPath, extraLinkTransformers } = opts ?? {};
+  const { projectPath, extraLinkTransformers, execute } = opts ?? {};
   const fileArticles = articlesWithFile(articles);
   const content = await getFileContent(
     session,
@@ -159,6 +159,7 @@ export async function localArticleToTypstRaw(
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
       ),
+      execute,
     },
   );
 
@@ -210,7 +211,7 @@ export async function localArticleToTypstTemplated(
   opts?: ExportFnOptions,
 ): Promise<ExportResults> {
   const { output, articles, template } = templateOptions;
-  const { projectPath, extraLinkTransformers, clean, ci } = opts ?? {};
+  const { projectPath, extraLinkTransformers, clean, ci, execute } = opts ?? {};
   const filesPath = path.join(path.dirname(output), 'files');
   const fileArticles = articlesWithFile(articles);
   const content = await getFileContent(
@@ -224,6 +225,7 @@ export async function localArticleToTypstTemplated(
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
       ),
+      execute,
     },
   );
   const bibtexWritten = writeBibtexFromCitationRenderers(

--- a/packages/myst-cli/src/build/utils/getFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getFileContent.ts
@@ -21,7 +21,7 @@ export async function getFileContent(
     extraTransforms,
     titleDepths,
     preFrontmatters,
-    execute
+    execute,
   }: {
     projectPath?: string;
     imageExtensions: ImageExtensions[];
@@ -70,7 +70,7 @@ export async function getFileContent(
         index: project.index,
         titleDepth,
         extraTransforms,
-	execute
+        execute,
       });
     }),
   );

--- a/packages/myst-cli/src/build/utils/getFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getFileContent.ts
@@ -21,6 +21,7 @@ export async function getFileContent(
     extraTransforms,
     titleDepths,
     preFrontmatters,
+    execute
   }: {
     projectPath?: string;
     imageExtensions: ImageExtensions[];
@@ -28,6 +29,7 @@ export async function getFileContent(
     extraTransforms?: TransformFn[];
     titleDepths?: number | (number | undefined)[];
     preFrontmatters?: Record<string, any> | (Record<string, any> | undefined)[];
+    execute?: boolean;
   },
 ) {
   const toc = tic();
@@ -68,6 +70,7 @@ export async function getFileContent(
         index: project.index,
         titleDepth,
         extraTransforms,
+	execute
       });
     }),
   );

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -251,7 +251,9 @@ export class Session implements ISession {
   }
 
   dispose() {
-    this._clones.forEach((session) => session.dispose());
+    this._clones.forEach((session) => {
+      session.dispose();
+    });
 
     if (this._jupyterSessionManagerPromise) {
       this._jupyterSessionManagerPromise.then((manager) => manager?.dispose?.());

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -251,7 +251,7 @@ export class Session implements ISession {
   }
 
   dispose() {
-    this._clones.forEach(session => session.dispose());
+    this._clones.forEach((session) => session.dispose());
 
     if (this._jupyterSessionManagerPromise) {
       this._jupyterSessionManagerPromise.then((manager) => manager?.dispose?.());

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -251,6 +251,8 @@ export class Session implements ISession {
   }
 
   dispose() {
+    this._clones.forEach(session => session.dispose());
+
     if (this._jupyterSessionManagerPromise) {
       this._jupyterSessionManagerPromise.then((manager) => manager?.dispose?.());
       this._jupyterSessionManagerPromise = undefined;


### PR DESCRIPTION
Fixes #1415 

@fwkoch I'm not clear on what the purpose of `session.clone` is, so I'm not sure whether sharing a Jupyter session between all clones is reasonable. I *think* we want the Jupyter session manager to be a singleton so that we don't end up spinning up multiple local servers, but your input is useful here if I've got the wrong end of the stick.