### PR TITLE
:eye: Remove outputs and code cells with `visibility==='remove'` in exports

### DIFF
--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -38,12 +38,14 @@ export async function transformOutputsToCache(
   if (!outputs.length) return;
   const cache = castSession(session);
   await Promise.all(
-    outputs.map(async (output) => {
-      output.data = await minifyCellOutput(output.data as IOutput[], cache.$outputs, {
-        computeHash,
-        maxCharacters: opts?.minifyMaxCharacters,
-      });
-    }),
+    outputs
+      .filter((output) => output.visibility !== 'remove')
+      .map(async (output) => {
+        output.data = await minifyCellOutput(output.data as IOutput[], cache.$outputs, {
+          computeHash,
+          maxCharacters: opts?.minifyMaxCharacters,
+        });
+      }),
   );
 }
 

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -1,4 +1,4 @@
-import type { Root, Parent, Code, Abbreviation } from 'myst-spec';
+import type { Root, Parent, Abbreviation } from 'myst-spec';
 import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
 import type { GenericNode, References } from 'myst-common';
@@ -16,7 +16,7 @@ import {
 } from './utils.js';
 import MATH_HANDLERS, { withRecursiveCommands } from './math.js';
 import { selectAll } from 'unist-util-select';
-import type { FootnoteDefinition, Heading } from 'myst-spec-ext';
+import type { FootnoteDefinition, Code, Heading } from 'myst-spec-ext';
 import { transformLegends } from './legends.js';
 import { proofHandler } from './proof.js';
 
