### PR TITLE
🖊️ Fix filename and highlight typo in `contribute-add-feature.md`

### DIFF
--- a/docs/contribute-add-feature.md
+++ b/docs/contribute-add-feature.md
@@ -492,9 +492,9 @@ Then we must use this transform in the `myst-cli` package, which contains much o
 🛠 Import the `wordCountPlugin` in `packages/myst-cli/src/process/mdast.ts`
 
 ```{code-block} typescript
-:filename: packages/myst-transforms/src/index.ts
+:filename: packages/myst-cli/src/process/mdast.ts
 :linenos:
-:emphasize-lines: 23
+:emphasize-lines: 3
 
 import {
   ...,
@@ -507,7 +507,7 @@ Finally, we'll _use_ this plugin as part of the MyST transformations in the same
 🛠 Add the `wordCountPlugin` to the unified pipe of transformations
 
 ```{code-block} typescript
-:filename: packages/myst-transforms/src/index.ts
+:filename: packages/myst-cli/src/process/mdast.ts
 :linenos:
 :emphasize-lines: 5
 


### PR DESCRIPTION
# Change
the code block filename and emphasize-lines in  `docs/contribute-add-feature.md`,
turns some `packages/myst-transforms/src/index.ts` into `packages/myst-cli/src/process/mdast.ts` to keep the consistency with the context above and practice.

The previous version just mislead me at my first time to go through the guide 