### PR TITLE
⏩ Simplify quickstart guide to use `mamba`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ description: MyST (Markedly Structured Text) is designed to create publication-q
 
 {abbr}`MyST (Markedly Structured Text)` is an ecosystem of open-source, community-driven tools designed to revolutionize scientific communication. Our powerful authoring framework supports blogs, online books, scientific papers, reports and journals articles.
 
-:::{card} Install MyST 👩‍💻
+:::{card} Get Started With MyST 👩‍💻
 :link: ./quickstart.md
 Start here to get up and running with the `myst` command-line tools.
 :::

--- a/docs/install-node.md
+++ b/docs/install-node.md
@@ -1,6 +1,7 @@
 ---
 title: Install NodeJS
 subject: Advanced Installation
+subtitle: Install the NodeJS runtime that powers MyST 
 description: The MyST Command Line Interface (CLI) is built on NodeJS, a Javascript runtime that is widely used in many projects including well-known Python projects such as Jupyter Lab. MyST can be installed by the package manager npm, PyPI, Conda or Mamba.
 ---
 

--- a/docs/install-node.md
+++ b/docs/install-node.md
@@ -1,5 +1,6 @@
 ---
 title: Install NodeJS
+subject: Advanced Installation
 description: The MyST Command Line Interface (CLI) is built on NodeJS, a Javascript runtime that is widely used in many projects including well-known Python projects such as Jupyter Lab. MyST can be installed by the package manager npm, PyPI, Conda or Mamba.
 ---
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,6 +1,7 @@
 ---
 title: Install and Update the MyST Markdown Command Line Interface
 subject: Advanced Installation
+subtitle: Install the MyST CLI using your favourite package manager
 short_title: Install and Update MyST
 description: MyST Markdown is available through Node and npm, install the package with `npm install mystmd`.
 ---

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,5 +1,6 @@
 ---
 title: Install and Update the MyST Markdown Command Line Interface
+subject: Advanced Installation
 short_title: Install and Update MyST
 description: MyST Markdown is available through Node and npm, install the package with `npm install mystmd`.
 ---

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,72 +1,76 @@
 ---
-title: Install and Update the MyST Markdown Command Line Interface
-subject: Advanced Installation
+title: Install the MyST Markdown Command Line Interface
 subtitle: Install the MyST CLI using your favourite package manager
-short_title: Install and Update MyST
+short_title: Install MyST
 description: MyST Markdown is available through Node and npm, install the package with `npm install mystmd`.
 ---
 
