### PR TITLE
:date: Fix date representation (again)

### DIFF
--- a/.changeset/yellow-hotels-visit.md
+++ b/.changeset/yellow-hotels-visit.md
@@ -1,6 +1,6 @@
 ---
-"simple-validators": patch
-"myst-templates": patch
+'simple-validators': patch
+'myst-templates': patch
 ---
 
 Fix datetime handling

--- a/.changeset/yellow-hotels-visit.md
+++ b/.changeset/yellow-hotels-visit.md
@@ -1,0 +1,6 @@
+---
+"simple-validators": patch
+"myst-templates": patch
+---
+
+Fix datetime handling

--- a/packages/myst-frontmatter/src/page/page.yml
+++ b/packages/myst-frontmatter/src/page/page.yml
@@ -40,7 +40,7 @@ cases:
         a: b
       subtitle: sub
       short_title: short
-      date: 14 Dec 2021
+      date: '14 Dec 2021'
       kernelspec: {}
       jupytext: {}
       keywords:
@@ -84,7 +84,7 @@ cases:
           macro: b
       subtitle: sub
       short_title: short
-      date: 14 Dec 2021
+      date: '2021-12-14'
       kernelspec: {}
       jupytext: {}
       keywords:

--- a/packages/myst-frontmatter/src/project/project.yml
+++ b/packages/myst-frontmatter/src/project/project.yml
@@ -27,7 +27,7 @@ cases:
       affiliations:
         - id: univa
           name: University A
-      date: 14 Dec 2021
+      date: '14 Dec 2021'
       doi: 10.1000/abcd/efg012
       arxiv: https://arxiv.org/example
       open_access: true
@@ -76,7 +76,7 @@ cases:
       affiliations:
         - id: univa
           name: University A
-      date: 14 Dec 2021
+      date: '2021-12-14'
       doi: 10.1000/abcd/efg012
       arxiv: https://arxiv.org/example
       open_access: true

--- a/packages/myst-templates/src/frontmatter.ts
+++ b/packages/myst-templates/src/frontmatter.ts
@@ -94,9 +94,9 @@ export function extendFrontmatter(frontmatter: PageFrontmatter): RendererDoc {
   const doc: RendererDoc = {
     ...frontmatter,
     date: {
-      day: String(datetime.getUTCDate()),
-      month: String(datetime.getUTCMonth() + 1),
-      year: String(datetime.getUTCFullYear()),
+      day: String(datetime.getDate()),
+      month: String(datetime.getMonth() + 1),
+      year: String(datetime.getFullYear()),
     },
     authors: addIndicesToAuthors(frontmatter.authors || [], affiliations, collaborations),
     affiliations,

--- a/packages/mystmd/tests/math-macros/outputs/index.json
+++ b/packages/mystmd/tests/math-macros/outputs/index.json
@@ -25,7 +25,7 @@
     ],
     "github": "https://github.com/jupyter-book/mystmd",
     "keywords": [],
-    "date": "1 Jan 2024"
+    "date": "2024-01-01"
   },
   "mdast": {
     "type": "root",

--- a/packages/simple-validators/package.json
+++ b/packages/simple-validators/package.json
@@ -30,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/jupyter-book/mystmd/issues"
   },
-  "devDependencies": {
+  "dependencies": {
     "moment": "^2.29.4"
   }
 }

