### PR TITLE
✊ Bump action versions.

### DIFF
--- a/.changeset/loud-parrots-rescue.md
+++ b/.changeset/loud-parrots-rescue.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Bump action versions.

--- a/docs/deployment-github-pages.md
+++ b/docs/deployment-github-pages.md
@@ -83,12 +83,12 @@ jobs:
       - name: Build HTML Assets
         run: myst build --html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './_build/html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
 ```
 
 :::

--- a/packages/myst-cli/src/init/gh-actions/index.ts
+++ b/packages/myst-cli/src/init/gh-actions/index.ts
@@ -62,12 +62,12 @@ jobs:
       - name: Build HTML Assets
         run: myst build --html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './_build/html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
 `;
 }
 


### PR DESCRIPTION
I received a [deprecation notice](https://github.com/berkeley-cdss/curriculum-guide/actions/runs/11221254729) in GitHub actions that the artifact actions were old. I bumped `upload-pages-artifact` to v3 and that required bumping `deploy-pages` as well.

Via https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ :
> Starting November 30, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible.

Note that `upload-pages-artifact` v3 uses `upload-artifact` v4.