### PR TITLE
␡ Enable strikethrough as markdownit extension

### DIFF
--- a/.changeset/tasty-fireants-behave.md
+++ b/.changeset/tasty-fireants-behave.md
@@ -1,0 +1,5 @@
+---
+"myst-parser": patch
+---
+
+Enable strikethrough as markdownit extension

--- a/packages/myst-parser/src/fromMarkdown.ts
+++ b/packages/myst-parser/src/fromMarkdown.ts
@@ -55,6 +55,7 @@ export type AllOptions = {
     tasklist?: boolean;
     tables?: boolean;
     blocks?: boolean;
+    strikethrough?: boolean;
   };
   mdast: MdastOptions;
   directives: DirectiveSpec[];

--- a/packages/myst-parser/src/myst.ts
+++ b/packages/myst-parser/src/myst.ts
@@ -41,6 +41,7 @@ export const defaultOptions: Omit<AllOptions, 'vfile'> = {
     tasklist: true,
     tables: true,
     blocks: true,
+    strikethrough: false,
   },
   mdast: {},
   directives: defaultDirectives,
@@ -75,6 +76,7 @@ export function createTokenizer(opts?: Options) {
   if (markdownit.linkify) {
     tokenizer.linkify.tlds(tlds.filter((tld) => !EXCLUDE_TLDS.includes(tld)));
   }
+  if (extensions.strikethrough) tokenizer.enable('strikethrough');
   if (extensions.smartquotes) tokenizer.enable('smartquotes');
   if (extensions.tables) tokenizer.enable('table');
   if (extensions.colonFences) tokenizer.use(colonFencePlugin);

--- a/packages/myst-parser/src/tokensToMyst.ts
+++ b/packages/myst-parser/src/tokensToMyst.ts
@@ -91,6 +91,7 @@ const defaultMdast: Record<string, TokenHandlerSpec> = {
       };
     },
   },
+  s: { type: 'delete' },
   hr: {
     type: 'thematicBreak',
     noCloseToken: true,

--- a/packages/myst-parser/tests/strikethrough.spec.ts
+++ b/packages/myst-parser/tests/strikethrough.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { visit } from 'unist-util-visit';
+import { mystParse } from '../src';
+import type { GenericParent } from 'myst-common';
+
+function stripPositions(tree: GenericParent) {
+  visit(tree, (node) => {
+    delete node.position;
+  });
+  return tree;
+}
+
+describe('strikethrough', () => {
+  it('strikethrough in paragraph', () => {
+    const content = 'A ~~div~~ paragraph!';
+    expect(stripPositions(mystParse(content))).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', value: 'A ~~div~~ paragraph!' }],
+        },
+      ],
+    });
+    expect(stripPositions(mystParse(content, { extensions: { strikethrough: true } }))).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'A ' },
+            {
+              type: 'delete',
+              children: [{ type: 'text', value: 'div' }],
+            },
+            { type: 'text', value: ' paragraph!' },
+          ],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Ends up parsing out to a `delete` node and uses the rendering logic for the delete directive