### PR TITLE
🧟‍♀️ Revive link-block directive to create linkBlock node

### DIFF
--- a/.changeset/nasty-cougars-smile.md
+++ b/.changeset/nasty-cougars-smile.md
@@ -1,0 +1,6 @@
+---
+'myst-directives': patch
+'myst-transforms': patch
+---
+
+Revive link-block directive to create linkBlock node

--- a/packages/myst-directives/src/index.ts
+++ b/packages/myst-directives/src/index.ts
@@ -8,6 +8,7 @@ import { iframeDirective } from './iframe.js';
 import { imageDirective } from './image.js';
 import { includeDirective } from './include.js';
 import { indexDirective, genIndexDirective } from './indices.js';
+import { linkBlockDirective } from './links.js';
 import { csvTableDirective, tableDirective, listTableDirective } from './table.js';
 import { asideDirective } from './aside.js';
 import { glossaryDirective } from './glossary.js';
@@ -34,6 +35,7 @@ export const defaultDirectives = [
   includeDirective,
   indexDirective,
   genIndexDirective,
+  linkBlockDirective,
   tableDirective,
   listTableDirective,
   asideDirective,
@@ -59,6 +61,7 @@ export { iframeDirective } from './iframe.js';
 export { imageDirective } from './image.js';
 export { includeDirective } from './include.js';
 export { indexDirective, genIndexDirective } from './indices.js';
+export { linkBlockDirective } from './links.js';
 export { csvTableDirective, listTableDirective, tableDirective } from './table.js';
 export { asideDirective } from './aside.js';
 export { mathDirective } from './math.js';

--- a/packages/myst-directives/src/links.ts
+++ b/packages/myst-directives/src/links.ts
@@ -1,0 +1,39 @@
+import type { DirectiveSpec, DirectiveData, GenericNode, GenericParent } from 'myst-common';
+import type { FlowContent, ListContent, PhrasingContent } from 'myst-spec';
+
+export const linkBlockDirective: DirectiveSpec = {
+  name: 'link-block',
+  arg: {
+    type: String,
+    doc: 'Link block URL',
+    required: true,
+  },
+  options: {
+    title: {
+      type: String,
+      doc: 'Link title',
+    },
+    // thumbnail: {
+    //   type: String,
+    //   doc: 'Path to link thumbnail',
+    // },
+  },
+  body: {
+    type: 'myst',
+  },
+  run(data: DirectiveData): GenericNode[] {
+    const linkBlock: GenericParent = {
+      type: 'linkBlock',
+      url: data.arg,
+      title: data.options?.title,
+      thumbnail: data.options?.thumbnail,
+      children: [],
+    };
+    if (data.body) {
+      linkBlock.children = [
+        ...(data.body as unknown as (FlowContent | ListContent | PhrasingContent)[]),
+      ];
+    }
+    return [linkBlock];
+  },
+};

--- a/packages/myst-transforms/src/links/check.ts
+++ b/packages/myst-transforms/src/links/check.ts
@@ -29,7 +29,7 @@ export function checkLinkTextTransform(
           note: key ? `You need an entry in your project references with key "${key}"` : undefined,
         });
       }
-    } else if (!toText(node.children) && !select('image', node)) {
+    } else if (!toText(node.children) && !select('image', node) && !node.title) {
       fileWarn(
         vfile,
         `Link text is empty for <${node.urlSource ?? node.url}${node.identifier ? `#${node.identifier}` : ''}>`,


### PR DESCRIPTION
The `link-block` directive used to exist, see this commit: https://github.com/jupyter-book/mystmd/commit/920c087ccf092bbf57c65833e139e34ee913e63d but somewhere in the monorepo refactor I believe it was lost.

There is still lingering support for `linkBlock` nodes in `mystmd`, e.g. https://github.com/jupyter-book/mystmd/blob/main/packages/myst-cli/src/process/mdast.ts#L83, and in `myst-theme`, https://github.com/jupyter-book/myst-theme/blob/main/packages/myst-to-react/src/links/index.tsx#L108

This PR revives the `link-block` directive to create `linkBlock` nodes. The `url` is required as directive arg, and `title` option and description in the body are optional.

![image](https://github.com/user-attachments/assets/1e8956dc-3a6e-47c0-838b-646ad5db17e1)