--- a/packages/simple-validators/src/utils.spec.ts
+++ b/packages/simple-validators/src/utils.spec.ts
@@ -3,9 +3,9 @@ import moment from 'moment';
 import { formatDate } from './utils';
 
 describe('formatDate', () => {
-  it('returns an ISO string', () => {
+  it('returns an ISO date string', () => {
     expect(formatDate(moment.utc('2020-06-01 10:10:30').toDate())).toEqual(
-      expect.stringMatching('2020-06-01T10:10:30.000Z'),
+      expect.stringMatching('2020-06-01'),
     );
   });
 });

--- a/packages/simple-validators/src/utils.ts
+++ b/packages/simple-validators/src/utils.ts
@@ -14,12 +14,22 @@ export function getDate(object: undefined | Date | string | { toDate: () => Date
   throw new Error(`Could not parse date: ${object}`);
 }
 
+
+function formatISODateString(date: Date): string {
+  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+
+  // Format the date as a machine-readable date
+  const isoString = utcDate.toISOString();
+  const match = isoString.match(/^\d+-\d+-\d+/);
+  return match![0];
+};
+
 export function formatDate(date: Date | { toDate: () => Date }): string {
   if (date instanceof Date) {
-    return date.toISOString();
+    return formatISODateString(date);
   }
   if (date?.toDate !== undefined) {
-    return date.toDate().toISOString();
+    return formatISODateString(date.toDate());
   }
   if (typeof date === 'string') {
     return formatDate(getDate(date));

--- a/packages/simple-validators/src/utils.ts
+++ b/packages/simple-validators/src/utils.ts
@@ -14,7 +14,6 @@ export function getDate(object: undefined | Date | string | { toDate: () => Date
   throw new Error(`Could not parse date: ${object}`);
 }
 
-
 function formatISODateString(date: Date): string {
   const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
 
@@ -22,7 +21,7 @@ function formatISODateString(date: Date): string {
   const isoString = utcDate.toISOString();
   const match = isoString.match(/^\d+-\d+-\d+/);
   return match![0];
-};
+}
 
 export function formatDate(date: Date | { toDate: () => Date }): string {
   if (date instanceof Date) {

--- a/packages/simple-validators/src/utils.ts
+++ b/packages/simple-validators/src/utils.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 export function getDate(object: undefined | Date | string | { toDate: () => Date }): Date {
   if (object == null) {
     return new Date();
@@ -6,7 +8,8 @@ export function getDate(object: undefined | Date | string | { toDate: () => Date
     return object;
   }
   if (typeof object === 'string') {
-    return new Date(object);
+    const result = moment.parseZone(object);
+    return result.toDate();
   }
   if (object?.toDate !== undefined) {
     return object.toDate();
@@ -15,10 +18,8 @@ export function getDate(object: undefined | Date | string | { toDate: () => Date
 }
 
 function formatISODateString(date: Date): string {
-  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-
   // Format the date as a machine-readable date
-  const isoString = utcDate.toISOString();
+  const isoString = date.toISOString();
   const match = isoString.match(/^\d+-\d+-\d+/);
   return match![0];
 }

--- a/packages/simple-validators/src/validators.spec.ts
+++ b/packages/simple-validators/src/validators.spec.ts
@@ -246,14 +246,14 @@ describe('validateDate', () => {
     '2021 December 14',
     '12/14/2021',
     '12-14-2021',
-    '2022/12/14',
-    '2022-12-14',
+    '2021/12/14',
+    '2021-12-14',
   ])('valid date: %p', async (date: any) => {
-    expect(validateDate(date, opts)).toEqual(date);
+    expect(validateDate(date, opts)).toEqual('2021-12-14');
   });
   it('date object is valid', () => {
-    const date = new Date();
-    expect(validateDate(date, opts)).toEqual(date.toISOString());
+    const date = new Date("2024-11-03");
+    expect(validateDate(date, opts)).toEqual("2024-11-03");
   });
   it('invalid date errors', () => {
     expect(validateDate('https://example.com', opts)).toEqual(undefined);

--- a/packages/simple-validators/src/validators.spec.ts
+++ b/packages/simple-validators/src/validators.spec.ts
@@ -252,8 +252,8 @@ describe('validateDate', () => {
     expect(validateDate(date, opts)).toEqual('2021-12-14');
   });
   it('date object is valid', () => {
-    const date = new Date("2024-11-03");
-    expect(validateDate(date, opts)).toEqual("2024-11-03");
+    const date = new Date('2024-11-03');
+    expect(validateDate(date, opts)).toEqual('2024-11-03');
   });
   it('invalid date errors', () => {
     expect(validateDate('https://example.com', opts)).toEqual(undefined);

--- a/packages/simple-validators/src/validators.ts
+++ b/packages/simple-validators/src/validators.ts
@@ -215,18 +215,14 @@ export function validateEnum<T>(
  * IETF timestamps are valid.
  */
 export function validateDate(input: any, opts: ValidationOptions) {
-  const parsedDate = new Date(input);
-  if (!parsedDate.getDate()) {
+  const date = new Date(input);
+  if (!date.getDate()) {
     return validationError(
       `invalid date "${input}" - must be ISO 8601 format or IETF timestamp`,
       opts,
     );
   }
-  // Build a "wall-time" timestamp (choosing UTC as the timezone) from the wall-time components
-  const date = new Date(
-    Date.UTC(parsedDate.getFullYear(), parsedDate.getMonth(), parsedDate.getDate()),
-  );
-  return typeof input === 'string' ? input : formatDate(date);
+  return formatDate(date);
 }
 
 /**

--- a/packages/simple-validators/src/validators.ts
+++ b/packages/simple-validators/src/validators.ts
@@ -1,5 +1,5 @@
 import type { KeyOptions, ValidationOptions } from './types.js';
-import { formatDate } from './utils.js';
+import { getDate, formatDate } from './utils.js';
 
 export function defined<T = any>(val: T | null | undefined): val is T {
   return val != null;
@@ -215,7 +215,8 @@ export function validateEnum<T>(
  * IETF timestamps are valid.
  */
 export function validateDate(input: any, opts: ValidationOptions) {
-  const date = new Date(input);
+  // Parse the date and preserve the timezone, or assume UTC
+  const date = getDate(input);
   if (!date.getDate()) {
     return validationError(
       `invalid date "${input}" - must be ISO 8601 format or IETF timestamp`,

--- a/packages/simple-validators/src/validators.ts
+++ b/packages/simple-validators/src/validators.ts
@@ -215,13 +215,17 @@ export function validateEnum<T>(
  * IETF timestamps are valid.
  */
 export function validateDate(input: any, opts: ValidationOptions) {
-  const date = new Date(input);
-  if (!date.getDate()) {
+  const parsedDate = new Date(input);
+  if (!parsedDate.getDate()) {
     return validationError(
       `invalid date "${input}" - must be ISO 8601 format or IETF timestamp`,
       opts,
     );
   }
+  // Build a "wall-time" timestamp (choosing UTC as the timezone) from the wall-time components
+  const date = new Date(
+    Date.UTC(parsedDate.getFullYear(), parsedDate.getMonth(), parsedDate.getDate()),
+  );
   return typeof input === 'string' ? input : formatDate(date);
 }
 


### PR DESCRIPTION
Presently, our datetime handling is not quite right. We sometimes (due to `Date`) parse dates in the local timezone, but we render them in templates as UTC.

i.e. for BST=UTC+1
```node
> // A valid UTC date
> new Date(Date.UTC(2024, 6, 1))
2024-07-01T00:00:00.000Z
> // The same date without UTC
> new Date(2024, 6, 1)
2024-06-30T23:00:00.000Z
```
where the `Z` suffix indicates UTC. At the moment, we then ask for `getUTCDate()`, which returns `30` because the code parses the date as the `00:00:00` timestamp in BST, which is `23:00:00` the previous day in UTC.

Instead, we should assume that a user is entering a valid "local"/"wall time" date. This PR fixes mystmd's validation to explicitly ignore timezones and directly take the day/month information from the `Date` object.

Should fix #1357

See also https://tc39.es/proposal-temporal/docs/ambiguity.html