### PR TITLE
🤖 Add `flake.nix` for Nix users

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725103162,
+        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,3 @@
-# in flake.nix
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,12 @@
                 with ps; [
                   jupyter-server
                   ipykernel
-		  # Computation modules
+                  # Computation modules
                   jupytext
-		  altair
-		  matplotlib
-		  vega-datasets
-		  numpy
+                  altair
+                  matplotlib
+                  vega-datasets
+                  numpy
                 ]))
               pkgs.texliveMedium
               pkgs.libwebp

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,12 @@
                 with ps; [
                   jupyter-server
                   ipykernel
+		  # Computation modules
+                  jupytext
+		  altair
+		  matplotlib
+		  vega-datasets
+		  numpy
                 ]))
               pkgs.texliveMedium
               pkgs.libwebp

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+# in flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem
+    (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+        with pkgs; {
+          devShells.default = mkShell {
+            buildInputs = [
+              pkgs.nodejs_22
+              (pkgs.python3.withPackages (ps:
+                with ps; [
+                  jupyter-server
+                  ipykernel
+                ]))
+              pkgs.texliveMedium
+              pkgs.libwebp
+              pkgs.imagemagick
+            ];
+          };
+        }
+    );
+}


### PR DESCRIPTION
This is a dev PR that adds `flake.nix` for Nix users. This makes it as easy to start running/developing MyST as `nix develop`. 

> [!NOTE]
> Developers will need to modify their NodeJS prefix in order for `myst` to be found on `PATH`

I will take responsibility for keeping this up to date, and it's only intended as a convenience for developers.