### PR TITLE
🐌 Fix slug generation for `.myst.json` files

### DIFF
--- a/.changeset/spicy-dingos-knock.md
+++ b/.changeset/spicy-dingos-knock.md
@@ -1,5 +1,5 @@
 ---
-"myst-cli": patch
+'myst-cli': patch
 ---
 
 Fix slug generation for JSON paths

--- a/.changeset/spicy-dingos-knock.md
+++ b/.changeset/spicy-dingos-knock.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Fix slug generation for JSON paths

--- a/packages/myst-cli/src/build/utils/defaultNames.ts
+++ b/packages/myst-cli/src/build/utils/defaultNames.ts
@@ -3,6 +3,7 @@ import { ExportFormats } from 'myst-frontmatter';
 import type { ISession } from '../../session/types.js';
 import { selectPageSlug } from '../../store/selectors.js';
 import { createSlug } from '../../utils/fileInfo.js';
+import { parseFilePath } from '../../utils/resolveExtension.js';
 
 /**
  * Get default filename for saving export.
@@ -10,7 +11,7 @@ import { createSlug } from '../../utils/fileInfo.js';
  * This uses the project slug if available, or creates a new slug from the filename otherwise.
  */
 export function getDefaultExportFilename(session: ISession, file: string, projectPath?: string) {
-  const { name } = path.parse(file);
+  const { name } = parseFilePath(file);
   const slugFromProject = projectPath
     ? selectPageSlug(session.store.getState(), projectPath, file)
     : undefined;

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -16,6 +16,7 @@ import { castSession } from '../session/cache.js';
 import { warnings, watch } from '../store/reducers.js';
 import type { PreRendererData, RendererData } from '../transforms/types.js';
 import { logMessagesFromVFile } from '../utils/logging.js';
+import { parseFilePath } from '../utils/resolveExtension.js';
 import { addWarningForFile } from '../utils/addWarningForFile.js';
 import { loadBibTeXCitationRenderers } from './citations.js';
 import { parseMyst } from './myst.js';
@@ -233,7 +234,7 @@ export async function loadFile(
       session.log.debug(toc(`loadFile: ${file} already loaded.`));
       return cache.$getMdast(file)?.pre;
     }
-    const ext = extension || path.extname(file).toLowerCase();
+    const ext = extension || parseFilePath(file).ext.toLowerCase();
     let loadResult: LoadFileResult | undefined;
     switch (ext) {
       case '.md': {
@@ -258,16 +259,9 @@ export async function loadFile(
         });
         break;
       }
-      case '.json': {
-        if (file.endsWith('.myst.json')) {
-          loadResult = loadMySTJSON(session, content, file);
-          break;
-        }
-        // This MUST be the final case before `default`, as
-        // we rely on falling through to the `default` case if
-        // a non-MyST JSON file is encountered here
-        //
-        // falls through
+      case '.myst.json': {
+        loadResult = loadMySTJSON(session, content, file);
+        break;
       }
       default:
         addWarningForFile(session, file, 'Unrecognized extension', 'error', {

--- a/packages/myst-cli/src/utils/fileInfo.ts
+++ b/packages/myst-cli/src/utils/fileInfo.ts
@@ -1,5 +1,5 @@
-import path from 'node:path';
 import type { PageSlugs } from '../project/types.js';
+import { parseFilePath } from './resolveExtension.js';
 
 function input2name(input: string, allowed: RegExp, join: string) {
   let name = `¶${input}`
@@ -54,7 +54,7 @@ export function createTitle(s: string): string {
 }
 
 export function fileInfo(file: string, pageSlugs: PageSlugs): { slug: string; title: string } {
-  const { name } = path.parse(file);
+  const { name } = parseFilePath(file);
   let slug = createSlug(name);
   const title = createTitle(name);
   if (pageSlugs[slug]) {

--- a/packages/myst-cli/src/utils/resolveExtension.spec.ts
+++ b/packages/myst-cli/src/utils/resolveExtension.spec.ts
@@ -77,13 +77,12 @@ describe('isValidFile', () => {
   });
 });
 
-
 describe('parseFilePath', () => {
   it.each([
-    ['/tmp/foo/bar.md', { dir: '/tmp/foo', name: 'bar', ext: '.md'}],
-    ['/tmp/foo/bar/bat.txt', { dir: '/tmp/foo/bar', name: 'bat', ext: '.txt'}],
-    ['/tmp/baz.myst.json', { dir: '/tmp', name: 'baz', ext: '.myst.json'}],
+    ['/tmp/foo/bar.md', { dir: '/tmp/foo', name: 'bar', ext: '.md' }],
+    ['/tmp/foo/bar/bat.txt', { dir: '/tmp/foo/bar', name: 'bat', ext: '.txt' }],
+    ['/tmp/baz.myst.json', { dir: '/tmp', name: 'baz', ext: '.myst.json' }],
   ])('%s parses properly', (path, result) => {
-    expect(parseFilePath(path)).toEqual(result)
+    expect(parseFilePath(path)).toEqual(result);
   });
 });

--- a/packages/myst-cli/src/utils/resolveExtension.spec.ts
+++ b/packages/myst-cli/src/utils/resolveExtension.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import memfs from 'memfs';
-import { isValidFile, resolveExtension } from './resolveExtension';
+import { isValidFile, resolveExtension, parseFilePath } from './resolveExtension';
 
 vi.mock('fs', () => ({ ['default']: memfs.fs }));
 
@@ -74,5 +74,16 @@ describe('isValidFile', () => {
   });
   it.each(['index.txt', 'INDEX', 'my-paper.latex'])(`%s is invalid`, async (f) => {
     expect(isValidFile(f)).toBe(false);
+  });
+});
+
+
+describe('parseFilePath', () => {
+  it.each([
+    ['/tmp/foo/bar.md', { dir: '/tmp/foo', name: 'bar', ext: '.md'}],
+    ['/tmp/foo/bar/bat.txt', { dir: '/tmp/foo/bar', name: 'bat', ext: '.txt'}],
+    ['/tmp/baz.myst.json', { dir: '/tmp', name: 'baz', ext: '.myst.json'}],
+  ])('%s parses properly', (path, result) => {
+    expect(parseFilePath(path)).toEqual(result)
   });
 });

--- a/packages/myst-cli/src/utils/resolveExtension.ts
+++ b/packages/myst-cli/src/utils/resolveExtension.ts
@@ -26,7 +26,6 @@ export function isValidFile(file: string): boolean {
   return VALID_FILE_EXTENSIONS.some((ext) => lowerCasePath.endsWith(ext));
 }
 
-
 /**
  * Parse a file path into its constituent parts
  *

--- a/packages/myst-cli/src/utils/resolveExtension.ts
+++ b/packages/myst-cli/src/utils/resolveExtension.ts
@@ -26,6 +26,27 @@ export function isValidFile(file: string): boolean {
   return VALID_FILE_EXTENSIONS.some((ext) => lowerCasePath.endsWith(ext));
 }
 
+
+/**
+ * Parse a file path into its constituent parts
+ *
+ * Handles multi-dot extensions
+ */
+export function parseFilePath(file: string): {
+  dir: string;
+  name: string;
+  ext: string;
+} {
+  const { dir, base, ext: baseExt, name: baseName } = path.parse(file);
+  for (const ext of VALID_FILE_EXTENSIONS) {
+    if (base.endsWith(ext)) {
+      const name = base.slice(0, base.length - ext.length);
+      return { dir, name, ext };
+    }
+  }
+  return { dir, name: baseName, ext: baseExt };
+}
+
 /**
  * Given a file with resolved path and filename, match to md, ipynb, or tex files
  *


### PR DESCRIPTION
Presently we use `path.parse` to strip away file extensions before slug generation. This PR replaces that logic with a custom `parse` function that understands the MyST extension list.

I'm not 100% sure whether talking about `.myst.json` as an _extension_ rather than a "suffix" is a poor choice of language, but we're walking down this path for now.