### PR TITLE
🌍 Add `LanguageInfo` to frontmatter

### DIFF
--- a/.changeset/fair-colts-design.md
+++ b/.changeset/fair-colts-design.md
@@ -1,6 +1,6 @@
 ---
-"myst-frontmatter": patch
-"myst-cli": patch
+'myst-frontmatter': patch
+'myst-cli': patch
 ---
 
 Add support for `language_info` frontmatter

--- a/.changeset/fair-colts-design.md
+++ b/.changeset/fair-colts-design.md
@@ -1,0 +1,6 @@
+---
+"myst-frontmatter": patch
+"myst-cli": patch
+---
+
+Add support for `language_info` frontmatter

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -232,7 +232,9 @@ export async function transformMdast(
   transformFilterOutputStreams(mdast, vfile, frontmatter.settings);
   transformCitations(session, file, mdast, fileCitationRenderer, references);
   await unified()
-    .use(codePlugin, { lang: frontmatter?.kernelspec?.language })
+    .use(codePlugin, {
+      lang: frontmatter?.language_info?.name ?? frontmatter?.kernelspec?.language,
+    })
     .use(footnotesPlugin) // Needs to happen near the end
     .run(mdast, vfile);
   transformImagesToEmbed(mdast);

--- a/packages/myst-frontmatter/src/languageInfo/languageInfo.yml
+++ b/packages/myst-frontmatter/src/languageInfo/languageInfo.yml
@@ -1,0 +1,25 @@
+title: Language Info
+cases:
+  - title: empty object throws errors
+    raw:
+      language_info: {}
+    normalized: {}
+    errors: 1
+  - title: full object returns self
+    raw:
+      language_info:
+        name: python
+    normalized:
+      language_info:
+        name: python
+  - title: extra keys removed
+    raw:
+      language_info:
+        extra: ''
+        name: python
+        other: Python is snakey
+    normalized:
+      language_info:
+        name: python
+    warnings: 1
+ 

--- a/packages/myst-frontmatter/src/languageInfo/languageInfo.yml
+++ b/packages/myst-frontmatter/src/languageInfo/languageInfo.yml
@@ -22,4 +22,3 @@ cases:
       language_info:
         name: python
     warnings: 1
- 

--- a/packages/myst-frontmatter/src/languageInfo/types.ts
+++ b/packages/myst-frontmatter/src/languageInfo/types.ts
@@ -1,0 +1,4 @@
+export type LanguageInfo = {
+  name: string;
+};
+

--- a/packages/myst-frontmatter/src/languageInfo/types.ts
+++ b/packages/myst-frontmatter/src/languageInfo/types.ts
@@ -1,4 +1,3 @@
 export type LanguageInfo = {
   name: string;
 };
-

--- a/packages/myst-frontmatter/src/languageInfo/validators.ts
+++ b/packages/myst-frontmatter/src/languageInfo/validators.ts
@@ -1,0 +1,19 @@
+import type { ValidationOptions } from 'simple-validators';
+import { incrementOptions, validateObjectKeys, validateString } from 'simple-validators';
+import type { LanguageInfo } from './types.js';
+
+/**
+ * Validate LanguageInfo object
+ */
+export function validateLanguageInfo(
+  input: any,
+  opts: ValidationOptions,
+): LanguageInfo | undefined {
+  const value = validateObjectKeys(input, { required: ['name'] }, opts);
+  if (value === undefined) return undefined;
+
+  const name = validateString(value.name, incrementOptions('name', opts));
+  if (name === undefined) return undefined;
+
+  return { name };
+}

--- a/packages/myst-frontmatter/src/page/types.ts
+++ b/packages/myst-frontmatter/src/page/types.ts
@@ -1,5 +1,6 @@
 import type { Jupytext } from '../jupytext/types.js';
 import type { KernelSpec } from '../kernelspec/types.js';
+import type { LanguageInfo } from '../languageInfo/types.js';
 import type { ProjectAndPageFrontmatter } from '../project/types.js';
 import { PROJECT_AND_PAGE_FRONTMATTER_KEYS } from '../project/types.js';
 
@@ -8,6 +9,7 @@ export const PAGE_FRONTMATTER_KEYS = [
   // These keys only exist on the page
   'label',
   'kernelspec',
+  'language_info',
   'jupytext',
   'tags',
   'content_includes_title',
@@ -16,6 +18,7 @@ export const PAGE_FRONTMATTER_KEYS = [
 export type PageFrontmatter = ProjectAndPageFrontmatter & {
   label?: string;
   kernelspec?: KernelSpec;
+  language_info?: LanguageInfo;
   jupytext?: Jupytext;
   tags?: string[];
   /** Flag if frontmatter title is duplicated in content

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -9,6 +9,7 @@ import {
 import { validateProjectAndPageFrontmatterKeys } from '../project/validators.js';
 import { PAGE_FRONTMATTER_KEYS, type PageFrontmatter } from './types.js';
 import { validateKernelSpec } from '../kernelspec/validators.js';
+import { validateLanguageInfo } from '../languageInfo/validators.js';
 import { validateJupytext } from '../jupytext/validators.js';
 import { FRONTMATTER_ALIASES } from '../site/types.js';
 
@@ -41,6 +42,9 @@ export function validatePageFrontmatterKeys(value: Record<string, any>, opts: Va
   }
   if (defined(value.kernelspec)) {
     output.kernelspec = validateKernelSpec(value.kernelspec, incrementOptions('kernelspec', opts));
+  }
+  if (defined(value.language_info)) {
+    output.language_info = validateLanguageInfo(value.language_info, incrementOptions('langage_info', opts));
   }
   if (defined(value.jupytext)) {
     output.jupytext = validateJupytext(value.jupytext, incrementOptions('jupytext', opts));

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -44,7 +44,10 @@ export function validatePageFrontmatterKeys(value: Record<string, any>, opts: Va
     output.kernelspec = validateKernelSpec(value.kernelspec, incrementOptions('kernelspec', opts));
   }
   if (defined(value.language_info)) {
-    output.language_info = validateLanguageInfo(value.language_info, incrementOptions('langage_info', opts));
+    output.language_info = validateLanguageInfo(
+      value.language_info,
+      incrementOptions('langage_info', opts),
+    );
   }
   if (defined(value.jupytext)) {
     output.jupytext = validateJupytext(value.jupytext, incrementOptions('jupytext', opts));


### PR DESCRIPTION
Recently, I authored #1490 to ensure that we don't break `jupytext` by having a frontmatter schema that is too loose. This PR is slightly different.

I've been noticing the "undefined language" warning during testing of execution. It turns out that [we look for a `language` key in `kernelspec`](https://github.com/jupyter-book/mystmd/blob/a6b59d6b88ecdce5b3231d18bebf336ebd871a74/packages/myst-cli/src/process/mdast.ts#L235) as a default for this field. When hand-authoring notebooks, I do not define such a field. I looked at the nbformat spec, and they don't define this value; it probably comes from JupyterLab. So, I think we should look to read an additional _well-specified_ field, and probably better to use one that _is_ defined in the schema rather than push harder on `kernelspec.language`.[^why]

> [!NOTE]
> My short reasoning is:
> 1. `language` of code-cells is related to the kernel
> 2. `nbformat` defines a proper place for this to live
> 3. Let's follow `nbformat` for ease & simpler down-stream conversion of md:myst documents to ipynb etc.

Thus, this PR adds support for validating `language_info` from nbformat:
https://github.com/jupyter/nbformat/blob/ba2c6f53afbeb18f6fad0c9b9f67def34e757cb4/nbformat/v4/nbformat.v4.5.schema.json#L33

> [!TIP]
> `language_info` also captures the language _version_ e.g. for Python: `3.12.0`
> For now, I didn't validate that, but it might be useful when reading `ipynb` files.

More broadly than this PR, we do need to be mindful of _why_ we are adopting external frontmatter schemas, with consideration of _who_ is ingesting our frontmatter. In my view, there are two cases:
1. Where we are the only consumers of MyST frontmatter. There, we should (in my view) opt for permissive-but-validatable definitions, and adopting external schemas is merely a good idea from the perspective of building on the shoulders of giants, or using external tools (like `jupyter server`). 
2. Where we are _not_ the only clients, e.g. `jupytext`. There, we need to ensure that they can read our metadata. 

RE (2): Jupytext _right now_ doesn't apply all the transforms to frontmatter that we do. Thus, we can end up in situations where `jupytext` either fails to validate (or actually, produces _invalid_ notebooks) e.g. the `authors` field set to a list of strings.

Finally, it's worth thinking about the distinction between hand-authored metadata, and programmatically generated metadata. `nbformat` does not distinguish between the two, but it's highly likely that `authors` is hand-authored whilst `language_info` is not (as it comes from the kernel).

[^why]: whilst `kernelspec.language` is fine, others could write something there that we don't want, precisely because it is not specified.