### PR TITLE
🐍 Add parser support for additional markup features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13617,6 +13617,36 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-before": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-before/-/unist-util-find-before-4.0.0.tgz",
+      "integrity": "sha512-bdXFv1xM0O19Gn8B7mJjXuVOyVSdE7eQZs4Ulo4EWOBb8OihHLpCDhOLwDGjrpMZCRPlmpUhxMMqlDohvswEsA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-before/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/unist-util-find-before/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-generated": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
@@ -15884,6 +15914,7 @@
         "unified": "^10.0.0",
         "unist-builder": "^3.0.0",
         "unist-util-find-after": "^4.0.0",
+        "unist-util-find-before": "4.0.0",
         "unist-util-map": "^3.0.0",
         "unist-util-modify-children": "^3.1.0",
         "unist-util-remove": "^3.1.0",

--- a/packages/markdown-it-myst/src/index.ts
+++ b/packages/markdown-it-myst/src/index.ts
@@ -2,17 +2,16 @@ import type MarkdownIt from 'markdown-it/lib';
 import { rolePlugin } from './roles.js';
 import { directivePlugin } from './directives.js';
 import { citationsPlugin } from './citations.js';
+import { labelsPlugin } from './labels.js';
 import { shortcodePlugin } from './shortcode.js';
 import { spanPlugin } from './span.js';
 
-export { rolePlugin, directivePlugin, citationsPlugin, shortcodePlugin };
+export { rolePlugin, directivePlugin, citationsPlugin, shortcodePlugin, labelsPlugin };
 
 /**
  * A markdown-it plugin for parsing MyST roles and directives to structured data
  */
 export function mystPlugin(md: MarkdownIt): void {
-  md.use(shortcodePlugin);
-  md.use(spanPlugin);
   md.use(rolePlugin);
   md.use(directivePlugin);
 }

--- a/packages/markdown-it-myst/src/index.ts
+++ b/packages/markdown-it-myst/src/index.ts
@@ -6,7 +6,7 @@ import { labelsPlugin } from './labels.js';
 import { shortcodePlugin } from './shortcode.js';
 import { spanPlugin } from './span.js';
 
-export { rolePlugin, directivePlugin, citationsPlugin, shortcodePlugin, labelsPlugin };
+export { rolePlugin, directivePlugin, citationsPlugin, shortcodePlugin, spanPlugin, labelsPlugin };
 
 /**
  * A markdown-it plugin for parsing MyST roles and directives to structured data

--- a/packages/markdown-it-myst/src/index.ts
+++ b/packages/markdown-it-myst/src/index.ts
@@ -2,13 +2,17 @@ import type MarkdownIt from 'markdown-it/lib';
 import { rolePlugin } from './roles.js';
 import { directivePlugin } from './directives.js';
 import { citationsPlugin } from './citations.js';
+import { shortcodePlugin } from './shortcode.js';
+import { spanPlugin } from './span.js';
 
-export { rolePlugin, directivePlugin, citationsPlugin };
+export { rolePlugin, directivePlugin, citationsPlugin, shortcodePlugin };
 
 /**
  * A markdown-it plugin for parsing MyST roles and directives to structured data
  */
 export function mystPlugin(md: MarkdownIt): void {
+  md.use(shortcodePlugin);
+  md.use(spanPlugin);
   md.use(rolePlugin);
   md.use(directivePlugin);
 }

