### PR TITLE
🤫 Update gitignore based on `git check-ignore`

### DIFF
--- a/.changeset/witty-shirts-guess.md
+++ b/.changeset/witty-shirts-guess.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Only write gitignore if it is not already ignored

--- a/packages/myst-cli/src/init/init.ts
+++ b/packages/myst-cli/src/init/init.ts
@@ -36,9 +36,8 @@ const SITE_CONFIG = `site:
   #   logo: site_logo.png
 `;
 
-const GITIGNORE = `# ${readableName()} build outputs
-_build
-`;
+const IGNORED_PATTERNS = ['_build'];
+const GITIGNORE = `# ${readableName()} build outputs\n${IGNORED_PATTERNS.join('\n')}\n`;
 
 export type InitOptions = {
   project?: boolean;
@@ -65,7 +64,8 @@ Learn more about this CLI and MyST Markdown at: ${chalk.bold(homeURL())}
 async function writeGitignore(session: ISession) {
   const inGit = await checkFolderIsGit();
   if (!inGit) return;
-  if (await checkIgnore('_build')) return;
+  const allIgnored = (await Promise.all(IGNORED_PATTERNS.map(checkIgnore))).every((x) => x);
+  if (allIgnored) return;
   if (fs.existsSync('.gitignore')) {
     session.log.info('💾 Updating .gitignore');
     const contents = fs.readFileSync('.gitignore').toString();

--- a/packages/myst-cli/src/utils/git.ts
+++ b/packages/myst-cli/src/utils/git.ts
@@ -10,6 +10,15 @@ export async function checkFolderIsGit(): Promise<boolean> {
   }
 }
 
+export async function checkIgnore(pattern: string): Promise<boolean> {
+  try {
+    await makeExecutable(`git check-ignore ${pattern}`, null)();
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 export async function checkAtGitRoot(): Promise<boolean> {
   return await fsExists('.git');
 }


### PR DESCRIPTION
MyST was previously creating .gitignore's in subfolders of a git repository. We only want that to happen if the main repo does not already ignore `_build`.

This updates the logic to be based on `git check-ignore _build` rather than parsing the `.gitignore` in the current folder (and not traversing upwards, etc.)