### PR TITLE
🖼 Add `icon` node

### DIFF
--- a/.changeset/dirty-bugs-drop.md
+++ b/.changeset/dirty-bugs-drop.md
@@ -1,6 +1,5 @@
 ---
 'myst-ext-icon': minor
-'myst-cli': minor
 ---
 
 Add support for parsing icon roles

--- a/.changeset/dirty-bugs-drop.md
+++ b/.changeset/dirty-bugs-drop.md
@@ -1,6 +1,6 @@
 ---
-"myst-ext-icon": minor
-"myst-cli": minor
+'myst-ext-icon': minor
+'myst-cli': minor
 ---
 
 Add support for parsing icon roles

--- a/.changeset/dirty-bugs-drop.md
+++ b/.changeset/dirty-bugs-drop.md
@@ -1,0 +1,6 @@
+---
+"myst-ext-icon": minor
+"myst-cli": minor
+---
+
+Add support for parsing icon roles

--- a/package-lock.json
+++ b/package-lock.json
@@ -9820,6 +9820,10 @@
       "resolved": "packages/myst-ext-grid",
       "link": true
     },
+    "node_modules/myst-ext-icon": {
+      "resolved": "packages/myst-ext-icon",
+      "link": true
+    },
     "node_modules/myst-ext-proof": {
       "resolved": "packages/myst-ext-proof",
       "link": true
@@ -15220,6 +15224,7 @@
         "myst-ext-card": "^1.0.7",
         "myst-ext-exercise": "^1.0.7",
         "myst-ext-grid": "^1.0.7",
+        "myst-ext-icon": "^0.0.0",
         "myst-ext-proof": "^1.0.10",
         "myst-ext-reactive": "^1.0.7",
         "myst-ext-tabs": "^1.0.7",
@@ -15592,6 +15597,16 @@
     },
     "packages/myst-ext-grid": {
       "version": "1.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "myst-common": "^1.5.1"
+      },
+      "devDependencies": {
+        "myst-parser": "^1.5.1"
+      }
+    },
+    "packages/myst-ext-icon": {
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "myst-common": "^1.5.1"
@@ -15981,6 +15996,17 @@
         "core-js": "^3.31.1",
         "js-yaml": "^4.1.0",
         "myst-cli": "^1.3.5"
+      }
+    },
+    "packages/mystmd-ext-icon": {
+      "version": "0.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "myst-common": "^1.5.1"
+      },
+      "devDependencies": {
+        "myst-parser": "^1.5.1"
       }
     },
     "packages/mystmd/node_modules/chalk": {

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -75,6 +75,7 @@
     "myst-ext-card": "^1.0.7",
     "myst-ext-exercise": "^1.0.7",
     "myst-ext-grid": "^1.0.7",
+    "myst-ext-icon": "^0.0.0",
     "myst-ext-proof": "^1.0.10",
     "myst-ext-reactive": "^1.0.7",
     "myst-ext-tabs": "^1.0.7",

--- a/packages/myst-cli/src/process/myst.ts
+++ b/packages/myst-cli/src/process/myst.ts
@@ -2,6 +2,7 @@ import { mystParse } from 'myst-parser';
 import { cardDirective } from 'myst-ext-card';
 import { gridDirectives } from 'myst-ext-grid';
 import { proofDirective } from 'myst-ext-proof';
+import { iconRole } from 'myst-ext-icon';
 import { exerciseDirectives } from 'myst-ext-exercise';
 import { reactiveDirective, reactiveRole } from 'myst-ext-reactive';
 import { tabDirectives } from 'myst-ext-tabs';
@@ -49,7 +50,7 @@ export function parseMyst(
     extensions: {
       frontmatter: !opts?.ignoreFrontmatter,
     },
-    roles: [reactiveRole, ...(session.plugins?.roles ?? [])],
+    roles: [reactiveRole, iconRole, ...(session.plugins?.roles ?? [])],
     vfile,
   });
   logMessagesFromVFile(session, vfile);

--- a/packages/myst-cli/src/process/myst.ts
+++ b/packages/myst-cli/src/process/myst.ts
@@ -50,7 +50,7 @@ export function parseMyst(
     extensions: {
       frontmatter: !opts?.ignoreFrontmatter,
     },
-    roles: [reactiveRole, iconRole, ...(session.plugins?.roles ?? [])],
+    roles: [reactiveRole, ...(session.plugins?.roles ?? [])],
     vfile,
   });
   logMessagesFromVFile(session, vfile);