-+++
+:::{tip}
+The MyST Markdown Command Line Interface (CLI) is available through [NodeJS](./install-node.md) and the node package manager, `npm`. NodeJS is used by [JupyterLab](https://github.com/jupyterlab/jupyterlab) (as well as many other Python packages) so you may already have it installed, and the following command may just work 🤞:
 
-## Install MyST
+```shell
+npm install -g mystmd
+```
+:::
 
-The MyST Markdown Command Line Interface (CLI) is available through [NodeJS](./install-node.md) and the node package manager, `npm`. Node is used by Jupyter (as well as many other Python packages) so you may already have it installed on your _PATH_, and the following command may just work 🤞.
+To install the MyST CLI, choose your preferred package manager. If you do not know what a package manager is, *it is recommended that you install MyST with `mamba` from conda-forge*.
 
-🛠️ Install `NodeJS` by following instructions at [](./install-node.md)
-
-🛠️ Choose either PyPI, Conda, Mamba or NPM and run the following command:
 
 (installing-myst-tabs)=
-::::{tab-set}
-:::{tab-item} PyPI
+:::::{tab-set}
+(installing-with-mamba)=
+::::{tab-item} conda-forge
+
+
+🛠 Install `mamba` (<https://mamba.readthedocs.io>), see <xref:biapol#ref:miniforge_python>.
+
+
+```shell
+$ mamba --version
+mamba 1.5.8
+conda 24.7.1   
+```
+
+🛠 Install `mystmd` from `conda-forge`:
+
+```shell
+mamba install -c conda-forge mystmd
+```
+
+::::
+::::{tab-item} PyPI
 
 🛠 Install `node` (<https://nodejs.org>), see [Installing NodeJS](./install-node.md):
 
-```bash
-node -v
->> v20.4.0
+```shell
+$ node -v
+v20.4.0
 ```
 
 🛠 Then install `mystmd`:
 
-```bash
+```shell
 pip install mystmd
 ```
 
-:::
-:::{tab-item} Conda / Mamba
-
-🛠 Install `node` (<https://nodejs.org>), or through conda (see [Installing NodeJS](./install-node.md)):
-
-```bash
-# Visit https://nodejs.org or:
-conda install -c conda-forge 'nodejs>=20,<21'
-```
-
-Then install `mystmd`:
-
-```bash
-conda install mystmd -c conda-forge
-```
-
-:::
-:::{tab-item} NPM
+::::
+::::{tab-item} NPM
 
 🛠 Install `node` (<https://nodejs.org>), see [Installing NodeJS](./install-node.md)
 
-```bash
-node -v
->> v20.4.0
+```shell
+$ node -v
+v20.4.0
 ```
 
-🛠 Install `mystmd` using npm, yarn or pnpm:
+🛠 Then install `mystmd` using npm, yarn or pnpm:
 
-```bash
+```shell
 npm install -g mystmd
 ```
 
-:::
 ::::
+:::::
 
 This will install `myst` globally (`-g`) on your system and add a link to the main CLI tool. To see if things worked, try checking the version with:
 
@@ -81,72 +85,26 @@ If you have any challenges installing, please [open an issue here](https://githu
 ```
 
 
-### Dependencies for $\LaTeX$ and PDF
+## Dependencies for $\LaTeX$ and PDF
 
 If you are exporting to $\LaTeX$ with an open-source template specified (see all [templates](https://github.com/myst-templates)) or if you are creating a PDF you will need to install a version of [LaTeX](https://www.latex-project.org/get).
 
+:::::{tab-set}
+::::{tab-item} conda-forge
 
-+++
-
-## Update MyST
-
-### Update the MyST CLI
-There are new releases of the MyST Markdown CLI every few weeks, to update to the latest version of `myst`, use:
+🛠 Install `mamba` (<https://mamba.readthedocs.io>), see <xref:biapol#ref:miniforge_python>.
 
 ```shell
-npm update -g mystmd
+$ mamba --version
+mamba 1.5.8
+conda 24.7.1   
 ```
 
-Try the `myst --version` command before and after, with an update you should be on the most up to date version (see [npm](https://npmjs.com/package/mystmd) for the latest version!). If you are not, try `npm uninstall -g mystmd` or without the `-g` global flag, until `myst` is no longer available on your command line. Then try installing again!
+🛠 Install `texlive-core` and `latexmk` from `conda-forge`:
 
-
-There are new releases of the MyST Markdown CLI every few weeks, to update to the latest version of `myst`, use:
-
-::::{tab-set}
-:::{tab-item} PyPI
-
-```bash
-pip install -U mystmd
+```shell
+$ mamba install -c conda-forge texlive-core latexmk
 ```
 
-:::
-:::{tab-item} Conda / Mamba
-
-```bash
-conda update mystmd -c conda-forge
-```
-
-:::
-:::{tab-item} NPM
-
-```bash
-npm update -g mystmd
-```
-
-:::
 ::::
-
-### Update the MyST templates and themes
-
-The MyST templates define how myst **renders** content into outputs like HTML and PDF.
-These are updated independently of the MyST CLI.
-If a template is not downloaded locally when you build documents with MyST, the latest version will be downloaded.
-
-To get the latest templates, clean your templates directory with:
-
-```shell
-myst clean --templates
-```
-
-This will remove the `_build/templates` directory, which will be re-downloaded with the latest templates when you run `myst start` or `myst build`.
-
-+++
-
-## Work with a Proxy Policy
-
-MyST performs web requests to download templates, check DOIs, etc. If you are working on a network that enforces a strict proxy policy for internet access, you may specify a proxy configuration string with the `HTTPS_PROXY` environment variable, for example:
-
-```shell
-HTTPS_PROXY=http://168.63.76.32:3128 \
-myst build
-```
+:::::

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -11,6 +11,7 @@ project:
     jupyterbook: https://jupyterbook.org/en/stable/
     jtex: https://mystmd.org/jtex/
     spec: https://mystmd.org/spec/
+    biapol: https://biapol.github.io/blog/
   abbreviations:
     AST: Abstract Syntax Tree
     DOI: Digital Object Identifier
@@ -70,6 +71,7 @@ project:
         - /jtex/contribute-a-template
   toc:
     - file: index.md
+    - file: installing.md
     - title: Tutorials
       children:
         - file: quickstart.md
@@ -137,8 +139,8 @@ project:
       children:
         - file: background.md
         - file: guiding-principles.md
-        - file: installing.md
         - file: install-node.md
+        - file: update-myst.md
         - file: commonmark.md
         - file: syntax-overview.md
         - file: directives.md

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,7 +55,7 @@ If you're familiar with either Python or JavaScript-based workflows, see [](inst
 :::
 ### Install the `mystmd` package
 
-Once `conda` has been installed, we can install the `mystmd` package from `conda-forge`:
+Once `mamba` has been installed, we can install the `mystmd` package (which `mamba` pulls from the `conda-forge` channel by default):
 ```shell
 mamba install mystmd
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,7 +57,7 @@ If you're familiar with either Python or JavaScript-based workflows, see [](inst
 
 Once `conda` has been installed, we can install the `mystmd` package from `conda-forge`:
 ```shell
-conda install -c conda-forge mystmd
+mamba install mystmd
 ```
 
 Once installed you should be able to print the version of MyST like so:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,7 +30,7 @@ The current tutorial will help you get up and running from scratch.
 `mystmd` is a {abbr}`CLI (Command Line Interface)` that provides modern tooling for technical writing, reproducible science, and creating scientific & technical websites.
 These instructions help you install the CLI.
 
-### Install `conda` and `conda-forge`
+### Install `mamba`
 
 The easiest way to install MyST is with [the `mamba`/`conda` package manager](https://mamba.readthedocs.io/en/latest/index.html).
 `mamba` is a multi-language manager that is useful for users across many data science languages like Python, R, Julia, and JavaScript.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,6 +49,10 @@ The easiest way to install `mamba` is with [the `miniforge` distribution](https:
    conda 24.7.1   
    ```
 
+:::{seealso} There are many ways to install MyST
+This tutorial focuses on the simplest possible way to install MyST from scratch.
+If you're familiar with either Python or JavaScript-based workflows, see [](installing.md) for more information on how to install MyST.
+:::
 ### Install the `mystmd` package
 
 Once `conda` has been installed, we can install the `mystmd` package from `conda-forge`:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,7 +71,7 @@ v1.3.1
 
 MyST needs both NodeJS and NPM to build sites locally. By installing `mystmd` from conda-forge, we do not need to install NodeJS manually. 
 
-See [](./install-node.md) for more information about installing a JavaScript environment.
+See [](./install-node.md) for more information about installing a JavaScript environment if you opt not to use `conda-forge`.
 :::
 
 For more information about installing MyST, see [installing MyST](./installing.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ These instructions help you install the CLI.
 
 ### Install `mamba`
 
-The easiest way to install MyST is with [the `mamba`/`conda` package manager](https://mamba.readthedocs.io/en/latest/index.html).
+The easiest way to install MyST is with [the `mamba` package manager](https://mamba.readthedocs.io/en/latest/index.html).
 `mamba` is a multi-language manager that is useful for users across many data science languages like Python, R, Julia, and JavaScript.
 
 The easiest way to install `mamba` is with [the `miniforge` distribution](https://github.com/conda-forge/miniforge?tab=readme-ov-file).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,57 +25,26 @@ The current tutorial will help you get up and running from scratch.
 
 > 🛠 Throughout the tutorial, whenever you're supposed to _do_ something you will see a 🛠
 
-## Install the MyST Markdown CLI 📦
+## Install the MyST Markdown CLI
 
-`mystmd` is a {abbr}`CLI (Command Line Interface)` that provides modern tooling for technical writing, reproducible science, and creating scientific & technical websites.
-These instructions help you install the CLI.
+🛠 Install MyST using your preferred packaging ecosystem. (See [](./installing.md) for more details).
 
-### Install `mamba`
 
-The easiest way to install MyST is with [the `mamba` package manager](https://mamba.readthedocs.io/en/latest/index.html).
-`mamba` is a cross-platform language-agnostic package manager that is useful for users across many data science languages like Python, R, Julia, and JavaScript.
+:::{tip} Not sure which to pick?
+:class: dropdown
 
-The easiest way to install `mamba` is with [the `miniforge` distribution](https://github.com/conda-forge/miniforge?tab=readme-ov-file).
-
-🛠 Install [miniforge](https://github.com/conda-forge/miniforge):
-
-1. Go to [the `miniforge` Downloads section](https://github.com/conda-forge/miniforge?tab=readme-ov-file#download).
-2. Download the release for your platform and follow the instructions.
-3. To check that you've installed properly, you should be able to execute the following command to print the version of conda:
-
-   ```shell
-   $ mamba --version
-   mamba 1.5.8
-   conda 24.7.1   
-   ```
-
-:::{seealso} There are many ways to install MyST
-This tutorial focuses on the simplest possible way to install MyST from scratch.
-If you're familiar with either Python or JavaScript-based workflows, see [](installing.md) for more information on how to install MyST.
+The easiest way to install MyST is with the `mamba` package manager. `mamba` is a cross-platform language-agnostic package manager that is useful for users across many data science languages like Python, R, Julia, and JavaScript.
 :::
-### Install the `mystmd` package
 
-Once `mamba` has been installed, we can install the `mystmd` package (which `mamba` pulls from the `conda-forge` channel by default):
-```shell
-mamba install mystmd
-```
+:::{embed} #installing-myst-tabs
+:::
 
-Once installed you should be able to print the version of MyST like so:
+🛠 Then, check that MyST has successfully been installed:
 
 ```shell
 $ myst -v
-v1.3.1
+v1.3.4
 ```
-
-:::{seealso} Not using `mamba`?
-
-MyST needs both NodeJS and NPM to build sites locally. By installing `mystmd` with `mamba`, we do not need to install NodeJS manually. 
-
-See [](./install-node.md) for more information about installing a JavaScript environment if you opt not to use `mamba`.
-:::
-
-For more information about installing MyST, see [installing MyST](./installing.md).
-If you run into any bugs or problems, [open an issue here](https://github.com/jupyter-book/mystmd/issues/new?assignees=&labels=bug&template=bug_report.yml). 🐛
 
 ## Build your first MyST site
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,47 +32,28 @@ These instructions help you install the CLI.
 
 ### Install `conda` and `conda-forge`
 
-The easiest way to install MyST is with [the `conda` package manager](https://conda.io/projects/conda/en/latest/).
-`conda` is a multi-language manager that is useful for users across many data science languages like Python, R, Julia, and JavaScript.
+The easiest way to install MyST is with [the `mamba`/`conda` package manager](https://mamba.readthedocs.io/en/latest/index.html).
+`mamba` is a multi-language manager that is useful for users across many data science languages like Python, R, Julia, and JavaScript.
 
-The easiest way to install `conda` is with [the `conda-forge` distribution](https://conda-forge.org/download/).
-This includes miniconda and a community-driven package index called `conda-forge`.
+The easiest way to install `mamba` is with [the `miniforge` distribution](https://github.com/conda-forge/miniforge?tab=readme-ov-file).
 
-🛠 Install miniconda from [conda-forge](https://conda-forge.org):
+🛠 Install [miniforge](https://github.com/conda-forge/miniforge):
 
-1. Go to [the conda-forge latest releases section](https://conda-forge.org/download/).
+1. Go to [the `miniforge` Downloads section](https://github.com/conda-forge/miniforge?tab=readme-ov-file#download).
 2. Download the release for your platform and follow the instructions.
 3. To check that you've installed properly, you should be able to execute the following command to print the version of conda:
 
    ```shell
-   $ conda --version
-   conda 24.7.1
+   $ mamba --version
+   mamba 1.5.8
+   conda 24.7.1   
    ```
 
-### Install Node and NPM
+### Install the `mystmd` package
 
-MyST needs both NodeJS and NPM to build sites locally.
-We'll install each with `conda`, using the `conda-forge` channel.
-
-🛠 Install Node and NPM:
-
+Once `conda` has been installed, we can install the `mystmd` package from `conda-forge`:
 ```shell
-conda install -c conda-forge 'nodejs>=20,<21'
-```
-
-:::{seealso} Other ways to install NodeJS and NPM
-See [](./install-node.md) for more information about installing a JavaScript environment.
-:::
-
-### Install the `mystmd` Python package
-
-The MySTMD Python package is a wrapper around the MyST JavaScript library, and makes it easier to upgrade and use MyST with Python workflows.
-
-🛠 Install Python and the `mystmd` package:
-
-```shell
-conda install -c conda-forge pip
-pip install mystmd
+conda install -c conda-forge mystmd
 ```
 
 Once installed you should be able to print the version of MyST like so:
@@ -81,6 +62,13 @@ Once installed you should be able to print the version of MyST like so:
 $ myst -v
 v1.3.1
 ```
+
+:::{seealso} Not using `conda-forge`?
+
+MyST needs both NodeJS and NPM to build sites locally. By installing `mystmd` from conda-forge, we do not need to install NodeJS manually. 
+
+See [](./install-node.md) for more information about installing a JavaScript environment.
+:::
 
 For more information about installing MyST, see [installing MyST](./installing.md).
 If you run into any bugs or problems, [open an issue here](https://github.com/jupyter-book/mystmd/issues/new?assignees=&labels=bug&template=bug_report.yml). 🐛

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,7 +33,7 @@ These instructions help you install the CLI.
 ### Install `mamba`
 
 The easiest way to install MyST is with [the `mamba` package manager](https://mamba.readthedocs.io/en/latest/index.html).
-`mamba` is a multi-language manager that is useful for users across many data science languages like Python, R, Julia, and JavaScript.
+`mamba` is a cross-platform language-agnostic package manager that is useful for users across many data science languages like Python, R, Julia, and JavaScript.
 
 The easiest way to install `mamba` is with [the `miniforge` distribution](https://github.com/conda-forge/miniforge?tab=readme-ov-file).
 
@@ -67,11 +67,11 @@ $ myst -v
 v1.3.1
 ```
 
-:::{seealso} Not using `conda-forge`?
+:::{seealso} Not using `mamba`?
 
-MyST needs both NodeJS and NPM to build sites locally. By installing `mystmd` from conda-forge, we do not need to install NodeJS manually. 
+MyST needs both NodeJS and NPM to build sites locally. By installing `mystmd` with `mamba`, we do not need to install NodeJS manually. 
 
-See [](./install-node.md) for more information about installing a JavaScript environment if you opt not to use `conda-forge`.
+See [](./install-node.md) for more information about installing a JavaScript environment if you opt not to use `mamba`.
 :::
 
 For more information about installing MyST, see [installing MyST](./installing.md).

--- a/docs/update-myst.md
+++ b/docs/update-myst.md
@@ -1,0 +1,63 @@
+---
+title: Update the MyST Markdown Command Line Interface
+subtitle: Update the MyST CLI using your favourite package manager
+short_title: Update MyST
+description: MyST Markdown is available through Node and npm, install the package with `npm install mystmd`.
+---
++++
+
+
+## Update the MyST CLI
+
+There are new releases of the MyST Markdown CLI every few weeks. To update to the latest version of `myst`, choose the package manager that you used in [](./installing.md):
+
+::::{tab-set}
+:::{tab-item} conda-forge
+
+```bash
+mamba update -c conda-forge mystmd
+```
+
+:::
+:::{tab-item} PyPI
+
+```bash
+pip install -U mystmd
+```
+
+:::
+:::{tab-item} NPM
+
+```bash
+npm update -g mystmd
+```
+
+:::
+::::
+
+Try the `myst --version` command before and after, with an update you should have the most up to date version (see [npm](https://npmjs.com/package/mystmd) for the latest version!). If you not, then you probably have multiple copies of `myst` installed on your computer, which should be removed before re-installing MyST.
+
+## Update the MyST templates and themes
+
+:::{tip}
+
+MyST performs web requests to download templates, check DOIs, etc. If you are working on a network that enforces a strict proxy policy for internet access, you may specify a proxy configuration string with the `HTTPS_PROXY` environment variable, for example:
+
+```shell
+HTTPS_PROXY=http://168.63.76.32:3128 \
+myst build
+```
+:::
+
+The MyST templates define how myst **renders** content into outputs like HTML and PDF.
+These are updated independently of the MyST CLI.
+If a template is not downloaded locally when you build documents with MyST, the latest version will be downloaded.
+
+To get the latest templates, clean your templates directory with:
+
+```shell
+myst clean --templates
+```
+
+This will remove the `_build/templates` directory, which will be re-downloaded with the latest templates when you run `myst start` or `myst build`.
+


### PR DESCRIPTION
Instead of going into detail about provisioning `node`, let's just go all-in on conda-forge; there's already a detailed article on installing manually
