### PR TITLE
🔬 Improve documentation for kernel spec and cell blocks

### DIFF
--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -215,6 +215,7 @@ The following table lists the available frontmatter fields, a brief description 
 
 +++
 
+(myst:field-behavior)=
 ## Field Behavior
 
 Frontmatter can be attached to a “page”, meaning a local `.md` or `.ipynb` or a “project”. However, individual frontmatter fields are not uniformly available at both levels, and behavior of certain fields are different between project and page levels. There are three field behaviors to be aware of:

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -215,7 +215,7 @@ The following table lists the available frontmatter fields, a brief description 
 
 +++
 
-(myst:field-behavior)=
+(field-behavior)=
 ## Field Behavior
 
 Frontmatter can be attached to a “page”, meaning a local `.md` or `.ipynb` or a “project”. However, individual frontmatter fields are not uniformly available at both levels, and behavior of certain fields are different between project and page levels. There are three field behaviors to be aware of:

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -209,7 +209,7 @@ The following table lists the available frontmatter fields, a brief description 
   - configuration for Jupyter execution (see [](./integrating-jupyter.md))
   - project only
 * - `kernelspec`
-  - configuration for the kernel (see [](./notebooks-with-markdown.md#kernel-specification))
+  - configuration for the kernel (see [](#kernel-specification))
   - page only
 ```
 

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -208,6 +208,9 @@ The following table lists the available frontmatter fields, a brief description 
 * - `jupyter` or `thebe`
   - configuration for Jupyter execution (see [](./integrating-jupyter.md))
   - project only
+* - `kernelspec`
+  - configuration for the kernel (see [](./notebooks-with-markdown.md#kernel-specification))
+  - page only
 ```
 
 +++

--- a/docs/notebooks-with-markdown.md
+++ b/docs/notebooks-with-markdown.md
@@ -14,17 +14,17 @@ import matplotlib.pyplot as plt
 import numpy as np
 ```
 
-You can specify Jupyter content in your Markdown, which allows you to execute computation using [MyST's notebook execution engine](./execute-notebooks.md). First, you will need to [define a kernel specification](#myst:define-kernel), after which you can introduce Markdown-based computation in several ways:
-- [Code cells](#myst:code-cell) for block-level content.
-- [Inline expressions](#myst:inline-expressions) for content inline with surrounding text.
+You can specify Jupyter content in your Markdown, which allows you to execute computation using [MyST's notebook execution engine](./execute-notebooks.md). First, you will need to [define a kernel specification](#kernel-specification), after which you can introduce Markdown-based computation in several ways:
+- [Code cells](#code-cell) for block-level content.
+- [Inline expressions](#inline-expressions) for content inline with surrounding text.
 
 
-(myst:define-kernel)=
+(kernel-specification)=
 ## Kernel specification
 
 Defining a kernel specification (`kernelspec`) informs the Jupyter server of the name of the kernel that should execute your code. When you call `myst build --execute` or `myst start --execute`, the MyST CLI starts a Jupyter kernel to execute your code and gather the execution results. Defining different `kernelspec`s in each notebook makes it possible to flexibly switch the package environment and programming language (e.g. to use R in one notebook, and Julia in another). 
 
-The `kernelspec` configuration should be defined in the *page-level* frontmatter of each executable markdown file (see [](myst:field-behavior) for more information). The following contents is a frontmatter defines a document that uses the `python` kernel:
+The `kernelspec` configuration should be defined in the *page-level* frontmatter of each executable markdown file (see [](field-behavior) for more information). The following contents is a frontmatter defines a document that uses the `python` kernel:
 
 ```yaml
 kernelspec:
@@ -65,7 +65,7 @@ The `kernelspec` field supports the same content that is validated by [`nbformat
   - human-readable name for the kernel, e.g. "Python 3.12"
 ```
 
-(myst:code-cell)=
+(code-cell)=
 
 ## Code cells with the {myst:directive}`code-cell` directive
 
@@ -215,9 +215,9 @@ See [](./quickstart-jupyter-lab-myst.md) for how these eval statements also work
 
 ## Markdown cells with block breaks
 
-In [](#myst:compatibility-jupytext), the `jupytext` tool for integrating text-based notebooks with existing Jupyter tools like JupyterLab is discussed. By default, when reading a MyST Markdown document, `jupytext` creates a single Markdown cell between adjacent code cells. The block-break (`+++`) syntax described in [](./blocks.md) can be used to separate blocks of Markdown into distinct Markdown cells.
+In [](#compatibility-jupytext), the `jupytext` tool for integrating text-based notebooks with existing Jupyter tools like JupyterLab is discussed. By default, when reading a MyST Markdown document, `jupytext` creates a single Markdown cell between adjacent code cells. The block-break (`+++`) syntax described in [](./blocks.md) can be used to separate blocks of Markdown into distinct Markdown cells.
 
-(myst:compatibility-jupytext)=
+(compatibility-jupytext)=
 ## Compatibility with `jupytext`
 
 [jupytext](https://github.com/mwouts/jupytext) is a Python package that converts between Jupyter Notebooks (ipynb files) and plain text documents (like MyST Markdown files). It provides both a commandline tool to perform these conversions, and an extension for JupyterLab to facilitate opening text-based notebooks with the Notebook viewer. MyST Markdown is understood by jupytext, which defines a `md:myst` format for reading from / writing to MyST Markdown.

--- a/docs/notebooks-with-markdown.md
+++ b/docs/notebooks-with-markdown.md
@@ -6,7 +6,10 @@ kernelspec:
 
 # Code Cells and Inline Expressions with Markdown
 
-
+```{warning} This is an alpha feature
+Markdown-based code cells are still in the works, and missing key functionality.
+Their behavior is subject to change unpredictably!
+```
 ```{code-cell} python
 :tag: hide-cell
 
@@ -24,7 +27,20 @@ You can specify Jupyter content in your Markdown, which allows you to execute co
 
 Defining a kernel specification (`kernelspec`) informs the Jupyter server of the name of the kernel that should execute your code. When you call `myst build --execute` or `myst start --execute`, the MyST CLI starts a Jupyter kernel to execute your code and gather the execution results. Defining different `kernelspec`s in each notebook makes it possible to flexibly switch the package environment and programming language (e.g. to use R in one notebook, and Julia in another). 
 
-The `kernelspec` configuration should be defined in the *page-level* frontmatter of each executable markdown file (see [](field-behavior) for more information). The following contents is a frontmatter defines a document that uses the `python` kernel:
+The `kernelspec` configuration should be defined in the *page-level* frontmatter of each executable markdown file (see [](#field-behavior) for more information), and supports the same content that is validated by [`nbformat`'s schema](https://github.com/jupyter/nbformat/blob/main/nbformat/v4/nbformat.v4.5.schema.json):
+```{list-table} A list of available kernelspec fields
+:header-rows: 1
+:label: table-kernelspec
+
+* - field
+  - description
+* - `name`
+  - name of the kernel, e.g. `python3`
+* - `display_name`
+  - human-readable name for the kernel, e.g. "Python 3.12"
+```
+
+The following contents is a frontmatter defines a document that uses the `python` kernel:
 
 ```yaml
 kernelspec:
@@ -32,7 +48,7 @@ kernelspec:
   display_name: "Python 3"
 ```
 
-When we declare the frontmatter, all the contents in {myst:directive}`code-cell` and {myst:role}`eval` will be executed by the `python` kernel during the building process.
+After we declare the frontmatter, the contents of each {myst:directive}`code-cell` directive and {myst:role}`eval` role will be executed by the `python` kernel during the building process.
 
 ### Use a different kernel
 Furthermore, you can build MyST Markdown content with other programming languages like JavaScript, R, and Julia by installing the corresponding kernel. For example, to build a page that uses JavaScript in the {myst:directive}`code-cell`, we could:
@@ -52,18 +68,6 @@ Furthermore, you can build MyST Markdown content with other programming language
     ```
     ````
 
-The `kernelspec` field supports the same content that is validated by [`nbformat`'s schema](https://github.com/jupyter/nbformat/blob/main/nbformat/v4/nbformat.v4.5.schema.json):
-```{list-table} A list of available kernelspec fields
-:header-rows: 1
-:label: table-kernelspec
-
-* - field
-  - description
-* - `name`
-  - name of the kernel, e.g. `python3`
-* - `display_name`
-  - human-readable name for the kernel, e.g. "Python 3.12"
-```
 
 (code-cell)=
 
@@ -71,10 +75,7 @@ The `kernelspec` field supports the same content that is validated by [`nbformat
 
 You can use the {myst:directive}`code-cell` directive to create block-level computational outputs in MyST Markdown.
 
-```{warning} This is an alpha feature
-Markdown-based code cells are still in the works, and missing key functionality.
-Their behavior is subject to change unpredictably!
-```
+
 
 {myst:directive}`code-cell` directives have the following form:
 

--- a/docs/notebooks-with-markdown.md
+++ b/docs/notebooks-with-markdown.md
@@ -1,16 +1,68 @@
+---
+kernelspec:
+  name: python3
+  display_name: Python 3
+---
+
 # Code Cells and Inline Expressions with Markdown
 
-You can specify Jupyter content in your markdown, which allows you to execute computation using [MyST's notebook execution engine](./execute-notebooks.md).
-
-You can define two types of markdown-based computation:
-
-- [**code cells**](#myst:code-cell): for block-level content
-- [**in-line expressions**](#myst:inline-expressions): for content inline with surrounding text
 
 ```{code-cell} python
 :tag: hide-cell
+
 import matplotlib.pyplot as plt
 import numpy as np
+```
+
+You can specify Jupyter content in your Markdown, which allows you to execute computation using [MyST's notebook execution engine](./execute-notebooks.md). First, you will need to [define a kernel specification](#myst:define-kernel), after which you can introduce Markdown-based computation in several ways:
+- [Code cells](#myst:code-cell) for block-level content.
+- [Inline expressions](#myst:inline-expressions) for content inline with surrounding text.
+
+
+(myst:define-kernel)=
+## Kernel specification
+
+Defining a kernel specification (`kernelspec`) informs the Jupyter server of the name of the kernel that should execute your code. When you call `myst build --execute` or `myst start --execute`, the MyST CLI starts a Jupyter kernel to execute your code and gather the execution results. Defining different `kernelspec`s in each notebook makes it possible to flexibly switch the package environment and programming language (e.g. to use R in one notebook, and Julia in another). 
+
+The `kernelspec` configuration should be defined in the *page-level* frontmatter of each executable markdown file (see [](myst:field-behavior) for more information). The following contents is a frontmatter defines a document that uses the `python` kernel:
+
+```yaml
+kernelspec:
+  name: python3
+  display_name: "Python 3"
+```
+
+When we declare the frontmatter, all the contents in {myst:directive}`code-cell` and {myst:role}`eval` will be executed by the `python` kernel during the building process.
+
+### Use a different kernel
+Furthermore, you can build MyST Markdown content with other programming languages like JavaScript, R, and Julia by installing the corresponding kernel. For example, to build a page that uses JavaScript in the {myst:directive}`code-cell`, we could:
+1. Install a JavaScript kernel, e.g. [ijavascript](https://github.com/n-riesco/ijavascript).
+2. Retrieve the kernel name with `jupyter kernelspec list`.  
+   In the default installation, the kernel name is `javascript`.
+3. Set the kernelspec in your document's frontmatter:
+    ```yaml
+    kernelspec:
+      name: javascript
+      display_name: JavaScript
+    ```
+4. Define a code cell that uses the new kernel:
+    ````markdown
+    ```{code-cell} javascript
+    console.log("hello javascript kernel");
+    ```
+    ````
+
+The `kernelspec` field supports the same content that is validated by [`nbformat`'s schema](https://github.com/jupyter/nbformat/blob/main/nbformat/v4/nbformat.v4.5.schema.json):
+```{list-table} A list of available kernelspec fields
+:header-rows: 1
+:label: table-kernelspec
+
+* - field
+  - description
+* - `name`
+  - name of the kernel, e.g. `python3`
+* - `display_name`
+  - human-readable name for the kernel, e.g. "Python 3.12"
 ```
 
 (myst:code-cell)=
@@ -161,82 +213,19 @@ See [](./quickstart-jupyter-lab-myst.md) for how these eval statements also work
 ![](#fig:eval-array)
 :::
 
-## Kernel specification
+## Markdown cells with block breaks
 
-Kernel specification (kernel spec) tells the jupyter server how to start a kernel that executes your code.
-When you call `myst build --execute` or `myst start --execute`, the MyST CLI starts a jupyter kernel to execute your code and gather its results.
-Choosing different kernel specs in JupyterNotebook helps the user to flexibly switch the package environments and programming languages(for example, use R or Julia in the Notebook).
-Similarly, we can also switch the kernel spec in MyST building.
+In [](#myst:compatibility-jupytext), the `jupytext` tool for integrating text-based notebooks with existing Jupyter tools like JupyterLab is discussed. By default, when reading a MyST Markdown document, `jupytext` creates a single Markdown cell between adjacent code cells. The block-break (`+++`) syntax described in [](./blocks.md) can be used to separate blocks of Markdown into distinct Markdown cells.
 
-### Setting in the frontmatter
+(myst:compatibility-jupytext)=
+## Compatibility with `jupytext`
 
-You could explicitly choose the kernel spec in the **page-level**  frontmatter of the markdown file.
-The following contents is a frontmatter sets the kernel spec to `python`:
+[jupytext](https://github.com/mwouts/jupytext) is a Python package that converts between Jupyter Notebooks (ipynb files) and plain text documents (like MyST Markdown files). It provides both a commandline tool to perform these conversions, and an extension for JupyterLab to facilitate opening text-based notebooks with the Notebook viewer. MyST Markdown is understood by jupytext, which defines a `md:myst` format for reading from / writing to MyST Markdown.
 
-```yaml
----
-# ... other sections of the frontmatter
-kernelspec:
-  name: python3
-  display_name: "Python 3"
----
-```
-
-When we declare the frontmatter, all the contents in {myst:directive}`code-cell` and {myst:role}`eval` will be executed by the `python` kernel during the building process.
-
-Furthermore, you can build myst markdown content with other programming languages like JavaScript, R, and Julia by installing the corresponding kernel.
-For example, to build a page that uses JavaScript in the {myst:directive}`code-cell`, we could:
-1. Install the interactive JavaScript Kernel, like [ijavascript](https://github.com/n-riesco/ijavascript)
-2. To check the installation and the kernel name, run `jupyter kernelspec list`. In the default installation, the kernel name is `javascript`.
-3. Set the kernel spec in the frontmatter:
-```yaml
----
-# ... other sections of the frontmatter
-kernelspec:
-  name: javascript
-  display_name: JavaScript
----
-```
-
-then the code cell like the following section will get the correct result and render.
-
-````
-```{code-cell} javascript
-console.log("hello javascript kernel");
-```
-````
-
-The full options of the kernel spec field supported is a subsect of [jupyter kernelspec](https://jupyter-client.readthedocs.io/en/latest/kernels.html#kernelspecs).
-They are:
-
-```yaml
-kernelspec:
-  name: python3 # required, the name of the kernel. can be found by `jupyter kernelspec list`
-  display_name: "Python3 Kernel" # required, the display name of the kernel.
-  language: python # optional, the language of the kernel, used for syntax highlight
-  env: {} # optional, A dictionary of environment variables to set for the kernel
-  argv: # optional, A list of command line arguments used to start the kernel
-```
-
-## Compatibility with jupytext
-
-[jupytext](https://github.com/mwouts/jupytext) is a python package that makes some conventions to get the notebook-like experience in plain text documents.
-It provides a JupyterBook extension to render those documents and an command tool to convert the plain text documents to the `.ipynb` notebook.
-MyST is also supported by jupytext, and some of our users could use jupytext to write the draft MyST markdown files and do the conversion in different file formats.
-The following command will convert the MyST markdown file to the `.ipynb` notebook, which could be helpful when you want to check the execution results and modify some code cells in the myst with a local jupyter notebook.
+The following command will convert a MyST markdown file `example.md` to the `.ipynb` notebook:
 
 ```shell
-$ jupytext --from md:myst --to notebook <path_to_the_md_document>
+$ jupytext --from md:myst --to notebook example.md
 ```
 
-### Kernel spec in jupytext
 
-In myst CLI, it will do the auto-filling if there is the missing `name` or missing `display_name`.
-But they are required by jupytext to do the rendering and conversion.
-So we will raise a warning when the `name` or `display_name` is missing and suggest setting both `name` and `display_name` in the kernel spec.
-
-### Cell Block breaking
-
-The notebook converted by jupytext will only put cell partitions in code-cell and other markdown parts.
-But in some common practice, it would be nice to separate long markdown contents into serval cell blocks.
-As section [](./blocks.md) suggests, you could put `+++` in some proper positions in the file to get a better separated `.ipynb` notebook converted by jupytext.

--- a/docs/notebooks-with-markdown.md
+++ b/docs/notebooks-with-markdown.md
@@ -160,3 +160,83 @@ This results in the following:
 See [](./quickstart-jupyter-lab-myst.md) for how these eval statements also work in JupyterLab.
 ![](#fig:eval-array)
 :::
+
+## Kernel specification
+
+Kernel specification (kernel spec) tells the jupyter server how to start a kernel that executes your code.
+When you call `myst build --execute` or `myst start --execute`, the MyST CLI starts a jupyter kernel to execute your code and gather its results.
+Choosing different kernel specs in JupyterNotebook helps the user to flexibly switch the package environments and programming languages(for example, use R or Julia in the Notebook).
+Similarly, we can also switch the kernel spec in MyST building.
+
+### Setting in the frontmatter
+
+You could explicitly choose the kernel spec in the **page-level**  frontmatter of the markdown file.
+The following contents is a frontmatter sets the kernel spec to `python`:
+
+```yaml
+---
+# ... other sections of the frontmatter
+kernelspec:
+  name: python3
+  display_name: "Python 3"
+---
+```
+
+When we declare the frontmatter, all the contents in {myst:directive}`code-cell` and {myst:role}`eval` will be executed by the `python` kernel during the building process.
+
+Furthermore, you can build myst markdown content with other programming languages like JavaScript, R, and Julia by installing the corresponding kernel.
+For example, to build a page that uses JavaScript in the {myst:directive}`code-cell`, we could:
+1. Install the interactive JavaScript Kernel, like [ijavascript](https://github.com/n-riesco/ijavascript)
+2. To check the installation and the kernel name, run `jupyter kernelspec list`. In the default installation, the kernel name is `javascript`.
+3. Set the kernel spec in the frontmatter:
+```yaml
+---
+# ... other sections of the frontmatter
+kernelspec:
+  name: javascript
+  display_name: JavaScript
+---
+```
+
+then the code cell like the following section will get the correct result and render.
+
+````
+```{code-cell} javascript
+console.log("hello javascript kernel");
+```
+````
+
+The full options of the kernel spec field supported is a subsect of [jupyter kernelspec](https://jupyter-client.readthedocs.io/en/latest/kernels.html#kernelspecs).
+They are:
+
+```yaml
+kernelspec:
+  name: python3 # required, the name of the kernel. can be found by `jupyter kernelspec list`
+  display_name: "Python3 Kernel" # required, the display name of the kernel.
+  language: python # optional, the language of the kernel, used for syntax highlight
+  env: {} # optional, A dictionary of environment variables to set for the kernel
+  argv: # optional, A list of command line arguments used to start the kernel
+```
+
+## Compatibility with jupytext
+
+[jupytext](https://github.com/mwouts/jupytext) is a python package that makes some conventions to get the notebook-like experience in plain text documents.
+It provides a JupyterBook extension to render those documents and an command tool to convert the plain text documents to the `.ipynb` notebook.
+MyST is also supported by jupytext, and some of our users could use jupytext to write the draft MyST markdown files and do the conversion in different file formats.
+The following command will convert the MyST markdown file to the `.ipynb` notebook, which could be helpful when you want to check the execution results and modify some code cells in the myst with a local jupyter notebook.
+
+```shell
+$ jupytext --from md:myst --to notebook <path_to_the_md_document>
+```
+
+### Kernel spec in jupytext
+
+In myst CLI, it will do the auto-filling if there is the missing `name` or missing `display_name`.
+But they are required by jupytext to do the rendering and conversion.
+So we will raise a warning when the `name` or `display_name` is missing and suggest setting both `name` and `display_name` in the kernel spec.
+
+### Cell Block breaking
+
+The notebook converted by jupytext will only put cell partitions in code-cell and other markdown parts.
+But in some common practice, it would be nice to separate long markdown contents into serval cell blocks.
+As section [](./blocks.md) suggests, you could put `+++` in some proper positions in the file to get a better separated `.ipynb` notebook converted by jupytext.


### PR DESCRIPTION
Add the a section about kernel spec and a section about jupytext. following issue #1372