--- a/packages/myst-ext-icon/.eslintrc.cjs
+++ b/packages/myst-ext-icon/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['curvenote'],
+};

--- a/packages/myst-ext-icon/README.md
+++ b/packages/myst-ext-icon/README.md
@@ -1,0 +1,3 @@
+# myst-ext-icon
+
+`mystmd` extension for `icon` role

--- a/packages/myst-ext-icon/package.json
+++ b/packages/myst-ext-icon/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "myst-ext-icon",
+  "version": "0.0.0",
+  "sideEffects": false,
+  "license": "MIT",
+  "description": "MyST extension for icon roles",
+  "author": "Angus Hollands <goosey15@gmail.com>",
+  "homepage": "https://github.com/jupyter-book/mystmd/tree/main/packages/myst-ext-icon",
+  "type": "module",
+  "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jupyter-book/mystmd.git"
+  },
+  "scripts": {
+    "clean": "rimraf dist",
+    "lint": "eslint \"src/**/!(*.spec).ts\" -c ./.eslintrc.cjs",
+    "lint:format": "npx prettier --check \"src/**/*.ts\"",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "build:esm": "tsc",
+    "build": "npm-run-all -l clean -p build:esm"
+  },
+  "bugs": {
+    "url": "https://github.com/jupyter-book/mystmd/issues"
+  },
+  "dependencies": {
+    "myst-common": "^1.5.1"
+  },
+  "devDependencies": {
+    "myst-parser": "^1.5.1"
+  }
+}

--- a/packages/myst-ext-icon/src/index.ts
+++ b/packages/myst-ext-icon/src/index.ts
@@ -1,0 +1,20 @@
+import type { RoleSpec, RoleData, GenericNode } from 'myst-common';
+
+export const iconRole: RoleSpec = {
+  name: 'fas',
+  alias: ['fab', 'far'],
+  body: {
+    type: String,
+    required: true,
+  },
+  run(data: RoleData): GenericNode[] {
+    const name = data.body as string;
+    const kind = data.name as string;
+    const icon = {
+      type: 'icon',
+      kind,
+      name,
+    };
+    return [icon];
+  },
+};