@@ -199,6 +199,9 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node, true);
   },
   code(node: Code, state) {
+    if (node.visibility === 'remove') {
+      return;
+    }
     let start = '\\begin{verbatim}\n';
     let end = '\n\\end{verbatim}';
 

--- a/packages/myst-to-tex/tests/notebook.yml
+++ b/packages/myst-to-tex/tests/notebook.yml
@@ -4,28 +4,28 @@ cases:
     mdast:
       type: root
       children:
-      - type: block
-        kind: notebook-code
-        children:
-          - type: code
-            executable: true
-            lang: python
-            value: |-
-              # I am visible
-              source = "Hello World"
-              
-              print(source)
-            visibility: show
-          - type: code
-            data:
-              type: output
-            value: 'Hello World
+        - type: block
+          kind: notebook-code
+          children:
+            - type: code
+              executable: true
+              lang: python
+              value: |-
+                # I am visible
+                source = "Hello World"
+
+                print(source)
+              visibility: show
+            - type: code
+              data:
+                type: output
+              value: 'Hello World
 
                 '
-            visibility: show
-        data:
-          tags: []
-        visibility: show
+              visibility: show
+          data:
+            tags: []
+          visibility: show
     latex: |-
       \begin{verbatim}
       # I am visible
@@ -41,30 +41,29 @@ cases:
     mdast:
       type: root
       children:
-      - type: block
-        kind: notebook-code
-        children:
-          - type: code
-            executable: true
-            lang: python
-            value: |-
-              # I am invisible
-              source = "Hello World"
-              
-              print(source)
-            visibility: remove
-          - type: code
-            data:
-              type: output
-            value: 'Hello World
+        - type: block
+          kind: notebook-code
+          children:
+            - type: code
+              executable: true
+              lang: python
+              value: |-
+                # I am invisible
+                source = "Hello World"
+
+                print(source)
+              visibility: remove
+            - type: code
+              data:
+                type: output
+              value: 'Hello World
 
                 '
-            visibility: show
-        data:
-          tags: []
-        visibility: show
+              visibility: show
+          data:
+            tags: []
+          visibility: show
     latex: |-
       \begin{verbatim}
       Hello World
       \end{verbatim}
-

--- a/packages/myst-to-tex/tests/notebook.yml
+++ b/packages/myst-to-tex/tests/notebook.yml
@@ -1,0 +1,70 @@
+title: myst-to-tex notebook features
+cases:
+  - title: notebook-code
+    mdast:
+      type: root
+      children:
+      - type: block
+        kind: notebook-code
+        children:
+          - type: code
+            executable: true
+            lang: python
+            value: |-
+              # I am visible
+              source = "Hello World"
+              
+              print(source)
+            visibility: show
+          - type: code
+            data:
+              type: output
+            value: 'Hello World
+
+                '
+            visibility: show
+        data:
+          tags: []
+        visibility: show
+    latex: |-
+      \begin{verbatim}
+      # I am visible
+      source = "Hello World"
+
+      print(source)
+      \end{verbatim}
+
+      \begin{verbatim}
+      Hello World
+      \end{verbatim}
+  - title: notebook-code-remove
+    mdast:
+      type: root
+      children:
+      - type: block
+        kind: notebook-code
+        children:
+          - type: code
+            executable: true
+            lang: python
+            value: |-
+              # I am invisible
+              source = "Hello World"
+              
+              print(source)
+            visibility: remove
+          - type: code
+            data:
+              type: output
+            value: 'Hello World
+
+                '
+            visibility: show
+        data:
+          tags: []
+        visibility: show
+    latex: |-
+      \begin{verbatim}
+      Hello World
+      \end{verbatim}
+

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -1,4 +1,4 @@
-import type { Root, Parent, Code } from 'myst-spec';
+import type { Root, Parent } from 'myst-spec';
 import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
 import type { GenericNode } from 'myst-common';
@@ -21,7 +21,7 @@ import {
 } from './utils.js';
 import MATH_HANDLERS, { resolveRecursiveCommands } from './math.js';
 import { select, selectAll } from 'unist-util-select';
-import type { Admonition, FootnoteDefinition } from 'myst-spec-ext';
+import type { Admonition, Code, FootnoteDefinition } from 'myst-spec-ext';
 import { tableCellHandler, tableHandler, tableRowHandler } from './table.js';
 
 export type { TypstResult } from './types.js';
@@ -138,6 +138,9 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node);
   },
   code(node: Code, state) {
+    if (node.visibility === 'remove') {
+      return;
+    }
     let ticks = '```';
     while (node.value.includes(ticks)) {
       ticks += '`';

--- a/packages/myst-to-typst/tests/notebook.yml
+++ b/packages/myst-to-typst/tests/notebook.yml
@@ -1,0 +1,72 @@
+title: myst-to-tex notebook features
+cases:
+  - title: notebook-code
+    mdast:
+      type: root
+      children:
+      - type: block
+        kind: notebook-code
+        children:
+          - type: code
+            executable: true
+            lang: python
+            value: |-
+              # I am visible
+              source = "Hello World"
+              
+              print(source)
+            visibility: show
+          - type: code
+            data:
+              type: output
+            value: 'Hello World
+
+                '
+            visibility: show
+        data:
+          tags: []
+        visibility: show
+    typst: |-
+      ```python
+      # I am visible
+      source = "Hello World"
+
+      print(source)
+      ```
+      
+      ```
+      Hello World
+
+      ```
+  - title: notebook-code-remove
+    mdast:
+      type: root
+      children:
+      - type: block
+        kind: notebook-code
+        children:
+          - type: code
+            executable: true
+            lang: python
+            value: |-
+              # I am invisible
+              source = "Hello World"
+              
+              print(source)
+            visibility: remove
+          - type: code
+            data:
+              type: output
+            value: 'Hello World
+
+                '
+            visibility: show
+        data:
+          tags: []
+        visibility: show
+    typst: |-
+      ```
+      Hello World
+
+      ```
+

--- a/packages/myst-to-typst/tests/notebook.yml
+++ b/packages/myst-to-typst/tests/notebook.yml
@@ -4,28 +4,28 @@ cases:
     mdast:
       type: root
       children:
-      - type: block
-        kind: notebook-code
-        children:
-          - type: code
-            executable: true
-            lang: python
-            value: |-
-              # I am visible
-              source = "Hello World"
-              
-              print(source)
-            visibility: show
-          - type: code
-            data:
-              type: output
-            value: 'Hello World
+        - type: block
+          kind: notebook-code
+          children:
+            - type: code
+              executable: true
+              lang: python
+              value: |-
+                # I am visible
+                source = "Hello World"
+
+                print(source)
+              visibility: show
+            - type: code
+              data:
+                type: output
+              value: 'Hello World
 
                 '
-            visibility: show
-        data:
-          tags: []
-        visibility: show
+              visibility: show
+          data:
+            tags: []
+          visibility: show
     typst: |-
       ```python
       # I am visible
@@ -33,7 +33,7 @@ cases:
 
       print(source)
       ```
-      
+
       ```
       Hello World
 
@@ -42,31 +42,30 @@ cases:
     mdast:
       type: root
       children:
-      - type: block
-        kind: notebook-code
-        children:
-          - type: code
-            executable: true
-            lang: python
-            value: |-
-              # I am invisible
-              source = "Hello World"
-              
-              print(source)
-            visibility: remove
-          - type: code
-            data:
-              type: output
-            value: 'Hello World
+        - type: block
+          kind: notebook-code
+          children:
+            - type: code
+              executable: true
+              lang: python
+              value: |-
+                # I am invisible
+                source = "Hello World"
+
+                print(source)
+              visibility: remove
+            - type: code
+              data:
+                type: output
+              value: 'Hello World
 
                 '
-            visibility: show
-        data:
-          tags: []
-        visibility: show
+              visibility: show
+          data:
+            tags: []
+          visibility: show
     typst: |-
       ```
       Hello World
 
       ```
-


### PR DESCRIPTION
This PR does the following:
- Make `typst` and `tex` exports aware of code-cell `visibility==='remove'`
- Remove outputs with `visibility==='remove'` during mdast finalisation

This last step has the highest probability of side-effects (in my opinion), but I think it's the "right" call. I'd prefer to handle visibility at the transform leaves (i.e. _during_ exports), but it's fine to do so earlier as long as we're mindful of it.

This PR fixes #1434 