### PR TITLE
🚀 Add executable docs tutorial

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -74,6 +74,7 @@ project:
       children:
         - file: quickstart.md
         - file: quickstart-myst-documents.md
+        - file: quickstart-executable-documents.md
         - file: quickstart-static-exports.md
         - file: quickstart-myst-markdown.md
         - file: quickstart-jupyter-lab-myst.md

--- a/docs/quickstart-executable-documents.md
+++ b/docs/quickstart-executable-documents.md
@@ -1,0 +1,156 @@
+---
+title: Executable Documents
+subject: MyST Quickstart Tutorial
+subtitle: Execute content and insert it into your pages when you build your MyST project.
+description: Learn the basics of how MyST can be used to execute content with Jupyter technology.
+---
+
+:::{note} Goals and prerequisites
+**Goals**: This tutorial covers how to take advantage of MyST features and customizability to execute computational content with your MyST build.
+
+**Prerequisites**: This assumes you've completed [](./quickstart.md) and have MyST installed locally, as well as a local version of the [MyST quickstart content](https://github.com/jupyter-book/mystmd-quickstart).
+:::
+
+![](#lookout-for-tutorial-actions)
+
+## Start MyST 🚀
+
+From [the MyST quickstart tutorial](./quickstart.md), you should already have created a `myst.yml` configuration file that is required to render your project.
+To confirm this, run a MyST server to serve the MyST quickstart content:
+
+🛠 Run `myst start` to serve your quickstart content
+
+```shell
+cd mystmd-quickstart
+myst start
+```
+
+```text
+📖 Built README.md in 33 ms.
+📖 Built 01-paper.md in 30 ms.
+📖 Built 02-notebook.ipynb in 6.94 ms.
+📚 Built 3 pages for myst in 76 ms.
+
+      ✨✨✨  Starting Book Theme  ✨✨✨
+
+⚡️ Compiled in 510ms.
+
+🔌 Server started on port 3000!  🥳 🎉
+
+      👉  http://localhost:3000  👈
+```
+
+🛠 Open your web browser to `http://localhost:3000`[^open-port]
+
+[^open-port]: If port `3000` is in use on your machine, an open port will be used instead, follow the link provided in the terminal.
+
+To fully explore `myst start` see [](./quickstart.md).
+
+## Install the packages needed for execution
+
+To execute the content in the `myst-quickstart` site, we must ensure that the proper environment is installed.
+To do so, install the packages listed in `myst-quickstart/requirements.txt`.
+
+🛠 Install `pip`
+
+```shell
+conda install pip
+```
+
+🛠 Use `pip` to install the packages for executing
+
+```shell
+pip install -r requirements.txt
+```
+
+## Execute demo content at build time
+
+Note that the content in `02-notebook/` has no outputs.
+By default, MyST will not execute any notebooks when your site builds.
+To execute your content at build time, use the `--execute` flag.
+
+🛠 Execute your content and build your MyST docs
+
+```shell
+myst start --execute
+```
+
+This will **execute** your notebook file before spinning up your MyST server.
+Go back to `02-notebook/` and you'll see the outputs there.
+
+:::{seealso}
+For more information about executing notebooks, see [](./execute-notebooks.md).
+:::
+
+## Label, reference, and embed an output
+
+You can attach labels to notebook outputs so that you can reference them later on in your site.
+MyST uses a special comment syntax for attaching metadata to Jupyter Notebook cells.
+Each of them use comments (`#` in Python) and the **pipe operator** (`|`) to add metadata.
+
+For example, this content would assign the label `mylabel` to the cell output:
+
+```python
+#| label: mylabel
+print("hi")
+```
+
+Your quickstart notebook already defines a cell output in one of its cells, find it to experiment with this feature.
+
+🛠 Find the cell that defines a label with the following code:
+
+```python
+#| label: horsepower
+points & bars
+```
+
+This assigns the label `horsepower` to the output of that code cell.
+
+You can reference it and embed it like you would any other item in MyST.
+
+🛠 Add a reference to this cell, as well as an embedding in a figure by copy and pasting this into a markdown block of the notebook.
+
+```markdown
+Here we reference [](#horsepower).
+
+And below we embed it:
+
+![](#horsepower)
+```
+
+:::{seealso}
+For more information about embedding notebook outputs, see [](./reuse-jupyter-outputs.md).
+:::
+
+## Add an executable cell to your Markdown file
+
+You can add any executable content to a MyST markdown file.
+This is useful if you want to more natively version control your executable content in a system like `git`.
+
+To add executable content, use the {myst:directive}`code-cell` directive.
+This will tell MyST to execute anything inside.
+
+🛠 Add the following code cell directive to `01-paper.md`
+
+````
+```{code-cell}
+:label: markdown-myst
+print("Here's some python!")
+```
+
+And here I reference [](#markdown-myst).
+````
+
+If you re-build your MyST site with `--execute`, the cell will be executed.
+Notice how we've also added a **label** to the code block, but using the directive option rather than the Python comments syntax we used above.
+
+:::{seealso}
+For more information about writing computational content in Markdown, see [](./notebooks-with-markdown.md).
+:::
+
+## Conclusion 🥳
+
+That's it for this quickstart tutorial!
+You've just learned how to add computational materials and execute your MyST document!
+
+![](#quickstart-cards)

--- a/docs/quickstart-executable-documents.md
+++ b/docs/quickstart-executable-documents.md
@@ -5,7 +5,7 @@ subtitle: Execute content and insert it into your pages when you build your MyST
 description: Learn the basics of how MyST can be used to execute content with Jupyter technology.
 ---
 
-:::{note} Goals and Prerequisites
+:::{note} Goals and prerequisites
 **Goals**: This tutorial covers how to take advantage of MyST features and customizability to execute computational content with your MyST build.
 
 **Prerequisites**: This assumes you've completed [](./quickstart.md) and have MyST installed locally, as well as a local version of the [MyST quickstart content](https://github.com/jupyter-book/mystmd-quickstart).

--- a/docs/quickstart-executable-documents.md
+++ b/docs/quickstart-executable-documents.md
@@ -5,7 +5,7 @@ subtitle: Execute content and insert it into your pages when you build your MyST
 description: Learn the basics of how MyST can be used to execute content with Jupyter technology.
 ---
 
-:::{note} Goals and prerequisites
+:::{note} Goals and Prerequisites
 **Goals**: This tutorial covers how to take advantage of MyST features and customizability to execute computational content with your MyST build.
 
 **Prerequisites**: This assumes you've completed [](./quickstart.md) and have MyST installed locally, as well as a local version of the [MyST quickstart content](https://github.com/jupyter-book/mystmd-quickstart).
@@ -21,11 +21,8 @@ To confirm this, run a MyST server to serve the MyST quickstart content:
 🛠 Run `myst start` to serve your quickstart content
 
 ```shell
-cd mystmd-quickstart
-myst start
-```
-
-```text
+$ cd mystmd-quickstart
+$ myst start
 📖 Built README.md in 33 ms.
 📖 Built 01-paper.md in 30 ms.
 📖 Built 02-notebook.ipynb in 6.94 ms.
@@ -48,14 +45,12 @@ To fully explore `myst start` see [](./quickstart.md).
 
 ## Install the packages needed for execution
 
+:::{note}
+This section requires the `pip` command. It should normally be installed with Python. 
+:::
+
 To execute the content in the `myst-quickstart` site, we must ensure that the proper environment is installed.
 To do so, install the packages listed in `myst-quickstart/requirements.txt`.
-
-🛠 Install `pip`
-
-```shell
-conda install pip
-```
 
 🛠 Use `pip` to install the packages for executing
 

--- a/docs/quickstart-executable-documents.md
+++ b/docs/quickstart-executable-documents.md
@@ -55,7 +55,7 @@ To do so, install the packages listed in `myst-quickstart/requirements.txt`.
 🛠 Use `pip` to install the packages for executing
 
 ```shell
-pip install -r requirements.txt
+$ pip install -r requirements.txt
 ```
 
 ## Execute demo content at build time
@@ -67,7 +67,7 @@ To execute your content at build time, use the `--execute` flag.
 🛠 Execute your content and build your MyST docs
 
 ```shell
-myst start --execute
+$ myst start --execute
 ```
 
 This will **execute** your notebook file before spinning up your MyST server.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -339,10 +339,16 @@ Here are some things to try for next steps:
 (quickstart-cards)=
 +++
 Check out the following tutorials for more step-by-step guides:
+
 ::::{grid} 1 1 2 2
 :::{card} Author enriched MyST documents ✨
 :link: ./quickstart-myst-documents.md
 Enhance your MyST documents with interactivity, open scholarship, and reproducibility.
+:::
+
+:::{card} Executable Documents with MyST 🌕
+:link: ./quickstart-executable-documents.md
+Learn how to use computation and execution with Jupyter in MyST.
 :::
 
 :::{card} Export to static documents 📑

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -346,7 +346,7 @@ Check out the following tutorials for more step-by-step guides:
 Enhance your MyST documents with interactivity, open scholarship, and reproducibility.
 :::
 
-:::{card} Executable Documents with MyST 🌕
+:::{card} Executable Documents with MyST 🐍 
 :link: ./quickstart-executable-documents.md
 Learn how to use computation and execution with Jupyter in MyST.
 :::

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,12 +30,16 @@ The current tutorial will help you get up and running from scratch.
 `mystmd` is a {abbr}`CLI (Command Line Interface)` that provides modern tooling for technical writing, reproducible science, and creating scientific & technical websites.
 These instructions help you install the CLI.
 
-### Install `conda` and `conda-forge`
+### Install `mamba` with `miniforge`
 
-The easiest way to install MyST is with [the `conda` package manager](https://conda.io/projects/conda/en/latest/).
+The easiest way to install MyST is with [`miniforge`](https://github.com/conda-forge/miniforge) from the [`conda-forge` community](https://conda-forge.org/) and the [`conda` package manager](https://docs.conda.io/en/latest/).
 `conda` is a multi-language manager that is useful for users across many data science languages like Python, R, Julia, and JavaScript.
 
-The easiest way to install `conda` is with [the `conda-forge` distribution](https://conda-forge.org/download/).
+:::{warning} Make sure you're using the `conda-forge` channel
+If you've installed `conda` before, make sure that you're using the `conda-forge` package channel and not the default channel provided by the Anaconda distribution.
+:::
+
+The easiest way to install `conda` is with [the `miniforge` distribution](https://conda-forge.org/download/).
 This includes miniconda and a community-driven package index called `conda-forge`.
 
 🛠 Install miniconda from [conda-forge](https://conda-forge.org):
@@ -49,31 +53,21 @@ This includes miniconda and a community-driven package index called `conda-forge
    conda 24.7.1
    ```
 
-### Install Node and NPM
+### Install `mystmd`
 
-MyST needs both NodeJS and NPM to build sites locally.
-We'll install each with `conda`, using the `conda-forge` channel.
+Next install MySTMD with `conda`, using the `conda-forge` channel.
 
-🛠 Install Node and NPM:
+🛠 Install the MySTMD package as well as `pip`:
 
 ```shell
-conda install -c conda-forge 'nodejs>=20,<21'
+conda install mystmd
 ```
 
-:::{seealso} Other ways to install NodeJS and NPM
+This will download `NodeJS` and `NPM`, and install the `mystmd` package with them.
+
+:::{seealso} Other ways to install MySTMD
 See [](./install-node.md) for more information about installing a JavaScript environment.
 :::
-
-### Install the `mystmd` Python package
-
-The MySTMD Python package is a wrapper around the MyST JavaScript library, and makes it easier to upgrade and use MyST with Python workflows.
-
-🛠 Install Python and the `mystmd` package:
-
-```shell
-conda install -c conda-forge pip
-pip install mystmd
-```
 
 Once installed you should be able to print the version of MyST like so:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,16 +30,12 @@ The current tutorial will help you get up and running from scratch.
 `mystmd` is a {abbr}`CLI (Command Line Interface)` that provides modern tooling for technical writing, reproducible science, and creating scientific & technical websites.
 These instructions help you install the CLI.
 
-### Install `mamba` with `miniforge`
+### Install `conda` and `conda-forge`
 
-The easiest way to install MyST is with [`miniforge`](https://github.com/conda-forge/miniforge) from the [`conda-forge` community](https://conda-forge.org/) and the [`conda` package manager](https://docs.conda.io/en/latest/).
+The easiest way to install MyST is with [the `conda` package manager](https://conda.io/projects/conda/en/latest/).
 `conda` is a multi-language manager that is useful for users across many data science languages like Python, R, Julia, and JavaScript.
 
-:::{warning} Make sure you're using the `conda-forge` channel
-If you've installed `conda` before, make sure that you're using the `conda-forge` package channel and not the default channel provided by the Anaconda distribution.
-:::
-
-The easiest way to install `conda` is with [the `miniforge` distribution](https://conda-forge.org/download/).
+The easiest way to install `conda` is with [the `conda-forge` distribution](https://conda-forge.org/download/).
 This includes miniconda and a community-driven package index called `conda-forge`.
 
 🛠 Install miniconda from [conda-forge](https://conda-forge.org):
@@ -53,21 +49,31 @@ This includes miniconda and a community-driven package index called `conda-forge
    conda 24.7.1
    ```
 
-### Install `mystmd`
+### Install Node and NPM
 
-Next install MySTMD with `conda`, using the `conda-forge` channel.
+MyST needs both NodeJS and NPM to build sites locally.
+We'll install each with `conda`, using the `conda-forge` channel.
 
-🛠 Install the MySTMD package as well as `pip`:
+🛠 Install Node and NPM:
 
 ```shell
-conda install mystmd
+conda install -c conda-forge 'nodejs>=20,<21'
 ```
 
-This will download `NodeJS` and `NPM`, and install the `mystmd` package with them.
-
-:::{seealso} Other ways to install MySTMD
+:::{seealso} Other ways to install NodeJS and NPM
 See [](./install-node.md) for more information about installing a JavaScript environment.
 :::
+
+### Install the `mystmd` Python package
+
+The MySTMD Python package is a wrapper around the MyST JavaScript library, and makes it easier to upgrade and use MyST with Python workflows.
+
+🛠 Install Python and the `mystmd` package:
+
+```shell
+conda install -c conda-forge pip
+pip install mystmd
+```
 
 Once installed you should be able to print the version of MyST like so:
 


### PR DESCRIPTION
This adds a tutorial on executable content to our quickstart tutorials. It is based on a little demo that we gave the DeepLabCut team in Geneva earlier today. Folks were very interested to learn about the executable content in MyST, so we covered these topics.

~~This also updates our mystmd install instructions in the tutorials so that we just install `mystmd` straight away with `conda` rather than installing `nodejs` manually.~~ I've reverted this so that we can focus the quickstart conversation over in:

- #1454 