--- a/packages/markdown-it-myst/src/labels.ts
+++ b/packages/markdown-it-myst/src/labels.ts
@@ -1,0 +1,29 @@
+import MarkdownIt from 'markdown-it/lib';
+import StateInline from 'markdown-it/lib/rules_inline/state_inline.js';
+
+const LABEL_PATTERN = /^\{\#(.+?)\}/im;
+
+const LABEL_TOKEN_NAME = 'myst_target';
+
+function labelRule(state: StateInline, silent: boolean): boolean {
+  // Check if the label is escaped
+  if (state.src.charCodeAt(state.pos - 1) === 0x5c) {
+    /* \ */
+    // TODO: this could be improved in the case of edge case '\\{', also multi-line
+    return false;
+  }
+  const match = LABEL_PATTERN.exec(state.src.slice(state.pos));
+  if (match == null) return false;
+  const [str, content] = match;
+  if (!silent) {
+    const token = state.push(LABEL_TOKEN_NAME, '', 0);
+    token.content = content;
+    (token as any).col = [state.pos, state.pos + str.length];
+  }
+  state.pos += str.length;
+  return true;
+}
+
+export function labelsPlugin(md: MarkdownIt): void {
+  md.inline.ruler.before('backticks', `parse_${LABEL_TOKEN_NAME}`, labelRule);
+}

--- a/packages/markdown-it-myst/src/roles.ts
+++ b/packages/markdown-it-myst/src/roles.ts
@@ -63,13 +63,14 @@ function runRoles(state: StateCore): boolean {
         if (child.type === 'role') {
           try {
             const { map } = token;
-            const { content, col } = child as any;
+            const { content, col, meta } = child as any;
             const roleOpen = new state.Token('parsed_role_open', '', 1);
             roleOpen.content = content;
             roleOpen.hidden = true;
             roleOpen.info = child.meta.name;
             roleOpen.block = false;
             roleOpen.map = map;
+            roleOpen.meta = meta;
             (roleOpen as any).col = col;
             const contentTokens = roleContentToTokens(content, map ? map[0] : 0, state);
             const roleClose = new state.Token('parsed_role_close', '', -1);

--- a/packages/markdown-it-myst/src/shortcode.ts
+++ b/packages/markdown-it-myst/src/shortcode.ts
@@ -1,0 +1,31 @@
+import type MarkdownIt from 'markdown-it/lib';
+import type StateCore from 'markdown-it/lib/rules_core/state_core.js';
+import type StateInline from 'markdown-it/lib/rules_inline/state_inline.js';
+import { nestedPartToTokens } from './nestedParse.js';
+
+export function shortcodePlugin(md: MarkdownIt): void {
+  md.inline.ruler.before('backticks', 'parse_short_codes', shortCodeRule);
+}
+
+// Hugo short code syntax e.g. {{< role value >}}
+const ROLE_PATTERN = /^\{\{\<\s*([a-z0-9_\-+:]{1,36})\s*([^>]*)\s*\>\}\}/;
+
+function shortCodeRule(state: StateInline, silent: boolean): boolean {
+  // Check if the role is escaped
+  if (state.src.charCodeAt(state.pos - 1) === 0x5c) {
+    /* \ */
+    // TODO: this could be improved in the case of edge case '\\{', also multi-line
+    return false;
+  }
+  const match = ROLE_PATTERN.exec(state.src.slice(state.pos));
+  if (match == null) return false;
+  const [str, name, content] = match;
+  if (!silent) {
+    const token = state.push('role', '', 0);
+    token.meta = { name };
+    token.content = content?.trim();
+    (token as any).col = [state.pos, state.pos + str.length];
+  }
+  state.pos += str.length;
+  return true;
+}

--- a/packages/markdown-it-myst/src/span.ts
+++ b/packages/markdown-it-myst/src/span.ts
@@ -1,0 +1,35 @@
+import type MarkdownIt from 'markdown-it/lib';
+import type StateCore from 'markdown-it/lib/rules_core/state_core.js';
+import type StateInline from 'markdown-it/lib/rules_inline/state_inline.js';
+import { nestedPartToTokens } from './nestedParse.js';
+
+export function spanPlugin(md: MarkdownIt): void {
+  md.inline.ruler.before('backticks', 'parse_span', spanRule);
+}
+
+// Inline span syntax e.g. [markdown]{.class}
+const ROLE_PATTERN = /^\[([^\]]*)\]\{([^\}]*)\}/;
+
+function spanRule(state: StateInline, silent: boolean): boolean {
+  // Check if the role is escaped
+  if (state.src.charCodeAt(state.pos - 1) === 0x5c) {
+    /* \ */
+    // TODO: this could be improved in the case of edge case '\\[', also multi-line
+    return false;
+  }
+  const match = ROLE_PATTERN.exec(state.src.slice(state.pos));
+  if (match == null) return false;
+  const [str, content, options] = match;
+  if (!silent) {
+    const token = state.push('role', '', 0);
+    const classes = options
+      .split(' ')
+      .map((c) => c.trim().replace(/^\./, ''))
+      .filter((c) => !!c);
+    token.meta = { name: 'span', options: { class: classes.join(' ') } };
+    token.content = content?.trim();
+    (token as any).col = [state.pos, state.pos + str.length];
+  }
+  state.pos += str.length;
+  return true;
+}

--- a/packages/markdown-it-myst/tests/cases.spec.ts
+++ b/packages/markdown-it-myst/tests/cases.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 import type Token from 'markdown-it/lib/token';
-import { citationsPlugin } from '../src';
+import { citationsPlugin, labelsPlugin } from '../src';
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
@@ -17,7 +17,7 @@ type TestCase = {
 };
 
 const directory = path.join('tests');
-const files = ['citations.yml'];
+const files = ['citations.yml', 'labels.yml'];
 
 const only = ''; // Can set this to a test title
 
@@ -36,7 +36,7 @@ casesList.forEach(({ title, cases }) => {
     test.each(casesToUse.map((c): [string, TestCase] => [c.title, c]))(
       '%s',
       (_, { md, tokens }) => {
-        const mdit = MarkdownIt().use(citationsPlugin);
+        const mdit = MarkdownIt().use(citationsPlugin).use(labelsPlugin);
         const parsed = mdit.parse(md, {});
         expect(parsed).containSubset(tokens);
       },

--- a/packages/markdown-it-myst/tests/labels.yml
+++ b/packages/markdown-it-myst/tests/labels.yml
@@ -1,0 +1,22 @@
+title: Labels
+cases:
+  - title: basic {#label}
+    md: '{#my-label}'
+    tokens:
+      - type: paragraph_open
+      - type: inline
+        children:
+          - type: myst_target
+            content: 'my-label'
+      - type: paragraph_close
+  - title: label stops at first }
+    md: '{#my-label}too}'
+    tokens:
+      - type: paragraph_open
+      - type: inline
+        children:
+          - type: myst_target
+            content: 'my-label'
+          - type: text
+            content: 'too}'
+      - type: paragraph_close

--- a/packages/markdown-it-myst/tests/shortcode.spec.ts
+++ b/packages/markdown-it-myst/tests/shortcode.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import MarkdownIt from 'markdown-it';
+import plugin from '../src';
+
+describe('parses roles', () => {
+  it('basic role parses', () => {
+    const mdit = MarkdownIt().use(plugin);
+    const tokens = mdit.parse('ok {{< var lang >}}', {});
+    expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
+    expect(tokens[1].children?.map((t) => t.type)).toEqual([
+      'text',
+      'parsed_role_open',
+      'role_body_open',
+      'inline',
+      'role_body_close',
+      'parsed_role_close',
+    ]);
+    expect(tokens[1].content).toEqual('ok {{< var lang >}}');
+    // Pass the column information for the role
+    expect((tokens[1].children?.[1] as any).col).toEqual([3, 19]);
+    expect(tokens[1].children?.[1].info).toEqual('var');
+    expect(tokens[1].children?.[1].content).toEqual('lang');
+    expect(tokens[1].children?.[3].content).toEqual('lang');
+  });
+  it('basic role parses', () => {
+    const mdit = MarkdownIt().use(plugin);
+    const content = `Notice that the value for \`some_numbers\` is {{< var np_or_r >}},
+and that this value *contains* 10 numbers.`;
+    const tokens = mdit.parse(content, {});
+    expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
+    expect(tokens[1].children?.map((t) => t.type)).toEqual([
+      'text',
+      'code_inline',
+      'text',
+      'parsed_role_open',
+      'role_body_open',
+      'inline',
+      'role_body_close',
+      'parsed_role_close',
+      'text',
+      'softbreak',
+      'text',
+      'em_open',
+      'text',
+      'em_close',
+      'text',
+    ]);
+    expect(tokens[1].content).toEqual(content);
+    // Pass the column information for the role
+    expect((tokens[1].children?.[3] as any).col).toEqual([44, 63]);
+    expect(tokens[1].children?.[3].info).toEqual('var');
+    expect(tokens[1].children?.[3].content).toEqual('np_or_r');
+    expect(tokens[1].children?.[3].content).toEqual('np_or_r');
+  });
+});

--- a/packages/markdown-it-myst/tests/shortcode.spec.ts
+++ b/packages/markdown-it-myst/tests/shortcode.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import MarkdownIt from 'markdown-it';
-import plugin from '../src';
+import { default as plugin, shortcodePlugin } from '../src';
 
 describe('parses roles', () => {
   it('basic role parses', () => {
-    const mdit = MarkdownIt().use(plugin);
+    const mdit = MarkdownIt().use(shortcodePlugin).use(plugin);
     const tokens = mdit.parse('ok {{< var lang >}}', {});
     expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
     expect(tokens[1].children?.map((t) => t.type)).toEqual([
@@ -23,7 +23,7 @@ describe('parses roles', () => {
     expect(tokens[1].children?.[3].content).toEqual('lang');
   });
   it('basic role parses', () => {
-    const mdit = MarkdownIt().use(plugin);
+    const mdit = MarkdownIt().use(shortcodePlugin).use(plugin);
     const content = `Notice that the value for \`some_numbers\` is {{< var np_or_r >}},
 and that this value *contains* 10 numbers.`;
     const tokens = mdit.parse(content, {});

--- a/packages/markdown-it-myst/tests/span.spec.ts
+++ b/packages/markdown-it-myst/tests/span.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import MarkdownIt from 'markdown-it';
-import plugin from '../src';
+import { default as plugin, spanPlugin } from '../src';
 
 describe('parses spans', () => {
   it('basic span parses', () => {
-    const mdit = MarkdownIt().use(plugin);
+    const mdit = MarkdownIt().use(spanPlugin).use(plugin);
     const tokens = mdit.parse('ok [content]{.python}', {});
     expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
     expect(tokens[1].children?.map((t) => t.type)).toEqual([
@@ -19,6 +19,7 @@ describe('parses spans', () => {
     // Pass the column information for the role
     expect((tokens[1].children?.[1] as any).col).toEqual([3, 21]);
     expect(tokens[1].children?.[1].info).toEqual('span');
+    expect(tokens[1].children?.[1].meta.options.class).toEqual('python');
     expect(tokens[1].children?.[1].content).toEqual('content');
     expect(tokens[1].children?.[3].content).toEqual('content');
   });

--- a/packages/markdown-it-myst/tests/span.spec.ts
+++ b/packages/markdown-it-myst/tests/span.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import MarkdownIt from 'markdown-it';
+import plugin from '../src';
+
+describe('parses spans', () => {
+  it('basic span parses', () => {
+    const mdit = MarkdownIt().use(plugin);
+    const tokens = mdit.parse('ok [content]{.python}', {});
+    expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
+    expect(tokens[1].children?.map((t) => t.type)).toEqual([
+      'text',
+      'parsed_role_open',
+      'role_body_open',
+      'inline',
+      'role_body_close',
+      'parsed_role_close',
+    ]);
+    expect(tokens[1].content).toEqual('ok [content]{.python}');
+    // Pass the column information for the role
+    expect((tokens[1].children?.[1] as any).col).toEqual([3, 21]);
+    expect(tokens[1].children?.[1].info).toEqual('span');
+    expect(tokens[1].children?.[1].content).toEqual('content');
+    expect(tokens[1].children?.[3].content).toEqual('content');
+  });
+});

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -181,15 +181,18 @@ export async function transformMdast(
     })
     .use(inlineMathSimplificationPlugin)
     .use(mathPlugin, { macros: frontmatter.math })
-    .use(glossaryPlugin) // This should be before the enumerate plugins
-    .use(abbreviationPlugin, { abbreviations: frontmatter.abbreviations })
-    .use(enumerateTargetsPlugin, { state }) // This should be after math/container transforms
     .use(joinGatesPlugin);
   // Load custom transform plugins
   session.plugins?.transforms.forEach((t) => {
     if (t.stage !== 'document') return;
     pipe.use(t.plugin, undefined, pluginUtils);
   });
+
+  pipe
+    .use(glossaryPlugin) // This should be before the enumerate plugins
+    .use(abbreviationPlugin, { abbreviations: frontmatter.abbreviations })
+    .use(enumerateTargetsPlugin, { state }); // This should be after math/container transforms
+
   await pipe.run(mdast, vfile);
 
   // This needs to come after basic transformations since meta tags are added there

--- a/packages/myst-parser/src/fromMarkdown.ts
+++ b/packages/myst-parser/src/fromMarkdown.ts
@@ -55,6 +55,7 @@ export type AllOptions = {
     tasklist?: boolean;
     tables?: boolean;
     blocks?: boolean;
+    rmd?: boolean;
   };
   mdast: MdastOptions;
   directives: DirectiveSpec[];

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -23,6 +23,7 @@ import { applyRoles } from './roles.js';
 import type { AllOptions } from './fromMarkdown.js';
 import type { GenericParent } from 'myst-common';
 import { visit } from 'unist-util-visit';
+import { labelsPlugin, shortcodePlugin, spanPlugin } from 'markdown-it-myst';
 
 type Options = Partial<AllOptions>;
 
@@ -41,6 +42,7 @@ export const defaultOptions: Omit<AllOptions, 'vfile'> = {
     tasklist: true,
     tables: true,
     blocks: true,
+    rmd: true,
   },
   mdast: {},
   directives: defaultDirectives,
@@ -82,6 +84,11 @@ export function createTokenizer(opts?: Options) {
   if (extensions.blocks) tokenizer.use(mystBlockPlugin);
   if (extensions.footnotes) tokenizer.use(footnotePlugin).disable('footnote_inline'); // not yet implemented in myst-parser
   if (extensions.citations) tokenizer.use(citationsPlugin);
+  if (extensions.rmd) {
+    tokenizer.use(labelsPlugin);
+    tokenizer.use(shortcodePlugin);
+    tokenizer.use(spanPlugin);
+  }
   tokenizer.use(mystPlugin);
   if (extensions.math) tokenizer.use(mathPlugin, extensions.math);
   if (extensions.deflist) tokenizer.use(deflistPlugin);

--- a/packages/myst-parser/src/tokensToMyst.ts
+++ b/packages/myst-parser/src/tokensToMyst.ts
@@ -416,9 +416,11 @@ const defaultMdast: Record<string, TokenHandlerSpec> = {
   parsed_role: {
     type: 'mystRole',
     getAttrs(t) {
+      if (t.info !== 'var') console.log({ role: t });
       return {
         name: t.info,
         value: t.content,
+        options: t.meta?.options,
         processed: false,
       };
     },

--- a/packages/myst-parser/src/tokensToMyst.ts
+++ b/packages/myst-parser/src/tokensToMyst.ts
@@ -416,7 +416,6 @@ const defaultMdast: Record<string, TokenHandlerSpec> = {
   parsed_role: {
     type: 'mystRole',
     getAttrs(t) {
-      if (t.info !== 'var') console.log({ role: t });
       return {
         name: t.info,
         value: t.content,

--- a/packages/myst-transforms/package.json
+++ b/packages/myst-transforms/package.json
@@ -36,6 +36,7 @@
     "unified": "^10.0.0",
     "unist-builder": "^3.0.0",
     "unist-util-find-after": "^4.0.0",
+    "unist-util-find-before": "4.0.0",
     "unist-util-modify-children": "^3.1.0",
     "unist-util-map": "^3.0.0",
     "unist-util-remove": "^3.1.0",

--- a/packages/myst-transforms/src/containers.ts
+++ b/packages/myst-transforms/src/containers.ts
@@ -197,6 +197,13 @@ export function containerChildrenTransform(tree: GenericParent, vfile: VFile) {
     if (subfigures.length > 1 && !container.noSubcontainers) {
       subfigures = subfigures.map((node) => createSubfigure(node, container));
     }
+    if (subfigures.length === 1 && !container.label && !container.identifier) {
+      const { label, identifier } = normalizeLabel(subfigures[0].label) ?? {};
+      container.label = label;
+      container.identifier = identifier;
+      delete subfigures[0].label;
+      delete subfigures[0].identifier;
+    }
     const children: GenericNode[] = [...subfigures];
     if (placeholderImage) children.push(placeholderImage);
     // Caption is above tables and below all other figures

--- a/packages/myst-transforms/src/containers.ts
+++ b/packages/myst-transforms/src/containers.ts
@@ -198,11 +198,13 @@ export function containerChildrenTransform(tree: GenericParent, vfile: VFile) {
       subfigures = subfigures.map((node) => createSubfigure(node, container));
     }
     if (subfigures.length === 1 && !container.label && !container.identifier) {
-      const { label, identifier } = normalizeLabel(subfigures[0].label) ?? {};
+      const { label, identifier, html_id } = normalizeLabel(subfigures[0].label) ?? {};
       container.label = label;
       container.identifier = identifier;
+      container.html_id = html_id;
       delete subfigures[0].label;
       delete subfigures[0].identifier;
+      delete subfigures[0].html_id;
     }
     const children: GenericNode[] = [...subfigures];
     if (placeholderImage) children.push(placeholderImage);

--- a/packages/myst-transforms/src/targets.ts
+++ b/packages/myst-transforms/src/targets.ts
@@ -40,7 +40,13 @@ export function mystTargetsTransform(tree: GenericParent) {
     const normalized = normalizeLabel(node.label);
     if (!normalized) return;
     let targetedNode = findAfter(parent, index) as GenericNode;
-    if (!targetedNode && parent.type === 'heading') targetedNode = parent;
+    if (!targetedNode && parent.type === 'heading') {
+      targetedNode = parent;
+      // Strip trailing whitespace if there is a label
+      const headingText = selectAll('text', targetedNode) as GenericNode[];
+      const lastHeadingText = headingText[headingText.length - 1];
+      lastHeadingText.value = lastHeadingText.value?.trimEnd();
+    }
     if (!targetedNode) {
       const prevNode = findBefore(parent, index) as GenericNode;
       if (prevNode?.type === 'image') targetedNode = prevNode;


### PR DESCRIPTION
This PR includes some work from SciPy sprints to support a wider variety of markdown syntaxes:

- roles from shortcodes, e.g. `{{< role value >}}`
- labels at the end of headings/images/etc, e.g. `{#my-label}`
- classes on spans, e.g. `[content]{.python}`
- colon fences can be used to create divs with classes