### PR TITLE
:snake: Don't resolve `node` symlink

### DIFF
--- a/packages/mystmd-py/src/mystmd_py/main.py
+++ b/packages/mystmd-py/src/mystmd_py/main.py
@@ -20,9 +20,11 @@ def main():
         )
     node = pathlib.Path(NODE_LOCATION).absolute()
 
-    _version = subprocess.run([node, "-v"], capture_output=True, check=True, text=True).stdout
+    _version = subprocess.run(
+        [node, "-v"], capture_output=True, check=True, text=True
+    ).stdout
     major_version_match = re.match(r"v(\d+).*", _version)
-    
+
     if major_version_match is None:
         raise SystemExit(f"MyST could not determine the version of Node.js: {_version}")
 
@@ -33,8 +35,12 @@ def main():
             "Please update to the latest LTS release, using your preferred package manager\n"
             "or following instructions here: https://nodejs.org/en/download"
         )
-    os.execve(node, [node.name, PATH_TO_BIN_JS, *sys.argv[1:]], {**os.environ, "MYST_LANG": "PYTHON"})
-  
+    os.execve(
+        node,
+        [node.name, PATH_TO_BIN_JS, *sys.argv[1:]],
+        {**os.environ, "MYST_LANG": "PYTHON"},
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/packages/mystmd-py/src/mystmd_py/main.py
+++ b/packages/mystmd-py/src/mystmd_py/main.py
@@ -18,7 +18,7 @@ def main():
             "We recommend installing the latest LTS release, using your preferred package manager\n"
             "or following instructions here: https://nodejs.org/en/download"
         )
-    node = pathlib.Path(NODE_LOCATION).resolve()
+    node = pathlib.Path(NODE_LOCATION).absolute()
 
     _version = subprocess.run([node, "-v"], capture_output=True, check=True, text=True).stdout
     major_version_match = re.match(r"v(\d+).*", _version)
@@ -29,7 +29,7 @@ def main():
     major_version = int(major_version_match[1])
     if not (major_version in {18, 20, 22} or major_version > 22):
         raise SystemExit(
-            f"MyST requires node 18, 20, or 22+; you are running node {version[1:3]}.\n\n"
+            f"MyST requires node 18, 20, or 22+; you are running node {major_version}.\n\n"
             "Please update to the latest LTS release, using your preferred package manager\n"
             "or following instructions here: https://nodejs.org/en/download"
         )


### PR DESCRIPTION
There's no need for us to resolve this symlink, and some platforms like Snap use a single binary to dispatch aliased applications (i.e. symlink with name `node` points to `/usr/bin/snap`).

This PR changes the `Path.resolve()` to `Path.absolute()`, and fixes a mistake in the node version validation.

Fixes #1419 