### PR TITLE
📦 Published `myst-ext-icon`

### DIFF
--- a/.changeset/dirty-bugs-drop.md
+++ b/.changeset/dirty-bugs-drop.md
@@ -1,5 +1,5 @@
 ---
-'myst-ext-icon': minor
+'myst-ext-icon': patch
 ---
 
 Add support for parsing icon roles

--- a/packages/myst-cli/src/process/myst.ts
+++ b/packages/myst-cli/src/process/myst.ts
@@ -2,7 +2,6 @@ import { mystParse } from 'myst-parser';
 import { cardDirective } from 'myst-ext-card';
 import { gridDirectives } from 'myst-ext-grid';
 import { proofDirective } from 'myst-ext-proof';
-import { iconRole } from 'myst-ext-icon';
 import { exerciseDirectives } from 'myst-ext-exercise';
 import { reactiveDirective, reactiveRole } from 'myst-ext-reactive';
 import { tabDirectives } from 'myst-ext-tabs';


### PR DESCRIPTION
I have published and added `ebp-bot` to the npm package. Changed this to a patch bump and removed unneeded import for now.