### PR TITLE
🪪 Allow custom licenses outside SPDX

### DIFF
--- a/.changeset/orange-dingos-promise.md
+++ b/.changeset/orange-dingos-promise.md
@@ -1,0 +1,6 @@
+---
+'myst-to-md': patch
+'myst-cli': patch
+---
+
+Consume new license simplification function

--- a/.changeset/unlucky-ties-reflect.md
+++ b/.changeset/unlucky-ties-reflect.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Allow custom licenses outside SPDX

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -636,7 +636,7 @@ This field can be set to a string value directly or to a License object.
 
 Available fields in the License object are `content` and `code` allowing licenses to be set separately for these two forms of content, as often different subsets of licenses are applicable to each. If you only wish to apply a single license to your page or project use the string form rather than an object.
 
-String values for licenses should be a valid “Identifier” string from the [SPDX License List](https://spdx.org/licenses/). Identifiers for well-known licenses are easily recognizable (e.g. `MIT` or `BSD`) and MyST will attempt to infer the specific identifier if an ambiguous license is specified (e.g. `GPL` will be interpreted as `GPL-3.0+` and a warning raised letting you know of this interpretation). Some common licenses are:
+If selecting a license from the [SPDX License List](https://spdx.org/licenses/), you may simply use the “Identifier” string; MyST will expand these identifiers into objects with `name`, `url`, and additional metadata related to open access ([OSI-approved](https://opensource.org/licenses), [FSF free](https://www.gnu.org/licenses/license-list.en.html), and [CC](https://creativecommons.org/)). Identifiers for well-known licenses are easily recognizable (e.g. `MIT` or `BSD`) and MyST will attempt to infer the specific identifier if an ambiguous license is specified (e.g. `GPL` will be interpreted as `GPL-3.0+` and a warning raised letting you know of this interpretation). Some common licenses are:
 
 ```{list-table}
 :header-rows: 1
@@ -658,7 +658,25 @@ String values for licenses should be a valid “Identifier” string from the [S
     - `AGPL`
 ```
 
-By using the correct SPDX Identifier, your website will automatically use the appropriate icon for the license and link to the license definition.
+By using the correct SPDX Identifier, your website will automatically use the appropriate icon for the license and link to the license definition.  The simplest and most common example is something like:
+
+```yaml
+license: CC-BY-4.0
+```
+
+### Nonstandard licenses
+
+Although not recommended, you may specify nonstandard licenses not found on the SPDX License List. For these, you may provide an object where available fields are `id`, `name`, `url`, and `note`. You can also extend the default SPDX Licenses by providing modified values for these fields. Here is a more complex example where content and code have different licenses; content uses an SPDX License with an additional note, and code uses a totally custom license.
+
+```yaml
+license:
+  content:
+    id: CC-BY-4.0
+    note: When attributing this content, please indicate the Source was MyST Documentation.
+  code:
+    name: I Am Not A Lawyer License
+    url: https://example.com/i-am-not-a-lawyer
+```
 
 (frontmatter:funding)=
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9964,9 +9964,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -15600,7 +15600,8 @@
         "@types/spdx-correct": "^3.1.0",
         "glob": "^10.3.1",
         "js-yaml": "^4.1.0",
-        "moment": "^2.29.4"
+        "moment": "^2.29.4",
+        "node-fetch": "^3.3.2"
       }
     },
     "packages/myst-parser": {

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -3,7 +3,7 @@ import type { Export, Licenses, PageFrontmatter } from 'myst-frontmatter';
 import {
   validateExportsList,
   fillPageFrontmatter,
-  licensesToString,
+  simplifyLicenses,
   unnestKernelSpec,
   validatePageFrontmatter,
 } from 'myst-frontmatter';
@@ -102,7 +102,7 @@ export function processPageFrontmatter(
 
 export function prepareToWrite(frontmatter: { license?: Licenses }) {
   if (!frontmatter.license) return { ...frontmatter };
-  return { ...frontmatter, license: licensesToString(frontmatter.license) };
+  return { ...frontmatter, license: simplifyLicenses(frontmatter.license) };
 }
 
 export function getExportListFromRawFrontmatter(

--- a/packages/myst-frontmatter/package.json
+++ b/packages/myst-frontmatter/package.json
@@ -43,6 +43,7 @@
     "@types/spdx-correct": "^3.1.0",
     "glob": "^10.3.1",
     "js-yaml": "^4.1.0",
-    "moment": "^2.29.4"
+    "moment": "^2.29.4",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/packages/myst-frontmatter/src/licenses/licenses.yml
+++ b/packages/myst-frontmatter/src/licenses/licenses.yml
@@ -1,5 +1,33 @@
 title: Licenses
 cases:
+  - title: non-spdx string warns
+    raw:
+      license: ''
+    normalized:
+      license:
+        content:
+          id: ''
+    warnings: 1
+  - title: non-spdx string under content warns
+    raw:
+      license:
+        content: ''
+    normalized:
+      license:
+        content:
+          id: ''
+    warnings: 1
+  - title: Empty license returns empty
+    raw:
+      license: {}
+    normalized: {}
+    warnings: 1
+  - title: Empty content returns empty
+    raw:
+      license:
+        content: {}
+    normalized: {}
+    warnings: 1
   - title: Valid License
     raw:
       license: CC-BY-4.0
@@ -11,7 +39,127 @@ cases:
           url: https://creativecommons.org/licenses/by/4.0/
           CC: true
           free: true
-  - title: Correct license (cc-by)
+  - title: Valid License under content
+    raw:
+      license:
+        content: CC-BY-4.0
+    normalized:
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
+  - title: Valid License under code
+    raw:
+      license:
+        code: CC-BY-4.0
+    normalized:
+      license:
+        code:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
+  - title: Matching code and content coerces
+    raw:
+      license:
+        content: CC-BY-4.0
+        code: CC-BY-4.0
+    normalized:
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
+  - title: Code and content coerce individually
+    raw:
+      license:
+        content: CC-BY-4.0
+        code: CC-BY-3.0
+    normalized:
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
+        code:
+          id: CC-BY-3.0
+          name: Creative Commons Attribution 3.0 Unported
+          url: https://creativecommons.org/licenses/by/3.0/
+          CC: true
+  - title: Note passes with coerced license
+    raw:
+      license:
+        content:
+          id: CC-BY-4.0
+          note: I love CC licenses!
+    normalized:
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
+          note: I love CC licenses!
+  - title: Valid object passes to content
+    raw:
+      license:
+        id: CC-BY-4.0
+        name: Creative Commons Attribution 4.0 International
+        url: https://creativecommons.org/licenses/by/4.0/
+        CC: true
+        free: true
+    normalized:
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
+  - title: Valid content object passes
+    raw:
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
+    normalized:
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
+  - title: Valid code object passes
+    raw:
+      license:
+        code:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
+    normalized:
+      license:
+        code:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
+  - title: Correct license (cc-by) coerces
     raw:
       license: cc-by
     normalized:
@@ -23,7 +171,7 @@ cases:
           CC: true
           free: true
     warnings: 1
-  - title: Correct licenses (gpl)
+  - title: Correct licenses (gpl) coerces
     raw:
       license: gpl
     normalized:
@@ -31,7 +179,132 @@ cases:
         content:
           id: GPL-3.0-or-later
           name: GNU General Public License v3.0 or later
-          url: https://opensource.org/licenses/GPL-3.0-or-later
+          url: https://opensource.org/licenses/GPL-3.0
           osi: true
           free: true
+    warnings: 1
+  - title: Correct licenses (apache 2) coerces
+    raw:
+      license: apache 2
+    normalized:
+      license:
+        content:
+          id: Apache-2.0
+          name: Apache License 2.0
+          url: https://opensource.org/licenses/Apache-2.0
+          free: true
+          osi: true
+    warnings: 1
+  - title: Invalid license content under correct id warns
+    raw:
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 Wrong Name
+          url: https://example.com
+    normalized:
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 Wrong Name
+          url: https://example.com
+          CC: true
+          free: true
+    warnings: 2
+  - title: Id not in spdx warns
+    raw:
+      license:
+        content:
+          id: my-custom-license
+    normalized:
+      license:
+        content:
+          id: my-custom-license
+    warnings: 1
+  - title: Non-spdx validates as custom license
+    raw:
+      license:
+        id: my-custom-license
+        url: https://example.com
+        note: I just made up this license!
+    normalized:
+      license:
+        content:
+          id: my-custom-license
+          url: https://example.com
+          note: I just made up this license!
+    warnings: 1
+  - title: OSI/free/CC fields warn for custom license if true
+    raw:
+      license:
+        content:
+          id: my-content-license
+          osi: true
+          free: true
+          cc: true
+        code:
+          id: my-code-license
+          osi: false
+          free: false
+          cc: false
+    normalized:
+      license:
+        content:
+          id: my-content-license
+        code:
+          id: my-code-license
+          osi: false
+          free: false
+          CC: false
+    warnings: 5
+  - title: CC passes for custom creativecommons license
+    raw:
+      license:
+        id: CC-BY-3.14
+        name: Creative Commons Pi License
+        url: http://creativecommons.org/licenses/pi
+        cc: true
+    normalized:
+      license:
+        content:
+          id: CC-BY-3.14
+          name: Creative Commons Pi License
+          url: http://creativecommons.org/licenses/pi
+          CC: true
+    warnings: 1
+  - title: url coerces to license (and warns)
+    raw:
+      license: https://example.com
+    normalized:
+      license:
+        content:
+          url: https://example.com
+    warnings: 1
+  - title: string with no spaces coerces to unknown id (and warns)
+    raw:
+      license: my-custom-license
+    normalized:
+      license:
+        content:
+          id: my-custom-license
+    warnings: 1
+  - title: Other short string coerces to note (and warns)
+    raw:
+      license: |
+        my custom license but this is really long, like, more than one hundred characters long.
+        clearly if it is this long it cannot be a name but must be a note.
+    normalized:
+      license:
+        content:
+          note: |
+            my custom license but this is really long, like, more than one hundred characters long.
+            clearly if it is this long it cannot be a name but must be a note.
+    warnings: 1
+  - title: Other long string coerces to name (and warns)
+    raw:
+      license: my custom license
+    normalized:
+      license:
+        content:
+          name: my custom license
     warnings: 1

--- a/packages/myst-frontmatter/src/licenses/types.ts
+++ b/packages/myst-frontmatter/src/licenses/types.ts
@@ -1,7 +1,9 @@
 export type License = {
-  name: string;
-  url: string;
-  id: string;
+  id?: string;
+  name?: string;
+  url?: string;
+  note?: string;
+  // These are only allowed if license is from SPDX
   free?: boolean;
   CC?: boolean;
   osi?: boolean;

--- a/packages/myst-frontmatter/src/licenses/validators.ts
+++ b/packages/myst-frontmatter/src/licenses/validators.ts
@@ -5,7 +5,8 @@ import {
   incrementOptions,
   validateObjectKeys,
   validateString,
-  validationError,
+  validateUrl,
+  validateBoolean,
 } from 'simple-validators';
 import spdxCorrect from 'spdx-correct';
 import LICENSES from './licenses.js';
@@ -19,9 +20,9 @@ function correctLicense(license?: string): string | undefined {
   return undefined;
 }
 
-function createURL(license: Omit<License, 'url'>): string {
-  if (license.CC) {
-    const match = /^([CBYSAND0-]+)(?:(?:-)([0-9].[0-9]))?(?:(?:-)([A-Z]{2}))?$/.exec(license.id);
+function createURL(id: string, cc?: boolean, osi?: boolean): string {
+  if (cc) {
+    const match = /^([CBYSAND0ZEROPD-]+)(?:(?:-)([0-9].[0-9]))?(?:(?:-)([A-Z]{2,3}))?$/.exec(id);
     if (!match) {
       throw new Error('Creative Commons license not found');
     }
@@ -62,55 +63,160 @@ function createURL(license: Omit<License, 'url'>): string {
     if (extra) link += `${extra}/`;
     return `https://creativecommons.org/licenses${link}`;
   }
-  if (license.osi) {
-    return `https://opensource.org/licenses/${license.id}`;
+  if (osi) {
+    return `https://opensource.org/licenses/${id.replace(/(-or-later)|(-only)$/, '')}`;
   }
-  return `https://spdx.org/licenses/${license.id}`;
+  return `https://spdx.org/licenses/${id}`;
 }
+
+function cleanUrl(url: string) {
+  return url.replace(/^http:/, 'https:').replace(/\/$/, '');
+}
+
+function isUrl(url: string) {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol.includes('http');
+  } catch (error) {
+    return false;
+  }
+}
+
+const ID_LICENSE_LOOKUP: Record<string, License> = Object.fromEntries(
+  Object.entries(LICENSES).map(([key, value]) => {
+    return [key, { id: key, ...value, url: createURL(key, value.CC, value.osi) }];
+  }),
+);
+
+const URL_ID_LOOKUP: Record<string, string> = Object.fromEntries(
+  Object.values(ID_LICENSE_LOOKUP)
+    .filter((value): value is License & { url: string; id: string } => !!value.url && !!value.id)
+    .map((value) => {
+      return [cleanUrl(value.url), value.id];
+    }),
+);
 
 /**
  * Validate input to be known license id and return corresponding License object
  */
 export function validateLicense(input: any, opts: ValidationOptions): License | undefined {
-  if (typeof input === 'object') {
-    const revalidated = validateLicense(input.id, {
-      ...opts,
-      suppressErrors: true,
-      suppressWarnings: true,
-    });
-    let equal = Boolean(revalidated);
-    if (revalidated) {
-      Object.entries(revalidated).forEach(([key, val]) => {
-        if (val !== input[key]) equal = false;
-      });
+  if (typeof input === 'string') {
+    const value = validateString(input, opts);
+    if (value === undefined) return undefined;
+    const valueSpdx = correctLicense(value);
+    if (URL_ID_LOOKUP[cleanUrl(value)]) {
+      input = { id: URL_ID_LOOKUP[cleanUrl(value)] };
+    } else if (isUrl(value)) {
+      input = { url: value };
+    } else if (valueSpdx) {
+      input = { id: value };
+    } else if (value.match(/^[^\s]*$/)) {
+      input = { id: value };
+    } else if (value.length < 100) {
+      input = { name: value };
+    } else {
+      input = { note: value };
     }
-    if (!equal) {
-      return validationError(
-        `invalid license object - use a valid license ID string instead, see https://spdx.org/licenses/`,
+  }
+  const value = validateObjectKeys(
+    input,
+    {
+      optional: ['id', 'name', 'url', 'note', 'free', 'CC', 'osi'],
+      alias: { cc: 'CC' },
+    },
+    opts,
+  );
+  if (!value) return undefined;
+  const output: License = {};
+  if (value.id != null) {
+    const id = validateString(value.id, incrementOptions('id', opts));
+    const idSpdx = correctLicense(id);
+    if (!idSpdx) {
+      validationWarning(
+        `unknown license ID "${id}" - using a SPDX license ID is recommended, see https://spdx.org/licenses/`,
+        opts,
+      );
+    } else if (idSpdx !== id) {
+      validationWarning(
+        `The SPDX ID for the license is "${idSpdx}". Corrected from "${id}".`,
         opts,
       );
     }
-    return revalidated;
-  }
-  const valueUnvalidated = validateString(input, opts);
-  if (valueUnvalidated === undefined) return undefined;
-  // Correct expects a non-empty string
-  const value = correctLicense(valueUnvalidated);
-  if (!value) {
-    return validationError(
-      `invalid value "${valueUnvalidated}" - must be a valid license ID, see https://spdx.org/licenses/`,
-      opts,
-    );
-  }
-  if (value !== valueUnvalidated) {
+    output.id = idSpdx ?? id;
+  } else {
     validationWarning(
-      `The SPDX ID for the license is "${value}". Corrected from "${valueUnvalidated}".`,
+      `no license ID - using a SPDX license ID is recommended, see https://spdx.org/licenses/`,
       opts,
     );
   }
-  const spdx = { id: value, ...LICENSES[value] };
-  const url = createURL(spdx);
-  return { ...spdx, url };
+  const expected = output.id ? ID_LICENSE_LOOKUP[output.id] : undefined;
+  if (value.url != null) {
+    const urlOpts = incrementOptions('url', opts);
+    const url = validateUrl(value.url, urlOpts);
+    if (url && expected?.url && cleanUrl(url) !== cleanUrl(expected.url)) {
+      validationWarning(`incorrect URL for SPDX license ${expected.id} - "${url}"`, urlOpts);
+    }
+    output.url = url;
+  } else if (expected?.url) {
+    output.url = expected.url;
+  }
+  if (value.name != null) {
+    const nameOpts = incrementOptions('name', opts);
+    const name = validateString(value.name, nameOpts);
+    if (name && expected?.name && name !== expected.name) {
+      validationWarning(`incorrect name for SPDX license ${expected.id} - "${name}"`, nameOpts);
+    }
+    output.name = name;
+  } else if (expected?.name) {
+    output.name = expected.name;
+  }
+  if (value.note != null) {
+    output.note = validateString(value.note, incrementOptions('note', opts));
+  }
+  if (value.free != null) {
+    const freeOpts = incrementOptions('free', opts);
+    const free = validateBoolean(value.free, freeOpts);
+    if (free && !expected?.free) {
+      validationWarning(
+        'only SPDX licenses may specify they are "free" as listed by the FSF',
+        freeOpts,
+      );
+    } else {
+      output.free = free;
+    }
+  } else if (expected?.free != null) {
+    output.free = expected.free;
+  }
+  if (value.CC != null) {
+    const ccOpts = incrementOptions('CC', opts);
+    const cc = validateBoolean(value.CC, ccOpts);
+    if (
+      cc &&
+      !(expected?.CC || (output.url && new URL(output.url).host === 'creativecommons.org'))
+    ) {
+      validationWarning(
+        'only licenses that link to creativecommons.org may specify that they are "CC"',
+        ccOpts,
+      );
+    } else {
+      output.CC = cc;
+    }
+  } else if (expected?.CC != null) {
+    output.CC = expected.CC;
+  }
+  if (value.osi != null) {
+    const osiOpts = incrementOptions('osi', opts);
+    const osi = validateBoolean(value.osi, osiOpts);
+    if (osi && !expected?.osi) {
+      validationWarning('only SPDX licenses may specify they are "OSI approved"', osiOpts);
+    } else {
+      output.osi = osi;
+    }
+  } else if (expected?.osi != null) {
+    output.osi = expected.osi;
+  }
+  if (Object.keys(output).length === 0) return undefined;
+  return output;
 }
 
 /**
@@ -121,7 +227,10 @@ export function validateLicense(input: any, opts: ValidationOptions): License | 
  */
 export function validateLicenses(input: any, opts: ValidationOptions): Licenses | undefined {
   let contentOpts: ValidationOptions;
-  if (typeof input === 'string') {
+  if (
+    typeof input === 'string' ||
+    (typeof input === 'object' && input.content == null && input.code == null)
+  ) {
     input = { content: input };
     contentOpts = opts;
   } else {
@@ -132,14 +241,22 @@ export function validateLicenses(input: any, opts: ValidationOptions): Licenses 
   if (value === undefined) return undefined;
   const output: Licenses = {};
   if (defined(value.content)) {
-    output.content = validateLicense(value.content, contentOpts);
+    const content = validateLicense(value.content, contentOpts);
+    if (content) output.content = content;
   }
   if (defined(value.code) && value.code !== value.content) {
-    output.code = validateLicense(value.code, incrementOptions('code', opts));
+    const code = validateLicense(value.code, incrementOptions('code', opts));
+    if (code) output.code = code;
   }
+  if (Object.keys(output).length === 0) return undefined;
   return output;
 }
 
+/**
+ * Convert license object to either a single string or content/code strings
+ *
+ * This function only retains license ids, so it may lose other custom fields.
+ */
 export function licensesToString(licenses: Licenses) {
   const stringLicenses: { content?: string; code?: string } = {};
   if (licenses.content) {
@@ -152,4 +269,54 @@ export function licensesToString(licenses: Licenses) {
     stringLicenses.code = licenses.code.id;
   }
   return stringLicenses;
+}
+
+function removeExpectedKeys(license: License, expected: License): License {
+  const output: Record<string, any> = {};
+  Object.entries(license).forEach(([key, val]) => {
+    const licenseKey = key as keyof License;
+    if (licenseKey === 'id' || val !== expected[licenseKey]) {
+      output[licenseKey] = val;
+    }
+  });
+  if (Object.keys(output).length === 1 && output.id) return output.id;
+  return output as License;
+}
+
+function objectsEqual(a?: Record<string, any> | string, b?: Record<string, any> | string) {
+  if (a == null || b == null) return false;
+  const aAsString = typeof a === 'string' ? a : JSON.stringify(Object.entries(a).sort());
+  const bAsString = typeof b === 'string' ? b : JSON.stringify(Object.entries(b).sort());
+  return aAsString === bAsString;
+}
+
+/**
+ * Simplify license object as much as possible without losing any custom fields
+ */
+export function simplifyLicenses(
+  licenses: Licenses,
+): string | { content?: string | License; code?: string | License } {
+  const { content, code } = licenses;
+  const simplified: { content?: string | License; code?: string | License } = {};
+  if (content) {
+    if (content.id) {
+      simplified.content = removeExpectedKeys(content, ID_LICENSE_LOOKUP[content.id] ?? {});
+    } else {
+      simplified.content = { ...content };
+    }
+  }
+  if (code) {
+    if (code.id) {
+      simplified.code = removeExpectedKeys(code, ID_LICENSE_LOOKUP[code.id] ?? {});
+    } else {
+      simplified.code = { ...code };
+    }
+  }
+  if (objectsEqual(simplified.content, simplified.code)) {
+    delete simplified.code;
+  }
+  if (!simplified.code && typeof simplified.content === 'string') {
+    return simplified.content;
+  }
+  return simplified;
 }

--- a/packages/myst-frontmatter/src/page/page.yml
+++ b/packages/myst-frontmatter/src/page/page.yml
@@ -29,7 +29,7 @@ cases:
       doi: 10.1000/abcd/efg012
       arxiv: https://arxiv.org/example
       open_access: true
-      license: {}
+      license: CC-BY-4.0
       github: https://github.com/example
       binder: https://example.com/binder
       source: https://example.com/source
@@ -74,7 +74,13 @@ cases:
       doi: 10.1000/abcd/efg012
       arxiv: https://arxiv.org/example
       open_access: true
-      license: {}
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
       github: https://github.com/example
       binder: https://example.com/binder
       source: https://example.com/source

--- a/packages/myst-frontmatter/src/project/project.yml
+++ b/packages/myst-frontmatter/src/project/project.yml
@@ -31,7 +31,7 @@ cases:
       doi: 10.1000/abcd/efg012
       arxiv: https://arxiv.org/example
       open_access: true
-      license: {}
+      license: CC-BY-4.0
       github: https://github.com/example
       binder: https://example.com/binder
       source: https://example.com/source
@@ -80,7 +80,13 @@ cases:
       doi: 10.1000/abcd/efg012
       arxiv: https://arxiv.org/example
       open_access: true
-      license: {}
+      license:
+        content:
+          id: CC-BY-4.0
+          name: Creative Commons Attribution 4.0 International
+          url: https://creativecommons.org/licenses/by/4.0/
+          CC: true
+          free: true
       github: https://github.com/example
       binder: https://example.com/binder
       source: https://example.com/source

--- a/packages/myst-to-md/src/utils.ts
+++ b/packages/myst-to-md/src/utils.ts
@@ -2,7 +2,7 @@ import YAML from 'js-yaml';
 import type { Handle } from 'mdast-util-to-markdown';
 import { RuleId, fileError } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
-import { licensesToString } from 'myst-frontmatter';
+import { simplifyLicenses } from 'myst-frontmatter';
 import type { Root } from 'myst-spec';
 import { selectAll } from 'unist-util-select';
 import type { VFile } from 'vfile';
@@ -81,7 +81,7 @@ export function runValidators(tree: Root, validators: Record<string, Validator>,
 export function addFrontmatter(page: string, frontmatter?: PageFrontmatter) {
   if (!frontmatter || !Object.keys(frontmatter).length) return page;
   const fm = frontmatter.license
-    ? { ...frontmatter, license: licensesToString(frontmatter.license) }
+    ? { ...frontmatter, license: simplifyLicenses(frontmatter.license) }
     : { ...frontmatter };
   return `---\n${YAML.dump(fm)}---\n${page}`;
 }


### PR DESCRIPTION
Currently `license` values in MyST frontmatter are strict. They must be from the [SPDX license list](https://spdx.org/licenses/), referenced by ID, with no extra, custom information. This is probably how licenses _should_ be used - just pick a good, existing one and stick with that, don't try to embellish it or make up your own. However, in reality, this is not the case. Publishers, authors, etc often have their own license notes, urls for their license policies, or entirely new licenses.

This PR updates license validation in MyST to enable more flexibility when defining license.

First, you may define a license as an SPDX ID, as before. The behavior for this is unchanged: it will be automatically expanded to contain all the relevant license metadata, including name, url, OSI status, etc:

```yaml
license: CC-BY-4.0
```

And, as before, you may still separate `content` and `code` licenses - again, no changes to this.

```yaml
license:
  content: CC-BY-4.0
  code: MIT
```

However, you may now add your own `note` - in this case, other metadata will still be populated as before, alongside your note:

```yaml
license:
  id: CC-BY-4.0
  note: When attributing this content, please indicate the Source was MyST Documentation.
```

You may also override metadata fields - in this case, the new `url` will be used, but other metadata will be populated as before:

```yaml
license:
  id: CC-BY-4.0
  url: https://example.com/licenses/how-our-journal-uses-cc-by
```

Finally, you may define your own totally new license:

```yaml
license:
  id: im-not-a-lawyer
  name: I'm Not A Lawyer License
  url: https://example.com/licenses/these-wont-stand-up-in-court
```

Note, in cases all where you (1) do not use an SPDX license or (2) override default SPDX fields, MyST will raise a warning.