### PR TITLE
🐛 Prevent crash on non-list tags for code-cell

### DIFF
--- a/.changeset/clean-pears-pull.md
+++ b/.changeset/clean-pears-pull.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Prevent crash on non-list tags for code-cell

--- a/packages/myst-cli/src/transforms/code.ts
+++ b/packages/myst-cli/src/transforms/code.ts
@@ -175,6 +175,7 @@ export function propagateBlockDataToCode(session: ISession, vfile: VFile, mdast:
         node: block,
         ruleId: RuleId.codeMetatagsValid,
       });
+      return;
     }
     const validMetatags = checkMetaTags(vfile, block, block.data.tags, true);
     const codeNode = select('code[executable=true]', block) as GenericNode | null;


### PR DESCRIPTION
If `code-cell` tags were not a list, MyST would print a nice error, but then crash anyway.

This PR simply adds a `return` if tags are not a list. This allows the build to continue, just ignoring the tags.