### PR TITLE
🏥 Add PubMed identifiers to frontmatter

### DIFF
--- a/.changeset/slimy-feet-sit.md
+++ b/.changeset/slimy-feet-sit.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Add pubmed identifiers to frontmatter

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -154,6 +154,12 @@ The following table lists the available frontmatter fields, a brief description 
 * - `arxiv`
   - a valid arXiv reference, either URL or id
   - page can override project
+* - `pmid`
+  - a valid PubMed ID, an integer
+  - page can override project
+* - `pmcid`
+  - a valid PubMed Central ID, a string 'PMC' followed by numeric digits
+  - page can override project
 * - `open_access`
   - boolean (true/false)
   - page can override project

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -20,6 +20,8 @@ export const USE_PROJECT_FALLBACK = [
   'date',
   'doi',
   'arxiv',
+  'pmid',
+  'pmcid',
   'open_access',
   'license',
   'github',

--- a/packages/myst-frontmatter/src/project/project.yml
+++ b/packages/myst-frontmatter/src/project/project.yml
@@ -236,3 +236,28 @@ cases:
         A: Abbreviation
     normalized: {}
     errors: 1
+  - title: pmcid validates
+    raw:
+      pmcid: PMC123
+    normalized:
+      pmcid: PMC123
+  - title: invalid pmcid errors
+    raw:
+      pmcid: '123'
+    normalized: {}
+    errors: 1
+  - title: pmid string validates
+    raw:
+      pmid: '123'
+    normalized:
+      pmid: 123
+  - title: pmid number validates
+    raw:
+      pmid: 123
+    normalized:
+      pmid: 123
+  - title: invalid pmid errors
+    raw:
+      pmid: 'abc'
+    normalized: {}
+    errors: 1

--- a/packages/myst-frontmatter/src/project/types.ts
+++ b/packages/myst-frontmatter/src/project/types.ts
@@ -24,6 +24,8 @@ export const PROJECT_AND_PAGE_FRONTMATTER_KEYS = [
   'date',
   'doi',
   'arxiv',
+  'pmid',
+  'pmcid',
   'open_access',
   'license',
   'binder',
@@ -62,6 +64,8 @@ export type ProjectAndPageFrontmatter = SiteFrontmatter & {
   date?: string;
   doi?: string;
   arxiv?: string;
+  pmid?: number;
+  pmcid?: string;
   open_access?: boolean;
   license?: Licenses;
   binder?: string;

--- a/packages/myst-frontmatter/src/project/validators.ts
+++ b/packages/myst-frontmatter/src/project/validators.ts
@@ -5,6 +5,7 @@ import {
   validateBoolean,
   validateDate,
   validateList,
+  validateNumber,
   validateObject,
   validateObjectKeys,
   validateString,
@@ -42,6 +43,19 @@ export function validateProjectAndPageFrontmatterKeys(
     output.arxiv = validateUrl(value.arxiv, {
       ...incrementOptions('arxiv', opts),
       includes: 'arxiv.org',
+    });
+  }
+  if (defined(value.pmid)) {
+    output.pmid = validateNumber(value.pmid, {
+      ...incrementOptions('pmid', opts),
+      integer: true,
+      min: 1,
+    });
+  }
+  if (defined(value.pmcid)) {
+    output.pmcid = validateString(value.pmcid, {
+      ...incrementOptions('pmcid', opts),
+      regex: '^PMC[0-9]+$',
     });
   }
   if (defined(value.open_access)) {


### PR DESCRIPTION
This PR just adds two more identifiers to frontmatter:

- `pmid` - PubMed ID, numeric value assigned to all PubMed records
- `pmcid` - PubMed Central ID, assigned to any records in the open-access PubMed Central database

These identifiers are added alongside existing identifiers `doi` and `arxiv`, and they are treated similarly during validation.