### PR TITLE
👷 Check `platform.system` to fix `myst` on Windows

### DIFF
--- a/packages/mystmd-py/src/mystmd_py/main.py
+++ b/packages/mystmd-py/src/mystmd_py/main.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import platform
 import shutil
 import subprocess
 import sys
@@ -35,11 +36,18 @@ def main():
             "Please update to the latest LTS release, using your preferred package manager\n"
             "or following instructions here: https://nodejs.org/en/download"
         )
-    os.execve(
-        node,
-        [node.name, PATH_TO_BIN_JS, *sys.argv[1:]],
-        {**os.environ, "MYST_LANG": "PYTHON"},
-    )
+
+    node_args = [PATH_TO_BIN_JS, *sys.argv[1:]]
+    node_env = {**os.environ, "MYST_LANG": "PYTHON"}
+    if platform.system() == "Windows":
+        result = subprocess.run([node, *node_args], env=node_env)
+        sys.exit(result.returncode)
+    else:
+        os.execve(
+            node,
+            [node.name, *node_args],
+            node_env,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We use `os.exec` to make the MyST binary an invisible wrapper after startup. However, on Windows this doesn't work as intended. So, this PR sets up a subprocess on Windows instead.

Fixes https://github.com/jupyter-book/mystmd/issues/1425