### PR TITLE
🆎 Explicitly ignore longer abbreviations

### DIFF
--- a/.changeset/ninety-jokes-tie.md
+++ b/.changeset/ninety-jokes-tie.md
@@ -1,0 +1,7 @@
+---
+"myst-frontmatter": patch
+"myst-transforms": patch
+"mystmd": patch
+---
+
+Allow for explicit ignoring of longer abbreviations

--- a/.changeset/twelve-dodos-shout.md
+++ b/.changeset/twelve-dodos-shout.md
@@ -1,0 +1,5 @@
+---
+"simple-validators": patch
+---
+
+Add minLength to string validation

--- a/docs/glossaries-and-terms.md
+++ b/docs/glossaries-and-terms.md
@@ -216,4 +216,5 @@ The abbreviations are case-sensitive and will replace all instances[^1] in your 
 :::{tip} Order of Abbreviations
 :class: dropdown
 Abbreviations defined in your frontmatter are applied in longest-sorted order. If you have two abbreviations with the same suffix (e.g. `RHR` and `HR`), the longer abbreviation will always take precedence.
+To have the longer abbreviations not be transformed, explicitly set them to `null` in your frontmatter (e.g. `RHR: null`).
 :::

--- a/packages/myst-frontmatter/src/project/project.yml
+++ b/packages/myst-frontmatter/src/project/project.yml
@@ -197,3 +197,26 @@ cases:
           - Example
         example_part:
           - Another example part!
+  - title: abbreviations can be null
+    raw:
+      abbreviations:
+        false-y: false
+        null-y: null
+        TEST: 'string'
+    normalized:
+      abbreviations:
+        false-y: null
+        null-y: null
+        TEST: 'string'
+  - title: abbreviations not added if invalid
+    raw:
+      abbreviations:
+        TEST: 42
+    normalized: {}
+    errors: 1
+  - title: short abbreviations are invalid
+    raw:
+      abbreviations:
+        A: Abbreviation
+    normalized: {}
+    errors: 1

--- a/packages/myst-frontmatter/src/project/types.ts
+++ b/packages/myst-frontmatter/src/project/types.ts
@@ -72,7 +72,7 @@ export type ProjectAndPageFrontmatter = SiteFrontmatter & {
   /** Math macros to be passed to KaTeX or LaTeX */
   math?: Record<string, MathMacro>;
   /** Abbreviations used throughout the project */
-  abbreviations?: Record<string, string>;
+  abbreviations?: Record<string, string | null>;
   exports?: Export[];
   downloads?: Download[];
   settings?: ProjectSettings;

--- a/packages/myst-transforms/src/abbreviations.ts
+++ b/packages/myst-transforms/src/abbreviations.ts
@@ -31,8 +31,7 @@ function replaceText(mdast: GenericParent, opts: Options) {
         abbr,
         (value: any, { stack }: RegExpMatchObject) => {
           if (!title) {
-            // Explicitly do not match this abbreviation
-            // This does need to mark and split the text, which is undone below
+            // Change the type of this match to a transient node to guard from further replacements
             return u('__skippedAbbreviation__', value);
           }
           if (stack.slice(-1)[0].type !== 'text') return false;

--- a/packages/myst-transforms/src/abbreviations.ts
+++ b/packages/myst-transforms/src/abbreviations.ts
@@ -43,6 +43,7 @@ function replaceText(mdast: GenericParent, opts: Options) {
       ]),
   );
   findAndReplace(mdast as any, replacements);
+  // Restore the original `text` type of the transient replacements performed above
   selectAll('__skippedAbbreviation__', mdast).forEach((n) => {
     n.type = 'text';
   });

--- a/packages/myst-transforms/tests/abbreviations.spec.ts
+++ b/packages/myst-transforms/tests/abbreviations.spec.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
 import { abbreviationTransform } from '../src';
+import type { Root } from 'myst-spec';
 
 type TestFile = {
   cases: TestCase[];

--- a/packages/myst-transforms/tests/abbreviations.yml
+++ b/packages/myst-transforms/tests/abbreviations.yml
@@ -61,6 +61,34 @@ cases:
               children:
                 - type: text
                   value: MyST
+  - title: Abbreviation with null
+    opts:
+      abbreviations:
+        HR: Heart Rate
+        SHRILL: null
+    before:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: Beating HR is not SHRILL
+    after:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'Beating '
+            - type: abbreviation
+              title: Heart Rate
+              children:
+                - type: text
+                  value: HR
+            - type: text
+              value: ' is not '
+            - type: text
+              value: SHRILL
   - title: Abbreviation first time long
     opts:
       firstTimeLong: true

--- a/packages/simple-validators/src/validators.spec.ts
+++ b/packages/simple-validators/src/validators.spec.ts
@@ -136,7 +136,11 @@ describe('validateString', () => {
     expect(validateString({}, opts)).toEqual(undefined);
     expect(opts.messages.errors?.length).toEqual(1);
   });
-  it('exceeding maxLenth errors', () => {
+  it('exceeding minLength errors', () => {
+    expect(validateString('a', { minLength: 2, ...opts })).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('exceeding maxLength errors', () => {
     expect(validateString('abc', { maxLength: 1, ...opts })).toEqual(undefined);
     expect(opts.messages.errors?.length).toEqual(1);
   });

--- a/packages/simple-validators/src/validators.ts
+++ b/packages/simple-validators/src/validators.ts
@@ -90,7 +90,12 @@ export function validateNumber(
  */
 export function validateString(
   input: any,
-  opts: { coerceNumber?: boolean; maxLength?: number; regex?: string | RegExp } & ValidationOptions,
+  opts: {
+    coerceNumber?: boolean;
+    minLength?: number;
+    maxLength?: number;
+    regex?: string | RegExp;
+  } & ValidationOptions,
 ): string | undefined {
   let value = input as string;
   if (opts.coerceNumber && typeof value === 'number') {
@@ -98,6 +103,9 @@ export function validateString(
     value = String(value);
   }
   if (typeof value !== 'string') return validationError(`must be string`, opts);
+  if (opts.minLength && value.length < opts.minLength) {
+    return validationError(`must be greater than ${opts.minLength} chars`, opts);
+  }
   if (opts.maxLength && value.length > opts.maxLength) {
     return validationError(`must be less than ${opts.maxLength} chars`, opts);
   }


### PR DESCRIPTION
This ignores longer abbreviations:

```yaml
HR: Heart Rate
RHR: null
```

This would make: HR an abbreviation, but leave RHR alone. Previously there was no way to let the `HR` in `RHR` not be abbreviated with `R<HR>`.