--- a/packages/myst-ext-icon/src/index.ts
+++ b/packages/myst-ext-icon/src/index.ts
@@ -1,15 +1,25 @@
 import type { RoleSpec, RoleData, GenericNode } from 'myst-common';
 
 export const iconRole: RoleSpec = {
-  name: 'fas',
-  alias: ['fab', 'far'],
+  name: 'icon:oct',
+  alias: [
+    'icon:mrg',
+    'icon:mol',
+    'icon:mrd',
+    'icon:msp',
+    'icon:mtt',
+    'icon:fab',
+    'icon:far',
+    'icon:fas',
+  ],
   body: {
     type: String,
     required: true,
   },
   run(data: RoleData): GenericNode[] {
+    const kindMatch = (data.name as string).match(/icon:(.*)/)!;
+    const kind = kindMatch[1];
     const name = data.body as string;
-    const kind = data.name as string;
     const icon = {
       type: 'icon',
       kind,

--- a/packages/myst-ext-icon/src/index.ts
+++ b/packages/myst-ext-icon/src/index.ts
@@ -23,7 +23,7 @@ export const iconRole: RoleSpec = {
     'icon:fab',
     'icon:far',
     'icon:fas',
-    ...Object.keys(LEGACY_ICON_ALIASES)
+    ...Object.keys(LEGACY_ICON_ALIASES),
   ],
   body: {
     type: String,

--- a/packages/myst-ext-icon/src/index.ts
+++ b/packages/myst-ext-icon/src/index.ts
@@ -1,5 +1,17 @@
 import type { RoleSpec, RoleData, GenericNode } from 'myst-common';
 
+export const LEGACY_ICON_ALIASES: Record<string, string> = {
+  octicon: 'oct',
+  fas: 'fas',
+  far: 'far',
+  fab: 'fab',
+  'material-twotone': 'mtt',
+  'material-sharp': 'msp',
+  'material-regular': 'mrg',
+  'material-round': 'mrd',
+  'material-outline': 'mol',
+};
+
 export const iconRole: RoleSpec = {
   name: 'icon:oct',
   alias: [
@@ -11,14 +23,24 @@ export const iconRole: RoleSpec = {
     'icon:fab',
     'icon:far',
     'icon:fas',
+    ...Object.keys(LEGACY_ICON_ALIASES)
   ],
   body: {
     type: String,
     required: true,
   },
   run(data: RoleData): GenericNode[] {
-    const kindMatch = (data.name as string).match(/icon:(.*)/)!;
-    const kind = kindMatch[1];
+    let kind: string;
+
+    const roleName = data.name as string;
+    const alias = LEGACY_ICON_ALIASES[roleName];
+
+    if (alias !== undefined) {
+      kind = alias;
+    } else {
+      const kindMatch = (data.name as string).match(/icon:(.*)/)!;
+      kind = kindMatch[1];
+    }
     const name = data.body as string;
     const icon = {
       type: 'icon',

--- a/packages/myst-ext-icon/tests/icon.spec.ts
+++ b/packages/myst-ext-icon/tests/icon.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { mystParse } from 'myst-parser';
-import { iconRole } from '../src';
+import { iconRole, LEGACY_ICON_ALIASES } from '../src';
 import { selectAll } from 'unist-util-select';
 
 function deletePositions(tree: any) {
@@ -12,8 +12,8 @@ function deletePositions(tree: any) {
 
 describe('icon role', () => {
   it.each([
-    "fab", "far", "fas", "mtt", "mrg", "mrd", "mol", "msp",,"oct"
-  ])('icon role parses', async (kind) => {
+    "fab", "far", "fas", "mtt", "mrg", "mrd", "mol", "msp","oct"
+  ])('icon:%s role parses', async (kind) => {
     const role = `icon:${kind}`;
     const icon = "any-icon";
 
@@ -28,6 +28,38 @@ describe('icon role', () => {
             {
               type: 'mystRole',
               name: role,
+              value: icon,
+              children: [
+                {
+                  type: 'icon',
+                  kind: kind,
+                  name: icon,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const output = mystParse(markup, {
+      roles: [iconRole],
+    });
+    expect(deletePositions(output)).toEqual(expected);
+  });
+  it.each(Object.entries(LEGACY_ICON_ALIASES))('legacy %s role parses', async (legacyName, kind) => {
+    const icon = "any-icon";
+
+    const markup = `{${legacyName}}\`${icon}\``;
+
+    const expected = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'mystRole',
+              name: legacyName,
               value: icon,
               children: [
                 {

--- a/packages/myst-ext-icon/tests/icon.spec.ts
+++ b/packages/myst-ext-icon/tests/icon.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { mystParse } from 'myst-parser';
+import { iconRole } from '../src';
+import { selectAll } from 'unist-util-select';
+
+function deletePositions(tree: any) {
+  selectAll('*', tree).forEach((n) => {
+    delete n.position;
+  });
+  return tree;
+}
+
+describe('icon role', () => {
+  it('icon role parses', async () => {
+    const content = '{fab}`github`';
+    const expected = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'mystRole',
+              name: 'fab',
+              value: 'github',
+              children: [
+                {
+                  type: 'icon',
+                  kind: 'fab',
+                  name: 'github',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const output = mystParse(content, {
+      roles: [iconRole],
+    });
+    expect(deletePositions(output)).toEqual(expected);
+  });
+});

--- a/packages/myst-ext-icon/tests/icon.spec.ts
+++ b/packages/myst-ext-icon/tests/icon.spec.ts
@@ -11,8 +11,14 @@ function deletePositions(tree: any) {
 }
 
 describe('icon role', () => {
-  it('icon role parses', async () => {
-    const content = '{fab}`github`';
+  it.each([
+    "fab", "far", "fas", "mtt", "mrg", "mrd", "mol", "msp",,"oct"
+  ])('icon role parses', async (kind) => {
+    const role = `icon:${kind}`;
+    const icon = "any-icon";
+
+    const markup = `{${role}}\`${icon}\``;
+
     const expected = {
       type: 'root',
       children: [
@@ -21,13 +27,13 @@ describe('icon role', () => {
           children: [
             {
               type: 'mystRole',
-              name: 'fab',
-              value: 'github',
+              name: role,
+              value: icon,
               children: [
                 {
                   type: 'icon',
-                  kind: 'fab',
-                  name: 'github',
+                  kind: kind,
+                  name: icon,
                 },
               ],
             },
@@ -35,7 +41,7 @@ describe('icon role', () => {
         },
       ],
     };
-    const output = mystParse(content, {
+    const output = mystParse(markup, {
       roles: [iconRole],
     });
     expect(deletePositions(output)).toEqual(expected);

--- a/packages/myst-ext-icon/tests/icon.spec.ts
+++ b/packages/myst-ext-icon/tests/icon.spec.ts
@@ -11,71 +11,75 @@ function deletePositions(tree: any) {
 }
 
 describe('icon role', () => {
-  it.each([
-    "fab", "far", "fas", "mtt", "mrg", "mrd", "mol", "msp","oct"
-  ])('icon:%s role parses', async (kind) => {
-    const role = `icon:${kind}`;
-    const icon = "any-icon";
+  it.each(['fab', 'far', 'fas', 'mtt', 'mrg', 'mrd', 'mol', 'msp', 'oct'])(
+    'icon:%s role parses',
+    async (kind) => {
+      const role = `icon:${kind}`;
+      const icon = 'any-icon';
 
-    const markup = `{${role}}\`${icon}\``;
+      const markup = `{${role}}\`${icon}\``;
 
-    const expected = {
-      type: 'root',
-      children: [
-        {
-          type: 'paragraph',
-          children: [
-            {
-              type: 'mystRole',
-              name: role,
-              value: icon,
-              children: [
-                {
-                  type: 'icon',
-                  kind: kind,
-                  name: icon,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    };
-    const output = mystParse(markup, {
-      roles: [iconRole],
-    });
-    expect(deletePositions(output)).toEqual(expected);
-  });
-  it.each(Object.entries(LEGACY_ICON_ALIASES))('legacy %s role parses', async (legacyName, kind) => {
-    const icon = "any-icon";
+      const expected = {
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'mystRole',
+                name: role,
+                value: icon,
+                children: [
+                  {
+                    type: 'icon',
+                    kind: kind,
+                    name: icon,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const output = mystParse(markup, {
+        roles: [iconRole],
+      });
+      expect(deletePositions(output)).toEqual(expected);
+    },
+  );
+  it.each(Object.entries(LEGACY_ICON_ALIASES))(
+    'legacy %s role parses',
+    async (legacyName, kind) => {
+      const icon = 'any-icon';
 
-    const markup = `{${legacyName}}\`${icon}\``;
+      const markup = `{${legacyName}}\`${icon}\``;
 
-    const expected = {
-      type: 'root',
-      children: [
-        {
-          type: 'paragraph',
-          children: [
-            {
-              type: 'mystRole',
-              name: legacyName,
-              value: icon,
-              children: [
-                {
-                  type: 'icon',
-                  kind: kind,
-                  name: icon,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    };
-    const output = mystParse(markup, {
-      roles: [iconRole],
-    });
-    expect(deletePositions(output)).toEqual(expected);
-  });
+      const expected = {
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'mystRole',
+                name: legacyName,
+                value: icon,
+                children: [
+                  {
+                    type: 'icon',
+                    kind: kind,
+                    name: icon,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const output = mystParse(markup, {
+        roles: [iconRole],
+      });
+      expect(deletePositions(output)).toEqual(expected);
+    },
+  );
 });

--- a/packages/myst-ext-icon/tsconfig.json
+++ b/packages/myst-ext-icon/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules", "src/**/*.spec.ts", "tests"]
+}

--- a/packages/myst-ext-icon/tsconfig.json
+++ b/packages/myst-ext-icon/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../tsconfig/base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
   },
   "include": ["."],
-  "exclude": ["dist", "build", "node_modules", "src/**/*.spec.ts", "tests"]
+  "exclude": ["dist", "build", "node_modules", "src/**/*.spec.ts", "tests"],
 }


### PR DESCRIPTION
This PR adds support for a subset of the icon syntax from sphinx-design. Although this new role supports the legacy role names such as `{fab}`, the preferred aliases are:

```
'icon:oct',
'icon:mrg',
'icon:mol',
'icon:mrd',
'icon:msp',
'icon:mtt',
'icon:fab',
'icon:far',
'icon:fas'
```
