### PR TITLE
👩‍💻 Allow index entries on many more node types for myst-to-tex

### DIFF
--- a/.changeset/unlucky-timers-clap.md
+++ b/.changeset/unlucky-timers-clap.md
@@ -1,0 +1,5 @@
+---
+'myst-to-tex': patch
+---
+
+Allow index entries on many more nodes for myst-to-tex

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -118,6 +118,7 @@ const handlers: Record<string, Handler> = {
     state.text(node.value);
   },
   paragraph(node, state) {
+    addIndexEntries(node, state);
     state.renderChildren(node);
   },
   heading(node: Heading, state) {
@@ -177,9 +178,11 @@ const handlers: Record<string, Handler> = {
       state.write('\\printindex\n');
       return;
     }
+    addIndexEntries(node, state);
     state.renderChildren(node, false);
   },
   blockquote(node, state) {
+    addIndexEntries(node, state);
     state.renderEnvironment(node, 'quote');
   },
   definitionList(node, state) {
@@ -202,6 +205,7 @@ const handlers: Record<string, Handler> = {
     if (node.visibility === 'remove') {
       return;
     }
+    addIndexEntries(node, state);
     let start = '\\begin{verbatim}\n';
     let end = '\n\\end{verbatim}';
 
@@ -223,6 +227,7 @@ const handlers: Record<string, Handler> = {
     state.closeBlock(node);
   },
   list(node, state) {
+    addIndexEntries(node, state);
     if (state.data.isInTable) {
       node.children.forEach((child: any, i: number) => {
         state.write(node.ordered ? `${i}.~~` : '\\textbullet~~');
@@ -253,6 +258,7 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node, false);
   },
   div(node, state) {
+    addIndexEntries(node, state);
     state.renderChildren(node, false);
   },
   span(node, state) {
@@ -341,6 +347,7 @@ const handlers: Record<string, Handler> = {
     state.write('}');
   },
   admonition(node, state) {
+    addIndexEntries(node, state);
     state.usePackages('framed');
     state.renderEnvironment(node, 'framed');
   },
@@ -350,6 +357,7 @@ const handlers: Record<string, Handler> = {
   },
   table: renderNodeToLatex,
   image(node, state) {
+    addIndexEntries(node, state);
     state.usePackages('graphicx');
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { width: nodeWidth, url: nodeSrc, align: nodeAlign } = node;

--- a/packages/myst-to-tex/src/math.ts
+++ b/packages/myst-to-tex/src/math.ts
@@ -1,4 +1,5 @@
 import type { Handler, ITexSerializer, SimplifiedMathPlugins } from './types.js';
+import { addIndexEntries } from './utils.js';
 
 // Top level environments in amsmath version 2.1 (and eqnarray), see:
 // http://anorien.csc.warwick.ac.uk/mirrors/CTAN/macros/latex/required/amsmath/amsldoc.pdf
@@ -82,6 +83,7 @@ const math: Handler = (node, state) => {
   }
   state.usePackages('amsmath');
   addMacrosToState(node.value, state);
+  addIndexEntries(node, state);
   if (state.data.isInTable) {
     state.write('\\(\\displaystyle ');
     state.write(node.value);

--- a/packages/myst-to-tex/src/proof.ts
+++ b/packages/myst-to-tex/src/proof.ts
@@ -5,6 +5,7 @@ import type { ProofContainer, ProofKind } from 'myst-ext-proof';
 import { select } from 'unist-util-select';
 import { remove } from 'unist-util-remove';
 import type { Handler } from './types.js';
+import { addIndexEntries } from './utils.js';
 
 function kindToEnvironment(kind: ProofKind): string {
   switch (kind) {
@@ -55,7 +56,7 @@ export const proofHandler: Handler = (node, state) => {
     t.type = '__delete__';
   }
   const newNode = remove(node, '__delete__') as GenericNode;
-
+  addIndexEntries(node, state);
   state.write('\\begin{');
   state.write(env);
   state.write('}');

--- a/packages/myst-to-tex/src/tables.ts
+++ b/packages/myst-to-tex/src/tables.ts
@@ -1,5 +1,6 @@
 import type { Table, TableRow, TableCell as SpecTableCell } from 'myst-spec';
 import type { ITexSerializer } from './types.js';
+import { addIndexEntries } from './utils.js';
 
 export const TOTAL_TABLE_WIDTH = 886;
 
@@ -101,6 +102,7 @@ export function renderNodeToLatex(node: Table, state: ITexSerializer) {
   if (!numColumns) {
     throw new Error('invalid table format, no columns');
   }
+  addIndexEntries(node, state);
   state.data.isInTable = true; // this is cleared at the end of this function
   if (!state.data.isInContainer) {
     state.write('\\bigskip\\noindent');


### PR DESCRIPTION
Previously, index entries only showed up in `pdf` exports if they were defined above headings or figures. For example, this would create an index entry:

````
```{index} my topic
```
# My Topic

Let me talk about my topic.
````

But this would _not_ create an index entry:

````
# My Topic

```{index} my topic
```
Let me talk about my topic.
````

This PR adds PDF index entry creation on many more node types, meaning users can insert their index entries exactly where they want without worrying they will be lost.