### PR TITLE
🐛 Citations broken with trim when a list

### DIFF
--- a/.changeset/early-donkeys-worry.md
+++ b/.changeset/early-donkeys-worry.md
@@ -1,0 +1,5 @@
+---
+"citation-js-utils": patch
+---
+
+Fix citations

--- a/.changeset/sweet-taxis-obey.md
+++ b/.changeset/sweet-taxis-obey.md
@@ -1,0 +1,5 @@
+---
+"mystmd": patch
+---
+
+🐛 Citations broken with trim when a list

--- a/packages/citation-js-utils/src/index.ts
+++ b/packages/citation-js-utils/src/index.ts
@@ -277,7 +277,7 @@ export function getCitationRenderers(data: CSL[]): CitationRenderer {
         'DOI',
         'ISSN',
       ].forEach((tag) => {
-        if (c[tag]) c[tag] = c[tag].trim();
+        if (c[tag] && typeof c[tag] === 'string') c[tag] = c[tag].trim();
       });
       // Trim the DOIs and URLs (these are encoded) on load
       if (c.URL) c.URL = c.URL.replace(/^(%20)*/, '').replace(/(%20)*$/, '');


### PR DESCRIPTION
This breaks on citations with more than one publisher.