### PR TITLE
🏗 Support parts as external files and in the site config

### DIFF
--- a/.changeset/blue-rocks-pull.md
+++ b/.changeset/blue-rocks-pull.md
@@ -1,0 +1,7 @@
+---
+'myst-to-jats': patch
+'myst-common': patch
+'myst-cli': patch
+---
+
+Consume frontmatter parts in static exports

--- a/.changeset/silly-candles-smile.md
+++ b/.changeset/silly-candles-smile.md
@@ -1,0 +1,6 @@
+---
+'myst-common': patch
+'myst-cli': patch
+---
+
+Load frontmatter parts as separate files for processing

--- a/.changeset/small-tigers-kneel.md
+++ b/.changeset/small-tigers-kneel.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fix local image paths for embedded nodes

--- a/.changeset/strong-colts-eat.md
+++ b/.changeset/strong-colts-eat.md
@@ -1,0 +1,6 @@
+---
+'myst-spec-ext': patch
+'myst-cli': patch
+---
+
+Keep track of implicit vs. explicit pages in project TOC

--- a/.changeset/stupid-flowers-push.md
+++ b/.changeset/stupid-flowers-push.md
@@ -1,0 +1,7 @@
+---
+'myst-frontmatter': patch
+'myst-config': patch
+'myst-cli': patch
+---
+
+Support parts in site config

--- a/.changeset/thirty-carrots-guess.md
+++ b/.changeset/thirty-carrots-guess.md
@@ -1,0 +1,6 @@
+---
+'myst-config': patch
+'myst-cli': patch
+---
+
+Parse project-level parts to mdast

--- a/.changeset/young-months-peel.md
+++ b/.changeset/young-months-peel.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Update processing to handle parts files

--- a/docs/document-parts.md
+++ b/docs/document-parts.md
@@ -22,6 +22,15 @@ abstract: |
 ---
 ```
 
+You may also write your part in a separate file, and point to that file from the frontmatter, for example:
+
+```yaml
+---
+title: My document
+abstract: ../abstract.md
+---
+```
+
 ### Known Frontmatter Parts
 
 The known parts that are recognized as _top-level_ document frontmatter keys are:
@@ -116,4 +125,20 @@ Project-level `parts` are useful, for example, if you have an abstract, acknowle
 
 ```{caution}
 Project-level `parts` are a new feature and may not yet be respected by your chosen MyST template or export format. If the project `part` is not behaving as you expect, try moving it to page frontmatter for now.
+```
+
+(parts:site)=
+
+## Parts in `myst.yml` Site configuration
+
+You may specify `parts` in the site configuration of your `myst.yml` file. These parts will only be used for MyST site builds, and they must correspond to `parts` declared in your [website theme's template](website-templates.md).
+
+```yaml
+version: 1
+site:
+  template: ...
+  parts:
+    footer: |
+      (c) MyST Markdown
+  ...
 ```

--- a/docs/website-templates.md
+++ b/docs/website-templates.md
@@ -58,7 +58,7 @@ Site options allow you to configure a theme's behavior.[^opts]
 These should be placed in the `site.options` in your `myst.yml`.
 For example:
 
-[^opts]: They are generally unique to the theme (and thus in a dediated `site.options` key rather than a top-level option in `site`).
+[^opts]: They are generally unique to the theme (and thus in a dedicated `site.options` key rather than a top-level option in `site`).
 
 ```{code-block} yaml
 :filename: myst.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -15632,6 +15632,7 @@
       "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
+        "myst-common": "^1.7.1",
         "myst-frontmatter": "^1.7.1",
         "simple-validators": "^1.1.0"
       },

--- a/packages/myst-cli/src/build/cff.ts
+++ b/packages/myst-cli/src/build/cff.ts
@@ -14,6 +14,7 @@ import { KNOWN_IMAGE_EXTENSIONS } from '../utils/resolveExtension.js';
 import type { ExportWithOutput, ExportFnOptions } from './types.js';
 import { cleanOutput } from './utils/cleanOutput.js';
 import { getFileContent } from './utils/getFileContent.js';
+import { resolveFrontmatterParts } from '../utils/resolveFrontmatterParts.js';
 import { parseMyst } from '../process/myst.js';
 
 function exportOptionsToCFF(exportOptions: ExportWithOutput): CFF {
@@ -40,11 +41,17 @@ export async function runCffExport(
   let abstract: string | undefined;
   if (projectPath && selectors.selectLocalConfigFile(state, projectPath) === sourceFile) {
     frontmatter = selectors.selectLocalProjectConfig(state, projectPath);
+    // TODO: This uses project-config-level parts which are not yet supported in the same way
+    // as page- and site-level parts. Once those are supported, this needs updating.
     const rawAbstract = frontmatter?.parts?.abstract?.join('\n\n');
     if (rawAbstract) {
       const abstractAst = parseMyst(session, rawAbstract, sourceFile);
       abstract = toText(abstractAst);
     }
+    // const { abstract: frontmatterAbstract } = resolveFrontmatterParts(session, frontmatter) ?? {};
+    // if (frontmatterAbstract) {
+    //   abstract = toText(frontmatterAbstract);
+    // }
   } else if (article.file) {
     const [content] = await getFileContent(session, [article.file], {
       projectPath,
@@ -52,7 +59,9 @@ export async function runCffExport(
       extraLinkTransformers,
     });
     frontmatter = content.frontmatter;
-    const abstractMdast = extractPart(content.mdast, 'abstract');
+    const abstractMdast = extractPart(content.mdast, 'abstract', {
+      frontmatterParts: resolveFrontmatterParts(session, frontmatter),
+    });
     if (abstractMdast) abstract = toText(abstractMdast);
   }
   if (!frontmatter) return { tempFolders: [] };

--- a/packages/myst-cli/src/build/cff.ts
+++ b/packages/myst-cli/src/build/cff.ts
@@ -40,18 +40,17 @@ export async function runCffExport(
   let frontmatter: PageFrontmatter | undefined;
   let abstract: string | undefined;
   if (projectPath && selectors.selectLocalConfigFile(state, projectPath) === sourceFile) {
+    // Process the project only, without any files
+    await getFileContent(session, [], {
+      projectPath,
+      imageExtensions: KNOWN_IMAGE_EXTENSIONS,
+      extraLinkTransformers,
+    });
     frontmatter = selectors.selectLocalProjectConfig(state, projectPath);
-    // TODO: This uses project-config-level parts which are not yet supported in the same way
-    // as page- and site-level parts. Once those are supported, this needs updating.
-    const rawAbstract = frontmatter?.parts?.abstract?.join('\n\n');
-    if (rawAbstract) {
-      const abstractAst = parseMyst(session, rawAbstract, sourceFile);
-      abstract = toText(abstractAst);
+    const { abstract: frontmatterAbstract } = resolveFrontmatterParts(session, frontmatter) ?? {};
+    if (frontmatterAbstract) {
+      abstract = toText(frontmatterAbstract.mdast);
     }
-    // const { abstract: frontmatterAbstract } = resolveFrontmatterParts(session, frontmatter) ?? {};
-    // if (frontmatterAbstract) {
-    //   abstract = toText(frontmatterAbstract);
-    // }
   } else if (article.file) {
     const [content] = await getFileContent(session, [article.file], {
       projectPath,

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -10,6 +10,7 @@ import { castSession } from '../../session/cache.js';
 import type { ISession } from '../../session/types.js';
 import { logMessagesFromVFile } from '../../utils/logging.js';
 import { KNOWN_IMAGE_EXTENSIONS } from '../../utils/resolveExtension.js';
+import { resolveFrontmatterParts } from '../../utils/resolveFrontmatterParts.js';
 import type { ExportWithOutput, ExportFnOptions } from '../types.js';
 import { cleanOutput } from '../utils/cleanOutput.js';
 import { getFileContent } from '../utils/getFileContent.js';
@@ -59,7 +60,12 @@ export async function runJatsExport(
       });
     }),
   );
-  const [processedArticle, ...processedSubArticles] = processedContents;
+  const [processedArticle, ...processedSubArticles] = processedContents.map(
+    ({ frontmatter, ...contents }) => {
+      const parts = resolveFrontmatterParts(session, frontmatter);
+      return { frontmatter: { ...frontmatter, parts }, ...contents };
+    },
+  );
   const vfile = new VFile();
   vfile.path = output;
   const jats = writeJats(vfile, processedArticle as any, {

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -1,10 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { hashAndCopyStaticFile } from 'myst-cli-utils';
-import type { GenericParent } from 'myst-common';
 import { RuleId, TemplateOptionType } from 'myst-common';
 import type { SiteAction, SiteExport, SiteManifest } from 'myst-config';
-import type { Download, PageFrontmatter } from 'myst-frontmatter';
+import type { Download } from 'myst-frontmatter';
 import {
   EXT_TO_FORMAT,
   ExportFormats,
@@ -19,12 +18,12 @@ import type { RootState } from '../../store/index.js';
 import { selectors } from '../../store/index.js';
 import { transformBanner, transformThumbnail } from '../../transforms/images.js';
 import { addWarningForFile } from '../../utils/addWarningForFile.js';
+import { resolveFrontmatterParts } from '../../utils/resolveFrontmatterParts.js';
 import version from '../../version.js';
 import { getSiteTemplate } from './template.js';
 import { collectExportOptions } from '../utils/collectExportOptions.js';
 import { filterPages } from '../../project/load.js';
 import { getRawFrontmatterFromFile } from '../../process/file.js';
-import { castSession } from '../../session/cache.js';
 
 type ManifestProject = Required<SiteManifest>['projects'][0];
 
@@ -368,18 +367,6 @@ function resolveSiteAction(
 export type SiteManifestOptions = {
   defaultTemplate?: string;
 };
-
-export function resolveFrontmatterParts(session: ISession, frontmatter: PageFrontmatter) {
-  const { parts } = frontmatter;
-  if (!parts || Object.keys(parts).length === 0) return undefined;
-  const partsMdast: Record<string, GenericParent> = {};
-  Object.entries(parts).forEach(([part, content]) => {
-    if (content.length !== 1) return;
-    const { mdast } = castSession(session).$getMdast(content[0])?.post ?? {};
-    if (mdast) partsMdast[part] = mdast;
-  });
-  return partsMdast;
-}
 
 /**
  * Build site manifest from local redux state

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -174,6 +174,7 @@ export async function localToManifestProject(
   const downloads = projConfigFile
     ? await resolvePageDownloads(session, projConfigFile, projectPath)
     : undefined;
+  const parts = resolveFrontmatterParts(session, projFrontmatter);
   const banner = await transformBanner(
     session,
     path.join(projectPath, 'myst.yml'),
@@ -205,6 +206,7 @@ export async function localToManifestProject(
       undefined,
     exports,
     downloads,
+    parts,
     bibliography: projFrontmatter.bibliography || [],
     title: projectTitle || 'Untitled',
     slug: projectSlug,

--- a/packages/myst-cli/src/build/site/watch.ts
+++ b/packages/myst-cli/src/build/site/watch.ts
@@ -92,15 +92,13 @@ async function processorFn(
     session.log.warn(`⚠️ File is not in project: ${file}`);
     return;
   }
-  if (pageSlug) {
-    await fastProcessFile(session, {
-      file,
-      projectPath,
-      projectSlug: siteProject.slug,
-      pageSlug,
-      ...opts,
-    });
-  }
+  await fastProcessFile(session, {
+    file,
+    projectPath,
+    projectSlug: siteProject.slug,
+    pageSlug,
+    ...opts,
+  });
   if (dependencies.length) {
     session.log.info(
       `🔄 Updating dependent pages for ${file} ${chalk.dim(`[${dependencies.join(', ')}]`)}`,

--- a/packages/myst-cli/src/build/site/watch.ts
+++ b/packages/myst-cli/src/build/site/watch.ts
@@ -41,7 +41,7 @@ function triggerProjectReload(
     : selectors.selectCurrentProjectFile(state);
   if (selectors.selectConfigExtensions(state).includes(file)) return true;
   if (file === projectConfigFile || basename(file) === '_toc.yml') return true;
-  // Reload project if file is added or remvoed
+  // Reload project if file is added or removed
   if (['add', 'unlink'].includes(eventType)) return true;
   // Otherwise do not reload project
   return false;
@@ -86,8 +86,9 @@ async function processorFn(
     return;
   }
   const projectPath = siteProject.path;
-  const pageSlug = selectors.selectPageSlug(session.store.getState(), siteProject.path, file);
-  const dependencies = selectors.selectDependentFiles(session.store.getState(), file);
+  const state = session.store.getState();
+  const pageSlug = selectors.selectPageSlug(state, siteProject.path, file);
+  const dependencies = selectors.selectDependentFiles(state, file);
   if (!pageSlug && dependencies.length === 0) {
     session.log.warn(`⚠️ File is not in project: ${file}`);
     return;
@@ -103,19 +104,28 @@ async function processorFn(
     session.log.info(
       `🔄 Updating dependent pages for ${file} ${chalk.dim(`[${dependencies.join(', ')}]`)}`,
     );
-    await Promise.all([
-      dependencies.map((dep) => {
-        const depSlug = selectors.selectPageSlug(session.store.getState(), projectPath, dep);
-        if (!depSlug) return undefined;
-        return fastProcessFile(session, {
-          file: dep,
-          projectPath,
-          projectSlug: siteProject.slug,
-          pageSlug: depSlug,
-          ...opts,
-        });
-      }),
-    ]);
+    const siteConfig = selectors.selectCurrentSiteFile(state);
+    const projConfig = selectors.selectCurrentProjectFile(state);
+    if (
+      (siteConfig && dependencies.includes(siteConfig)) ||
+      (projConfig && dependencies.includes(projConfig))
+    ) {
+      await processSite(session, { ...opts, reloadProject: true });
+    } else {
+      await Promise.all([
+        dependencies.map(async (dep) => {
+          const depSlug = selectors.selectPageSlug(state, projectPath, dep);
+          if (!depSlug) return undefined;
+          return fastProcessFile(session, {
+            file: dep,
+            projectPath,
+            projectSlug: siteProject.slug,
+            pageSlug: depSlug,
+            ...opts,
+          });
+        }),
+      ]);
+    }
   }
   serverReload();
   // TODO: process full site silently and update if there are any

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -31,6 +31,7 @@ import { getFileContent } from '../utils/getFileContent.js';
 import { addWarningForFile } from '../../utils/addWarningForFile.js';
 import { cleanOutput } from '../utils/cleanOutput.js';
 import { createTempFolder } from '../../utils/createTempFolder.js';
+import { resolveFrontmatterParts } from '../../utils/resolveFrontmatterParts.js';
 import type { ExportWithOutput, ExportResults, ExportFnOptions } from '../types.js';
 import { writeBibtexFromCitationRenderers } from '../utils/bibtex.js';
 
@@ -72,7 +73,9 @@ export function extractTexPart(
   frontmatter: PageFrontmatter,
   templateYml: TemplateYml,
 ): LatexResult | LatexResult[] | undefined {
-  const part = extractPart(mdast, partDefinition.id);
+  const part = extractPart(mdast, partDefinition.id, {
+    frontmatterParts: resolveFrontmatterParts(session, frontmatter),
+  });
   if (!part) return undefined;
   if (!partDefinition.as_list) {
     // Do not build glossaries when extracting parts: references cannot be mapped to definitions

--- a/packages/myst-cli/src/build/typst.ts
+++ b/packages/myst-cli/src/build/typst.ts
@@ -32,6 +32,7 @@ import { logMessagesFromVFile } from '../utils/logging.js';
 import { getFileContent } from './utils/getFileContent.js';
 import { addWarningForFile } from '../utils/addWarningForFile.js';
 import { createTempFolder } from '../utils/createTempFolder.js';
+import { resolveFrontmatterParts } from '../utils/resolveFrontmatterParts.js';
 import version from '../version.js';
 import { cleanOutput } from './utils/cleanOutput.js';
 import type { ExportWithOutput, ExportResults, ExportFnOptions } from './types.js';
@@ -90,7 +91,9 @@ export function extractTypstPart(
   frontmatter: PageFrontmatter,
   templateYml: TemplateYml,
 ): TypstResult | TypstResult[] | undefined {
-  const part = extractPart(mdast, partDefinition.id);
+  const part = extractPart(mdast, partDefinition.id, {
+    frontmatterParts: resolveFrontmatterParts(session, frontmatter),
+  });
   if (!part) return undefined;
   if (!partDefinition.as_list) {
     // Do not build glossaries when extracting parts: references cannot be mapped to definitions

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -304,13 +304,22 @@ export async function loadFile(
     success = false;
   }
   if (success) session.log.debug(successMessage ?? toc(`loadFile: loaded ${file} in %s.`));
-  if (pre?.frontmatter) await loadFrontmatterParts(session, file, pre.frontmatter, projectPath);
+  if (pre?.frontmatter) {
+    pre.frontmatter.parts = await loadFrontmatterParts(
+      session,
+      file,
+      'parts',
+      pre.frontmatter,
+      projectPath,
+    );
+  }
   return pre;
 }
 
 export async function loadFrontmatterParts(
   session: ISession,
   file: string,
+  property: string,
   frontmatter: PageFrontmatter,
   projectPath?: string,
 ) {
@@ -349,7 +358,7 @@ export async function loadFrontmatterParts(
         }
       } else {
         const cache = castSession(session);
-        partFile = `${path.resolve(file)}#parts.${part}`;
+        partFile = `${path.resolve(file)}#${property}.${part}`;
         if (contents.length !== 1 || contents[0] !== partFile || !cache.$getMdast(contents[0])) {
           const mdast = {
             type: 'root',
@@ -389,7 +398,7 @@ export async function loadFrontmatterParts(
       return [part, [partFile]];
     }),
   );
-  frontmatter.parts = Object.fromEntries(modifiedParts);
+  return Object.fromEntries(modifiedParts);
 }
 
 /**

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -333,7 +333,11 @@ export async function loadFrontmatterParts(
           session.log.warn(`Part file does not exist: ${partFile}`);
           return [part, contents];
         }
-        await loadFile(session, partFile, projectPath, undefined, { kind: SourceFileKind.Part });
+        await loadFile(session, partFile, projectPath, undefined, {
+          kind: SourceFileKind.Part,
+          /** Frontmatter from the source page is prioritized over frontmatter from the part file itself */
+          preFrontmatter: pageFrontmatter,
+        });
         session.store.dispatch(
           watch.actions.addLocalDependency({
             path: file,

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -259,7 +259,7 @@ export async function transformMdast(
     url = `/${projectSlug}/${useSlug ? pageSlug : ''}`;
     dataUrl = `/${projectSlug}/${pageSlug}.json`;
   } else if (pageSlug) {
-    url = `/${projectSlug}/${pageSlug}.json`;
+    url = `/${useSlug ? pageSlug : ''}`;
     dataUrl = `/${pageSlug}.json`;
   }
   updateFileInfoFromFrontmatter(session, file, frontmatter, url, dataUrl);

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -74,7 +74,6 @@ import type { ImageExtensions } from '../utils/resolveExtension.js';
 import { logMessagesFromVFile } from '../utils/logging.js';
 import { combineCitationRenderers } from './citations.js';
 import { bibFilesInDir, selectFile } from './file.js';
-import { frontmatterPartsTransform } from '../transforms/parts.js';
 import { parseMyst } from './myst.js';
 import { kernelExecutionTransform, LocalDiskCache } from 'myst-execute';
 import type { IOutput } from '@jupyterlab/nbformat';
@@ -98,6 +97,14 @@ export type TransformFn = (
   session: ISession,
   opts: Parameters<typeof transformMdast>[1],
 ) => Promise<void>;
+
+function referenceFileFromPartFile(session: ISession, partFile: string) {
+  const state = session.store.getState();
+  const partDeps = selectors.selectDependentFiles(state, partFile);
+  if (partDeps.length > 0) return partDeps[0];
+  const file = selectors.selectFileFromPart(state, partFile);
+  return file ?? partFile;
+}
 
 export async function transformMdast(
   session: ISession,
@@ -164,10 +171,14 @@ export async function transformMdast(
   const references: References = {
     cite: { order: [], data: {} },
   };
-  const state = new ReferenceState(file, { numbering: frontmatter.numbering, identifiers, vfile });
+  const refFile = kind === SourceFileKind.Part ? referenceFileFromPartFile(session, file) : file;
+  const state = new ReferenceState(refFile, {
+    numbering: frontmatter.numbering,
+    identifiers,
+    vfile,
+  });
   cache.$internalReferences[file] = state;
   // Import additional content from mdast or other files
-  frontmatterPartsTransform(session, file, mdast, frontmatter);
   importMdastFromJson(session, file, mdast);
   await includeFilesTransform(session, file, mdast, frontmatter, vfile);
   rawDirectiveTransform(mdast, vfile);
@@ -242,10 +253,15 @@ export async function transformMdast(
   if (isJupytext) transformLiftCodeBlocksInJupytext(mdast);
   const sha256 = selectors.selectFileInfo(store.getState(), file).sha256 as string;
   const useSlug = pageSlug !== index;
-  const url = projectSlug
-    ? `/${projectSlug}/${useSlug ? pageSlug : ''}`
-    : `/${useSlug ? pageSlug : ''}`;
-  const dataUrl = projectSlug ? `/${projectSlug}/${pageSlug}.json` : `/${pageSlug}.json`;
+  let url: string | undefined;
+  let dataUrl: string | undefined;
+  if (pageSlug && projectSlug) {
+    url = `/${projectSlug}/${useSlug ? pageSlug : ''}`;
+    dataUrl = `/${projectSlug}/${pageSlug}.json`;
+  } else if (pageSlug) {
+    url = `/${projectSlug}/${pageSlug}.json`;
+    dataUrl = `/${pageSlug}.json`;
+  }
   updateFileInfoFromFrontmatter(session, file, frontmatter, url, dataUrl);
   const data: RendererData = {
     kind: isJupytext ? SourceFileKind.Notebook : kind,

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -20,7 +20,6 @@ import { reloadAllConfigsForCurrentSite } from '../config.js';
 import type { SiteManifestOptions } from '../build/site/manifest.js';
 import {
   getSiteManifest,
-  resolveFrontmatterParts,
   resolvePageDownloads,
   resolvePageExports,
 } from '../build/site/manifest.js';
@@ -37,6 +36,7 @@ import type { MystData } from '../transforms/crossReferences.js';
 import { addWarningForFile } from '../utils/addWarningForFile.js';
 import { logMessagesFromVFile } from '../utils/logging.js';
 import { ImageExtensions } from '../utils/resolveExtension.js';
+import { resolveFrontmatterParts } from '../utils/resolveFrontmatterParts.js';
 import version from '../version.js';
 import { combineProjectCitationRenderers } from './citations.js';
 import { loadFile, selectFile } from './file.js';

--- a/packages/myst-cli/src/project/fromPath.ts
+++ b/packages/myst-cli/src/project/fromPath.ts
@@ -74,6 +74,7 @@ function projectPagesFromPath(
         file,
         level,
         slug: fileInfo(file, pageSlugs).slug,
+        implicit: true,
       } as LocalProjectPage;
     });
   const folders = contents

--- a/packages/myst-cli/src/project/fromTOC.ts
+++ b/packages/myst-cli/src/project/fromTOC.ts
@@ -36,7 +36,13 @@ const DEFAULT_INDEX_WITH_EXT = ['.md', '.ipynb', '.myst.json']
   .map((ext) => DEFAULT_INDEX_FILENAMES.map((file) => `${file}${ext}`))
   .flat();
 
-type EntryWithoutPattern = FileEntry | URLEntry | FileParentEntry | URLParentEntry | ParentEntry;
+type EntryWithoutPattern = (
+  | FileEntry
+  | URLEntry
+  | FileParentEntry
+  | URLParentEntry
+  | ParentEntry
+) & { implicit?: boolean };
 
 export function comparePaths(a: string, b: string): number {
   const aDirName = dirname(a);
@@ -118,6 +124,7 @@ export function patternsToFileEntries(
         const newEntries = matches.map((item) => {
           return {
             file: item,
+            implicit: true,
           };
         });
         if (newEntries.length === 0) {
@@ -168,7 +175,7 @@ function pagesFromEntries(
       });
       if (file && fs.existsSync(file) && !isDirectory(file)) {
         const { slug } = fileInfo(file, pageSlugs);
-        pages.push({ file, level: entryLevel, slug });
+        pages.push({ file, level: entryLevel, slug, implicit: entry.implicit });
       }
     } else if (isURL(entry)) {
       addWarningForFile(

--- a/packages/myst-cli/src/project/toc.pattern.spec.ts
+++ b/packages/myst-cli/src/project/toc.pattern.spec.ts
@@ -38,11 +38,11 @@ describe('patternsToFileEntries', () => {
         fs: memfs,
       }),
     ).toEqual([
-      { file: 'bar/file-2.md' },
-      { file: 'bar/file-9.md' },
-      { file: 'foo/file-1.md' },
-      { file: 'foo/file-3.md' },
-      { file: 'foo/file-10.md' },
+      { file: 'bar/file-2.md', implicit: true },
+      { file: 'bar/file-9.md', implicit: true },
+      { file: 'foo/file-1.md', implicit: true },
+      { file: 'foo/file-3.md', implicit: true },
+      { file: 'foo/file-10.md', implicit: true },
     ]);
   });
   it('files containing natural numbers are sorted correctly', () => {
@@ -57,10 +57,10 @@ describe('patternsToFileEntries', () => {
         fs: memfs,
       }),
     ).toEqual([
-      { file: 'foo/file-01.md' },
-      { file: 'foo/file-2.md' },
-      { file: 'foo/file-3.md' },
-      { file: 'foo/file-10.md' },
+      { file: 'foo/file-01.md', implicit: true },
+      { file: 'foo/file-2.md', implicit: true },
+      { file: 'foo/file-3.md', implicit: true },
+      { file: 'foo/file-10.md', implicit: true },
     ]);
   });
   it('directories with index files are sorted correctly', () => {
@@ -79,14 +79,14 @@ describe('patternsToFileEntries', () => {
         fs: memfs,
       }),
     ).toEqual([
-      { file: 'bar/index.md' },
-      { file: 'bar/file-1.md' },
-      { file: 'bar/file-8.md' },
-      { file: 'bar/file-10.md' },
-      { file: 'foo/index.ipynb' },
-      { file: 'foo/file-2.md' },
-      { file: 'foo/file-3.md' },
-      { file: 'foo/file-10.md' },
+      { file: 'bar/index.md', implicit: true },
+      { file: 'bar/file-1.md', implicit: true },
+      { file: 'bar/file-8.md', implicit: true },
+      { file: 'bar/file-10.md', implicit: true },
+      { file: 'foo/index.ipynb', implicit: true },
+      { file: 'foo/file-2.md', implicit: true },
+      { file: 'foo/file-3.md', implicit: true },
+      { file: 'foo/file-10.md', implicit: true },
     ]);
   });
 });

--- a/packages/myst-cli/src/project/toc.spec.ts
+++ b/packages/myst-cli/src/project/toc.spec.ts
@@ -48,7 +48,7 @@ describe('site section generation', () => {
       path: '.',
       index: 'index',
       implicitIndex: true,
-      pages: [{ file: 'README.md', level: 1, slug: 'readme' }],
+      pages: [{ file: 'README.md', level: 1, slug: 'readme', implicit: true }],
     });
   });
   it('index.md only', async () => {
@@ -83,11 +83,13 @@ describe('site section generation', () => {
           file: 'notebook.ipynb',
           slug: 'notebook',
           level: 1,
+          implicit: true,
         },
         {
           file: 'page.md',
           slug: 'page',
           level: 1,
+          implicit: true,
         },
       ],
     });
@@ -108,11 +110,13 @@ describe('site section generation', () => {
           file: 'folder/notebook.ipynb',
           slug: 'notebook',
           level: 2,
+          implicit: true,
         },
         {
           file: 'folder/page.md',
           slug: 'page',
           level: 2,
+          implicit: true,
         },
       ],
     });
@@ -145,11 +149,13 @@ describe('site section generation', () => {
           file: 'folder1/01_MySecond_folder-ok/folder3/01_notebook.ipynb',
           slug: 'notebook',
           level: 4,
+          implicit: true,
         },
         {
           file: 'folder1/01_MySecond_folder-ok/folder3/02_page.md',
           slug: 'page',
           level: 4,
+          implicit: true,
         },
       ],
     });
@@ -166,6 +172,7 @@ describe('site section generation', () => {
           file: 'zfile.md',
           slug: 'zfile',
           level: 1,
+          implicit: true,
         },
         {
           title: 'Afolder',
@@ -175,6 +182,7 @@ describe('site section generation', () => {
           file: 'afolder/page.md',
           slug: 'page',
           level: 2,
+          implicit: true,
         },
       ],
     });
@@ -197,6 +205,7 @@ describe('site section generation', () => {
           file: 'folder1/page1.md',
           slug: 'page1',
           level: 1,
+          implicit: true,
         },
         {
           title: 'Folder2',
@@ -206,6 +215,7 @@ describe('site section generation', () => {
           file: 'folder1/folder2/page2.md',
           slug: 'page2',
           level: 2,
+          implicit: true,
         },
         {
           title: 'Folder3',
@@ -215,6 +225,7 @@ describe('site section generation', () => {
           file: 'folder1/folder2/folder3/page3.md',
           slug: 'page3',
           level: 3,
+          implicit: true,
         },
       ],
     });
@@ -235,6 +246,7 @@ describe('site section generation', () => {
           file: 'folder/notebook.ipynb',
           slug: 'notebook',
           level: 2,
+          implicit: true,
         },
       ],
     });
@@ -251,6 +263,7 @@ describe('site section generation', () => {
           file: 'page.md',
           slug: 'page',
           level: 1,
+          implicit: true,
         },
       ],
     });
@@ -267,6 +280,7 @@ describe('site section generation', () => {
           file: 'aaa.ipynb',
           slug: 'aaa',
           level: 1,
+          implicit: true,
         },
       ],
     });
@@ -297,11 +311,13 @@ describe('site section generation', () => {
           file: 'index.ipynb',
           slug: 'index',
           level: 1,
+          implicit: true,
         },
         {
           file: 'page.md',
           slug: 'page',
           level: 1,
+          implicit: true,
         },
       ],
     });
@@ -326,11 +342,13 @@ describe('site section generation', () => {
           file: 'folder/index.ipynb',
           slug: 'index',
           level: 2,
+          implicit: true,
         },
         {
           file: 'folder/main.tex',
           slug: 'main',
           level: 2,
+          implicit: true,
         },
       ],
     });
@@ -355,11 +373,13 @@ describe('site section generation', () => {
           file: 'folder/main.tex',
           slug: 'main',
           level: 2,
+          implicit: true,
         },
         {
           file: 'folder/page.md',
           slug: 'page',
           level: 2,
+          implicit: true,
         },
       ],
     });
@@ -380,6 +400,7 @@ describe('site section generation', () => {
           file: 'notebook.ipynb',
           slug: 'notebook',
           level: 1,
+          implicit: true,
         },
         {
           title: 'Folder',
@@ -389,6 +410,7 @@ describe('site section generation', () => {
           file: 'folder/main.tex',
           slug: 'main',
           level: 2,
+          implicit: true,
         },
       ],
     });
@@ -415,11 +437,13 @@ describe('site section generation', () => {
           file: 'folder/notebook.ipynb',
           slug: 'notebook',
           level: 2,
+          implicit: true,
         },
         {
           file: 'folder/page.md',
           slug: 'page',
           level: 2,
+          implicit: true,
         },
       ],
     });
@@ -441,16 +465,19 @@ describe('site section generation', () => {
           file: 'chapter1.md',
           slug: 'chapter1',
           level: 1,
+          implicit: true,
         },
         {
           file: 'chapter2.ipynb',
           slug: 'chapter2',
           level: 1,
+          implicit: true,
         },
         {
           file: 'chapter10.ipynb',
           slug: 'chapter10',
           level: 1,
+          implicit: true,
         },
       ],
     });
@@ -478,11 +505,13 @@ describe('site section generation', () => {
           file: 'folder/notebook.ipynb',
           slug: 'notebook',
           level: 2,
+          implicit: true,
         },
         {
           file: 'folder/page.md',
           slug: 'page',
           level: 2,
+          implicit: true,
         },
       ],
     });
@@ -822,21 +851,21 @@ describe('pagesFromSphinxTOC', () => {
       'project/c.md': '',
       'project/d.md': '',
     });
-    expect(await projectFromPath(session, '.')).toEqual({
+    expect(projectFromPath(session, '.')).toEqual({
       path: '.',
       index: 'readme',
       file: 'readme.md',
       implicitIndex: true,
       pages: [
-        { slug: 'x', file: 'x.md', level: 1 },
+        { slug: 'x', file: 'x.md', level: 1, implicit: true },
         { slug: 'index', file: 'project/index.md', level: 1 },
         { slug: 'a', file: 'project/a.md', level: 2 },
         { title: 'Sections', level: 2 },
         { slug: 'b', file: 'project/b.md', level: 3 },
         { slug: 'c', file: 'project/c.md', level: 3 },
         { title: 'Section', level: 1 },
-        { slug: 'y', file: 'section/y.md', level: 2 },
-        { slug: 'z', file: 'section/z.md', level: 2 },
+        { slug: 'y', file: 'section/y.md', level: 2, implicit: true },
+        { slug: 'z', file: 'section/z.md', level: 2, implicit: true },
       ],
     });
   });
@@ -853,22 +882,22 @@ describe('pagesFromSphinxTOC', () => {
       'project/c.md': '',
       'project/d.md': '',
     });
-    expect(await projectFromPath(session, '.')).toEqual({
+    expect(projectFromPath(session, '.')).toEqual({
       path: '.',
       index: 'readme',
       file: 'readme.md',
       implicitIndex: true,
       pages: [
-        { slug: 'x', file: 'x.md', level: 1 },
+        { slug: 'x', file: 'x.md', level: 1, implicit: true },
         { title: 'Project', level: 1 },
-        { slug: 'index', file: 'project/index.md', level: 2 },
-        { slug: 'a', file: 'project/a.md', level: 2 },
-        { slug: 'b', file: 'project/b.md', level: 2 },
-        { slug: 'c', file: 'project/c.md', level: 2 },
-        { slug: 'd', file: 'project/d.md', level: 2 },
+        { slug: 'index', file: 'project/index.md', level: 2, implicit: true },
+        { slug: 'a', file: 'project/a.md', level: 2, implicit: true },
+        { slug: 'b', file: 'project/b.md', level: 2, implicit: true },
+        { slug: 'c', file: 'project/c.md', level: 2, implicit: true },
+        { slug: 'd', file: 'project/d.md', level: 2, implicit: true },
         { title: 'Section', level: 1 },
-        { slug: 'y', file: 'section/y.md', level: 2 },
-        { slug: 'z', file: 'section/z.md', level: 2 },
+        { slug: 'y', file: 'section/y.md', level: 2, implicit: true },
+        { slug: 'z', file: 'section/z.md', level: 2, implicit: true },
       ],
     });
   });

--- a/packages/myst-cli/src/project/types.ts
+++ b/packages/myst-cli/src/project/types.ts
@@ -20,6 +20,8 @@ export type LocalProjectPage = {
   file: string;
   slug: string;
   level: PageLevels;
+  /** Flag to mark if the page is implied from a TOC pattern or folder structure */
+  implicit?: boolean;
 };
 
 export type LocalProject = {

--- a/packages/myst-cli/src/session/session.spec.ts
+++ b/packages/myst-cli/src/session/session.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { addWarningForFile } from 'myst-cli';
 import { Session } from '../session';
 import { RuleId } from 'myst-common';
+import { addWarningForFile } from '../utils/addWarningForFile';
 
 describe('session warnings', () => {
   it('getAllWarnings returns for single session', async () => {

--- a/packages/myst-cli/src/store/reducers.ts
+++ b/packages/myst-cli/src/store/reducers.ts
@@ -133,6 +133,7 @@ export const watch = createSlice({
     },
     addLocalDependency(state, action: PayloadAction<{ path: string; dependency: string }>) {
       const { path, dependency } = action.payload;
+      if (!state.files[resolve(path)]) state.files[resolve(path)] = {};
       const existingDeps = [...(state.files[resolve(path)].localDependencies ?? [])];
       if (!existingDeps.includes(dependency)) {
         state.files[resolve(path)].localDependencies = [...existingDeps, dependency];
@@ -172,7 +173,7 @@ export const watch = createSlice({
         dataUrl,
       } = action.payload;
       const resolvedPath = resolve(path);
-      if (!state.files[resolvedPath]) return;
+      if (!state.files[resolvedPath]) state.files[resolvedPath] = {};
       if (title) state.files[resolvedPath].title = title;
       if (short_title) state.files[resolvedPath].short_title = short_title;
       if (description) state.files[resolvedPath].description = description;

--- a/packages/myst-cli/src/store/reducers.ts
+++ b/packages/myst-cli/src/store/reducers.ts
@@ -33,6 +33,8 @@ export const config = createSlice({
   initialState: {
     rawConfigs: {},
     projects: {},
+    projectParts: {},
+    fileParts: {},
     sites: {},
     filenames: {},
   } as {
@@ -40,6 +42,8 @@ export const config = createSlice({
     currentSitePath: string | undefined;
     rawConfigs: Record<string, { raw: Record<string, any>; validated: ValidatedRawConfig }>;
     projects: Record<string, Record<string, any>>;
+    projectParts: Record<string, string[]>;
+    fileParts: Record<string, string[]>;
     sites: Record<string, Record<string, any>>;
     filenames: Record<string, string>;
     configExtensions?: string[];
@@ -75,6 +79,20 @@ export const config = createSlice({
     receiveConfigExtension(state, action: PayloadAction<{ file: string }>) {
       state.configExtensions ??= [];
       state.configExtensions.push(action.payload.file);
+    },
+    receiveProjectPart(state, action: PayloadAction<{ partFile: string; path: string }>) {
+      const { path, partFile } = action.payload;
+      const partFiles = state.projectParts[resolve(path)] ?? [];
+      if (!partFiles.includes(partFile)) {
+        state.projectParts[resolve(path)] = [...partFiles, partFile];
+      }
+    },
+    receiveFilePart(state, action: PayloadAction<{ partFile: string; file: string }>) {
+      const { file, partFile } = action.payload;
+      const partFiles = state.fileParts[resolve(file)] ?? [];
+      if (!partFiles.includes(partFile)) {
+        state.fileParts[resolve(file)] = [...partFiles, partFile];
+      }
     },
   },
 });
@@ -154,6 +172,7 @@ export const watch = createSlice({
         dataUrl,
       } = action.payload;
       const resolvedPath = resolve(path);
+      if (!state.files[resolvedPath]) return;
       if (title) state.files[resolvedPath].title = title;
       if (short_title) state.files[resolvedPath].short_title = short_title;
       if (description) state.files[resolvedPath].description = description;

--- a/packages/myst-cli/src/store/selectors.ts
+++ b/packages/myst-cli/src/store/selectors.ts
@@ -50,6 +50,23 @@ export function selectCurrentProjectConfig(state: RootState): ProjectConfig | un
   return mutableCopy(state.local.config.projects[resolve(state.local.config.currentProjectPath)]);
 }
 
+export function selectProjectParts(state: RootState, path: string): string[] {
+  return [...(state.local.config.projectParts[resolve(path)] ?? [])];
+}
+
+export function selectFileParts(state: RootState, file: string): string[] {
+  return [...(state.local.config.fileParts[resolve(file)] ?? [])];
+}
+
+export function selectFileFromPart(state: RootState, partFile: string): string | undefined {
+  let file: string | undefined;
+  Object.entries(state.local.config.fileParts).forEach(([key, value]) => {
+    if (file) return;
+    if (value.includes(partFile)) file = key;
+  });
+  return file;
+}
+
 export function selectCurrentProjectPath(state: RootState): string | undefined {
   return state.local.config.currentProjectPath;
 }

--- a/packages/myst-cli/src/transforms/crossReferences.ts
+++ b/packages/myst-cli/src/transforms/crossReferences.ts
@@ -1,20 +1,36 @@
 import type { VFile } from 'vfile';
 import { selectAll } from 'unist-util-select';
-import type { GenericNode, GenericParent } from 'myst-common';
+import type { GenericNode, GenericParent, References } from 'myst-common';
 import { RuleId, fileWarn, plural, selectMdastNodes } from 'myst-common';
 import { computeHash, tic } from 'myst-cli-utils';
 import { addChildrenFromTargetNode } from 'myst-transforms';
 import type { PageFrontmatter } from 'myst-frontmatter';
-import type { CrossReference, Link } from 'myst-spec-ext';
+import type { CrossReference, Dependency, Link, SourceFileKind } from 'myst-spec-ext';
 import type { ISession } from '../session/types.js';
 import { loadFromCache, writeToCache } from '../session/cache.js';
-import type { RendererData } from './types.js';
+import type { SiteAction, SiteExport } from 'myst-config';
 
 export const XREF_MAX_AGE = 1; // in days
 
 function mystDataFilename(dataUrl: string) {
   return `myst-${computeHash(dataUrl)}.json`;
 }
+
+export type MystData = {
+  kind?: SourceFileKind;
+  sha256?: string;
+  slug?: string;
+  location?: string;
+  dependencies?: Dependency[];
+  frontmatter?: Omit<PageFrontmatter, 'downloads' | 'exports' | 'parts'> & {
+    downloads?: SiteAction[];
+    exports?: [{ format: string; filename: string; url: string }, ...SiteExport[]];
+    parts?: Record<string, GenericParent>;
+  };
+  widgets?: Record<string, any>;
+  mdast?: GenericParent;
+  references?: References;
+};
 
 async function fetchMystData(
   session: ISession,
@@ -27,12 +43,12 @@ async function fetchMystData(
     const filename = mystDataFilename(dataUrl);
     const cacheData = loadFromCache(session, filename, { maxAge: XREF_MAX_AGE });
     if (cacheData) {
-      return JSON.parse(cacheData) as RendererData;
+      return JSON.parse(cacheData) as MystData;
     }
     try {
       const resp = await session.fetch(dataUrl);
       if (resp.ok) {
-        const data = (await resp.json()) as RendererData;
+        const data = (await resp.json()) as MystData;
         writeToCache(session, filename, JSON.stringify(data));
         return data;
       }
@@ -67,7 +83,7 @@ export async function fetchMystXRefData(session: ISession, node: CrossReference,
 }
 
 export function nodesFromMystXRefData(
-  data: RendererData,
+  data: MystData,
   identifier: string,
   vfile: VFile,
   opts?: {
@@ -75,7 +91,11 @@ export function nodesFromMystXRefData(
     urlSource?: string;
   },
 ) {
-  const targetNodes = selectMdastNodes(data.mdast, identifier, opts?.maxNodes).nodes;
+  let targetNodes: GenericNode[] | undefined;
+  [data.mdast, ...Object.values(data.frontmatter?.parts ?? {})].forEach((tree) => {
+    if (!tree || targetNodes?.length) return;
+    targetNodes = selectMdastNodes(tree, identifier, opts?.maxNodes).nodes;
+  });
   if (!targetNodes?.length) {
     fileWarn(vfile, `Unable to resolve content from external MyST reference: ${opts?.urlSource}`, {
       ruleId: RuleId.mystLinkValid,

--- a/packages/myst-cli/src/transforms/crossReferences.ts
+++ b/packages/myst-cli/src/transforms/crossReferences.ts
@@ -1,6 +1,6 @@
 import type { VFile } from 'vfile';
 import { selectAll } from 'unist-util-select';
-import type { GenericNode, GenericParent, References } from 'myst-common';
+import type { FrontmatterParts, GenericNode, GenericParent, References } from 'myst-common';
 import { RuleId, fileWarn, plural, selectMdastNodes } from 'myst-common';
 import { computeHash, tic } from 'myst-cli-utils';
 import { addChildrenFromTargetNode } from 'myst-transforms';
@@ -25,7 +25,7 @@ export type MystData = {
   frontmatter?: Omit<PageFrontmatter, 'downloads' | 'exports' | 'parts'> & {
     downloads?: SiteAction[];
     exports?: [{ format: string; filename: string; url: string }, ...SiteExport[]];
-    parts?: Record<string, GenericParent>;
+    parts?: FrontmatterParts;
   };
   widgets?: Record<string, any>;
   mdast?: GenericParent;
@@ -92,9 +92,9 @@ export function nodesFromMystXRefData(
   },
 ) {
   let targetNodes: GenericNode[] | undefined;
-  [data.mdast, ...Object.values(data.frontmatter?.parts ?? {})].forEach((tree) => {
-    if (!tree || targetNodes?.length) return;
-    targetNodes = selectMdastNodes(tree, identifier, opts?.maxNodes).nodes;
+  [data, ...Object.values(data.frontmatter?.parts ?? {})].forEach(({ mdast }) => {
+    if (!mdast || targetNodes?.length) return;
+    targetNodes = selectMdastNodes(mdast, identifier, opts?.maxNodes).nodes;
   });
   if (!targetNodes?.length) {
     fileWarn(vfile, `Unable to resolve content from external MyST reference: ${opts?.urlSource}`, {

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -60,9 +60,17 @@ function mutateEmbedNode(
   if (targetFile && sourceFile) {
     // TODO: Other node types that point to a file?
     selectAll('image', targetNode).forEach((imageNode: GenericNode) => {
-      const absoluteUrl = path.resolve(path.dirname(sourceFile), imageNode.url);
-      if (fs.existsSync(absoluteUrl)) {
-        imageNode.url = path.relative(path.dirname(targetFile), absoluteUrl);
+      if (imageNode.url) {
+        const absoluteUrl = path.resolve(path.dirname(sourceFile), imageNode.url);
+        if (fs.existsSync(absoluteUrl)) {
+          imageNode.url = path.relative(path.dirname(targetFile), absoluteUrl);
+        }
+      }
+      if (imageNode.urlSource) {
+        const absoluteUrlSource = path.resolve(path.dirname(sourceFile), imageNode.urlSource);
+        if (fs.existsSync(absoluteUrlSource)) {
+          imageNode.urlSource = path.relative(path.dirname(targetFile), absoluteUrlSource);
+        }
       }
     });
   }

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { filter } from 'unist-util-filter';
 import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
@@ -21,15 +23,16 @@ import { selectFile } from '../process/file.js';
 import type { ISession } from '../session/types.js';
 import { watch } from '../store/reducers.js';
 import { castSession } from '../session/cache.js';
+import type { MystData } from './crossReferences.js';
 import { fetchMystLinkData, fetchMystXRefData, nodesFromMystXRefData } from './crossReferences.js';
 import { fileFromRelativePath } from './links.js';
-import type { RendererData } from './types.js';
 
 function mutateEmbedNode(
   node: Embed,
   targetNode?: GenericNode | null,
-  opts?: { url?: string; dataUrl?: string },
+  opts?: { url?: string; dataUrl?: string; targetFile?: string; sourceFile?: string },
 ) {
+  const { url, dataUrl, targetFile, sourceFile } = opts ?? {};
   if (targetNode && node['remove-output']) {
     targetNode = filter(targetNode, (n: GenericNode) => {
       return n.type !== 'output' && n.data?.type !== 'output';
@@ -49,11 +52,20 @@ function mutateEmbedNode(
   });
   (selectAll('crossReference', targetNode) as CrossReference[]).forEach((targetXRef) => {
     if (!targetXRef.remote) {
-      targetXRef.url = opts?.url;
-      targetXRef.dataUrl = opts?.dataUrl;
+      targetXRef.url = url;
+      targetXRef.dataUrl = dataUrl;
       targetXRef.remote = true;
     }
   });
+  if (targetFile && sourceFile) {
+    // TODO: Other node types that point to a file?
+    selectAll('image', targetNode).forEach((imageNode: GenericNode) => {
+      const absoluteUrl = path.resolve(path.dirname(sourceFile), imageNode.url);
+      if (fs.existsSync(absoluteUrl)) {
+        imageNode.url = path.relative(path.dirname(targetFile), absoluteUrl);
+      }
+    });
+  }
   if (!targetNode) {
     node.children = [];
   } else if (targetNode.type === 'block') {
@@ -111,7 +123,7 @@ export async function embedTransform(
         const transformed = mystTransformer.transform(referenceLink, vfile);
         const referenceXRef = referenceLink as any as CrossReference;
         if (transformed) {
-          let data: RendererData | undefined;
+          let data: MystData | undefined;
           let targetNodes: GenericNode[] | undefined;
           if (referenceXRef.identifier) {
             data = await fetchMystXRefData(session, referenceXRef, vfile);
@@ -122,7 +134,7 @@ export async function embedTransform(
             });
           } else {
             data = await fetchMystLinkData(session, referenceLink, vfile);
-            if (!data) return;
+            if (!data?.mdast) return;
             targetNodes = data.mdast.children;
           }
           if (!targetNodes?.length) return;
@@ -196,7 +208,7 @@ export async function embedTransform(
         return;
       }
       const { url, dataUrl, filePath } = stateProvider;
-      mutateEmbedNode(node, target, { url, dataUrl });
+      mutateEmbedNode(node, target, { url, dataUrl, targetFile: file, sourceFile: filePath });
       if (!url) return;
       const source: Dependency = { url, label };
       if (filePath) {

--- a/packages/myst-cli/src/transforms/parts.ts
+++ b/packages/myst-cli/src/transforms/parts.ts
@@ -4,6 +4,11 @@ import { parseMyst } from '../process/myst.js';
 import type { GenericParent } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 
+/**
+ * Parse frontmatter parts and prepend them as blocks to mdast children
+ *
+ * @deprecated frontmatter parts are now processed separately by MyST
+ */
 export function frontmatterPartsTransform(
   session: ISession,
   file: string,

--- a/packages/myst-cli/src/utils/index.ts
+++ b/packages/myst-cli/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from './logging.js';
 export * from './nextLevel.js';
 export * from './removeExtension.js';
 export * from './resolveExtension.js';
+export * from './resolveFrontmatterParts.js';
 export * from './shouldIgnoreFile.js';
 export * from './toc.js';
 export * from './uniqueArray.js';

--- a/packages/myst-cli/src/utils/resolveFrontmatterParts.ts
+++ b/packages/myst-cli/src/utils/resolveFrontmatterParts.ts
@@ -1,4 +1,4 @@
-import type { GenericParent } from 'myst-common';
+import type { FrontmatterParts } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import { castSession } from '../session/cache.js';
 import type { ISession } from '../session/types.js';
@@ -8,15 +8,15 @@ import type { ISession } from '../session/types.js';
  */
 export function resolveFrontmatterParts(
   session: ISession,
-  frontmatter?: PageFrontmatter,
-): Record<string, GenericParent> | undefined {
-  const { parts } = frontmatter ?? {};
+  pageFrontmatter?: PageFrontmatter,
+): FrontmatterParts | undefined {
+  const { parts } = pageFrontmatter ?? {};
   if (!parts || Object.keys(parts).length === 0) return undefined;
-  const partsMdast: Record<string, GenericParent> = {};
+  const partsMdast: FrontmatterParts = {};
   Object.entries(parts).forEach(([part, content]) => {
     if (content.length !== 1) return;
-    const { mdast } = castSession(session).$getMdast(content[0])?.post ?? {};
-    if (mdast) partsMdast[part] = mdast;
+    const { mdast, frontmatter } = castSession(session).$getMdast(content[0])?.post ?? {};
+    if (mdast) partsMdast[part] = { mdast, frontmatter };
   });
   return partsMdast;
 }

--- a/packages/myst-cli/src/utils/resolveFrontmatterParts.ts
+++ b/packages/myst-cli/src/utils/resolveFrontmatterParts.ts
@@ -1,0 +1,22 @@
+import type { GenericParent } from 'myst-common';
+import type { PageFrontmatter } from 'myst-frontmatter';
+import { castSession } from '../session/cache.js';
+import type { ISession } from '../session/types.js';
+
+/**
+ * Load frontmatter parts from session and return part:node lookup
+ */
+export function resolveFrontmatterParts(
+  session: ISession,
+  frontmatter?: PageFrontmatter,
+): Record<string, GenericParent> | undefined {
+  const { parts } = frontmatter ?? {};
+  if (!parts || Object.keys(parts).length === 0) return undefined;
+  const partsMdast: Record<string, GenericParent> = {};
+  Object.entries(parts).forEach(([part, content]) => {
+    if (content.length !== 1) return;
+    const { mdast } = castSession(session).$getMdast(content[0])?.post ?? {};
+    if (mdast) partsMdast[part] = mdast;
+  });
+  return partsMdast;
+}

--- a/packages/myst-common/src/extractParts.spec.ts
+++ b/packages/myst-common/src/extractParts.spec.ts
@@ -272,15 +272,17 @@ describe('extractPart', () => {
       extractPart(tree, 'test_part', {
         frontmatterParts: {
           test_part: {
-            type: 'root',
-            children: [
-              {
-                type: 'block',
-                children: [
-                  { type: 'paragraph', children: [{ type: 'text', value: 'frontmatter part' }] },
-                ],
-              },
-            ],
+            mdast: {
+              type: 'root',
+              children: [
+                {
+                  type: 'block',
+                  children: [
+                    { type: 'paragraph', children: [{ type: 'text', value: 'frontmatter part' }] },
+                  ],
+                },
+              ],
+            },
           },
         },
       }),

--- a/packages/myst-common/src/extractParts.spec.ts
+++ b/packages/myst-common/src/extractParts.spec.ts
@@ -244,6 +244,79 @@ describe('extractPart', () => {
       ],
     });
   });
+  it('frontmatter part prioritized, tagged block removed, implicit part unchanged', async () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'other_tag' },
+          children: [{ type: 'text', value: 'untagged content' }],
+        },
+        {
+          type: 'block' as any,
+          data: { part: 'test_part' },
+          children: [{ type: 'text', value: 'block part' }],
+        },
+        {
+          type: 'heading',
+          children: [{ type: 'text', value: 'test_part' }],
+        },
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', value: 'implicit part' }],
+        },
+      ],
+    };
+    expect(
+      extractPart(tree, 'test_part', {
+        frontmatterParts: {
+          test_part: {
+            type: 'root',
+            children: [
+              {
+                type: 'block',
+                children: [
+                  { type: 'paragraph', children: [{ type: 'text', value: 'frontmatter part' }] },
+                ],
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'block',
+          data: {
+            part: 'test_part',
+          },
+          children: [
+            { type: 'paragraph', children: [{ type: 'text', value: 'frontmatter part' }] },
+          ],
+        },
+      ],
+    });
+    expect(tree).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'block' as any,
+          data: { part: 'other_tag' },
+          children: [{ type: 'text', value: 'untagged content' }],
+        },
+        {
+          type: 'heading',
+          children: [{ type: 'text', value: 'test_part' }],
+        },
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', value: 'implicit part' }],
+        },
+      ],
+    });
+  });
 });
 
 describe('extractImplicitPart', () => {

--- a/packages/myst-common/src/extractParts.ts
+++ b/packages/myst-common/src/extractParts.ts
@@ -1,5 +1,5 @@
 import type { Block } from 'myst-spec-ext';
-import type { GenericNode, GenericParent } from './types.js';
+import type { FrontmatterParts, GenericNode, GenericParent } from './types.js';
 import { remove } from 'unist-util-remove';
 import { selectAll } from 'unist-util-select';
 import { copyNode, toText } from './utils.js';
@@ -54,7 +54,7 @@ export function selectBlockParts(tree: GenericParent, part?: string | string[]):
  * Returns array of blocks.
  */
 export function selectFrontmatterParts(
-  frontmatterParts?: Record<string, GenericParent>,
+  frontmatterParts?: FrontmatterParts,
   part?: string | string[],
 ): Block[] {
   if (!frontmatterParts) return [];
@@ -63,7 +63,7 @@ export function selectFrontmatterParts(
   const blockParts: Block[] = [];
   parts.forEach((p) => {
     Object.entries(frontmatterParts).forEach(([key, value]) => {
-      if (p === key.toLowerCase()) blockParts.push(...(value.children as Block[]));
+      if (p === key.toLowerCase()) blockParts.push(...(value.mdast.children as Block[]));
     });
   });
   return blockParts;
@@ -170,7 +170,7 @@ export function extractPart(
     /** Provide an option so implicit section-to-part behavior can be disabled */
     requireExplicitPart?: boolean;
     /** Dictionary of part trees, processed from frontmatter */
-    frontmatterParts?: Record<string, GenericParent>;
+    frontmatterParts?: FrontmatterParts;
   },
 ): GenericParent | undefined {
   const partStrings = coercePart(part);

--- a/packages/myst-common/src/extractParts.ts
+++ b/packages/myst-common/src/extractParts.ts
@@ -131,7 +131,9 @@ export function extractImplicitPart(
 }
 
 /**
- * Returns a copy of the block parts and removes them from the tree.
+ * Returns a copy of block parts, if defined in the tree, and removes them from the tree.
+ *
+ * This does not look at parts defined in frontmatter.
  */
 export function extractPart(
   tree: GenericParent,

--- a/packages/myst-common/src/index.ts
+++ b/packages/myst-common/src/index.ts
@@ -53,4 +53,6 @@ export type {
   PluginOptions,
   PluginUtils,
   TransformSpec,
+  FrontmatterPart,
+  FrontmatterParts,
 } from './types.js';

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -3,6 +3,7 @@ import type { Directive, Node, Role } from 'myst-spec';
 import type { VFile } from 'vfile';
 import type * as nbformat from '@jupyterlab/nbformat';
 import type { PartialJSONObject } from '@lumino/coreutils';
+import type { PageFrontmatter } from 'myst-frontmatter';
 
 export type GenericNode<T extends Record<string, any> = Record<string, any>> = {
   type: string;
@@ -187,3 +188,7 @@ export interface IExpressionError {
 }
 
 export type IExpressionResult = IExpressionError | IExpressionOutput;
+
+export type FrontmatterPart = { mdast: GenericParent; frontmatter?: PageFrontmatter };
+
+export type FrontmatterParts = Record<string, FrontmatterPart>;

--- a/packages/myst-config/package.json
+++ b/packages/myst-config/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/jupyter-book/mystmd/issues"
   },
   "dependencies": {
+    "myst-common": "^1.7.1",
     "myst-frontmatter": "^1.7.1",
     "simple-validators": "^1.1.0"
   },

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -1,4 +1,4 @@
-import type { GenericParent } from 'myst-common';
+import type { FrontmatterParts } from 'myst-common';
 import type { ExportFormats, ProjectFrontmatter, SiteFrontmatter } from 'myst-frontmatter';
 
 export interface SiteProject {
@@ -65,7 +65,7 @@ type ManifestProject = {
   tags?: string[];
   downloads?: SiteAction[];
   exports?: SiteExport[];
-  parts?: Record<string, GenericParent>;
+  parts?: FrontmatterParts;
 } & Omit<ProjectFrontmatter, 'downloads' | 'exports' | 'parts'>;
 
 export type SiteManifest = Omit<SiteFrontmatter, 'parts'> & {
@@ -77,5 +77,5 @@ export type SiteManifest = Omit<SiteFrontmatter, 'parts'> & {
   domains?: string[];
   favicon?: string;
   template?: string;
-  parts?: Record<string, GenericParent>;
+  parts?: FrontmatterParts;
 };

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -65,7 +65,8 @@ type ManifestProject = {
   tags?: string[];
   downloads?: SiteAction[];
   exports?: SiteExport[];
-} & Omit<ProjectFrontmatter, 'downloads' | 'exports'>;
+  parts?: Record<string, GenericParent>;
+} & Omit<ProjectFrontmatter, 'downloads' | 'exports' | 'parts'>;
 
 export type SiteManifest = Omit<SiteFrontmatter, 'parts'> & {
   myst: string;

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -1,3 +1,4 @@
+import type { GenericParent } from 'myst-common';
 import type { ExportFormats, ProjectFrontmatter, SiteFrontmatter } from 'myst-frontmatter';
 
 export interface SiteProject {
@@ -66,7 +67,7 @@ type ManifestProject = {
   exports?: SiteExport[];
 } & Omit<ProjectFrontmatter, 'downloads' | 'exports'>;
 
-export type SiteManifest = SiteFrontmatter & {
+export type SiteManifest = Omit<SiteFrontmatter, 'parts'> & {
   myst: string;
   id?: string;
   projects?: ManifestProject[];
@@ -75,4 +76,5 @@ export type SiteManifest = SiteFrontmatter & {
   domains?: string[];
   favicon?: string;
   template?: string;
+  parts?: Record<string, GenericParent>;
 };

--- a/packages/myst-frontmatter/src/project/types.ts
+++ b/packages/myst-frontmatter/src/project/types.ts
@@ -10,16 +10,6 @@ import type { SiteFrontmatter } from '../site/types.js';
 import { SITE_FRONTMATTER_KEYS } from '../site/types.js';
 import type { ExpandedThebeFrontmatter } from '../thebe/types.js';
 
-export const PAGE_KNOWN_PARTS = [
-  'abstract',
-  'summary',
-  'keypoints',
-  'dedication',
-  'epigraph',
-  'data_availability',
-  'acknowledgments',
-];
-
 export const PROJECT_AND_PAGE_FRONTMATTER_KEYS = [
   'date',
   'doi',
@@ -43,8 +33,6 @@ export const PROJECT_AND_PAGE_FRONTMATTER_KEYS = [
   'exports',
   'downloads',
   'settings', // We maybe want to move this into site frontmatter in the future
-  'parts',
-  ...PAGE_KNOWN_PARTS,
   // Do not add any project specific keys here!
   ...SITE_FRONTMATTER_KEYS,
 ];
@@ -86,7 +74,6 @@ export type ProjectAndPageFrontmatter = SiteFrontmatter & {
   exports?: Export[];
   downloads?: Download[];
   settings?: ProjectSettings;
-  parts?: Record<string, string[]>;
 };
 
 export type ProjectFrontmatter = ProjectAndPageFrontmatter & {

--- a/packages/myst-frontmatter/src/project/validators.ts
+++ b/packages/myst-frontmatter/src/project/validators.ts
@@ -10,7 +10,6 @@ import {
   validateObjectKeys,
   validateString,
   validateUrl,
-  validationError,
 } from 'simple-validators';
 import { validateTOC } from 'myst-toc';
 import { validatePublicationMeta } from '../biblio/validators.js';
@@ -22,7 +21,7 @@ import { validateExternalReferences } from '../references/validators.js';
 import { validateSiteFrontmatterKeys } from '../site/validators.js';
 import { validateThebe } from '../thebe/validators.js';
 import { validateDoi, validateStringOrNumber } from '../utils/validators.js';
-import { PAGE_KNOWN_PARTS, PROJECT_FRONTMATTER_KEYS } from './types.js';
+import { PROJECT_FRONTMATTER_KEYS } from './types.js';
 import type { ProjectAndPageFrontmatter, ProjectFrontmatter } from './types.js';
 import { validateProjectAndPageSettings } from '../settings/validators.js';
 import { FRONTMATTER_ALIASES } from '../site/types.js';
@@ -169,40 +168,6 @@ export function validateProjectAndPageFrontmatterKeys(
       incrementOptions('settings', opts),
     );
     if (settings) output.settings = settings;
-  }
-  const partsOptions = incrementOptions('parts', opts);
-  let parts: Record<string, any> | undefined;
-  if (defined(value.parts)) {
-    parts = validateObjectKeys(
-      value.parts,
-      { optional: PAGE_KNOWN_PARTS, alias: FRONTMATTER_ALIASES },
-      { keepExtraKeys: true, suppressWarnings: true, ...partsOptions },
-    );
-  }
-  PAGE_KNOWN_PARTS.forEach((partKey) => {
-    if (defined(value[partKey])) {
-      parts ??= {};
-      if (parts[partKey]) {
-        validationError(`duplicate value for part ${partKey}`, partsOptions);
-      } else {
-        parts[partKey] = value[partKey];
-      }
-    }
-  });
-  if (parts) {
-    const partsEntries = Object.entries(parts)
-      .map(([k, v]) => {
-        return [
-          k,
-          validateList(v, { coerce: true, ...incrementOptions(k, partsOptions) }, (item, index) => {
-            return validateString(item, incrementOptions(`${k}.${index}`, partsOptions));
-          }),
-        ];
-      })
-      .filter((entry): entry is [string, string[]] => !!entry[1]?.length);
-    if (partsEntries.length > 0) {
-      output.parts = Object.fromEntries(partsEntries);
-    }
   }
   return output;
 }

--- a/packages/myst-frontmatter/src/site/types.ts
+++ b/packages/myst-frontmatter/src/site/types.ts
@@ -3,6 +3,16 @@ import type { Contributor } from '../contributors/types.js';
 import type { Funding } from '../funding/types.js';
 import type { Venue } from '../venues/types.js';
 
+export const PAGE_KNOWN_PARTS = [
+  'abstract',
+  'summary',
+  'keypoints',
+  'dedication',
+  'epigraph',
+  'data_availability',
+  'acknowledgments',
+];
+
 export const SITE_FRONTMATTER_KEYS = [
   'title',
   'subtitle',
@@ -24,6 +34,8 @@ export const SITE_FRONTMATTER_KEYS = [
   'funding',
   'copyright',
   'options',
+  'parts',
+  ...PAGE_KNOWN_PARTS,
 ];
 
 export const FRONTMATTER_ALIASES = {
@@ -82,4 +94,5 @@ export type SiteFrontmatter = {
   copyright?: string;
   contributors?: Contributor[];
   options?: Record<string, any>;
+  parts?: Record<string, string[]>;
 };

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -184,6 +184,7 @@ export type InlineExpression = {
 export enum SourceFileKind {
   Article = 'Article',
   Notebook = 'Notebook',
+  Part = 'Part',
 }
 
 export type Dependency = {

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -1,8 +1,8 @@
-import type { Contributor, ProjectFrontmatter, Affiliation } from 'myst-frontmatter';
+import type { Contributor, Affiliation } from 'myst-frontmatter';
 import * as credit from 'credit-roles';
 import { doi } from 'doi-utils';
 import { orcid } from 'orcid';
-import type { Element, IJatsSerializer } from './types.js';
+import type { Element, FrontmatterWithParts, IJatsSerializer } from './types.js';
 
 export function getJournalIds(): Element[] {
   // [{ type: 'element', name: 'journal-id', attributes: {'journal-id-type': ...}, text: ...}]
@@ -59,7 +59,7 @@ export function getJournalMeta(): Element | null {
  *
  * See: https://jats.nlm.nih.gov/archiving/tag-library/1.3/element/article-title.html
  */
-export function getArticleTitle(frontmatter: ProjectFrontmatter): Element[] {
+export function getArticleTitle(frontmatter: FrontmatterWithParts): Element[] {
   const title = frontmatter?.title;
   const subtitle = frontmatter?.subtitle;
   const short_title = frontmatter?.short_title;
@@ -156,7 +156,7 @@ function nameElementFromContributor(contrib: Contributor): Element | undefined {
  *
  * Authors are tagged as contrib-type="author"
  */
-export function getArticleAuthors(frontmatter: ProjectFrontmatter): Element[] {
+export function getArticleAuthors(frontmatter: FrontmatterWithParts): Element[] {
   const generateContrib = (author: Contributor, type?: string): Element => {
     const attributes: Record<string, any> = {};
     const elements: Element[] = [];
@@ -302,7 +302,7 @@ function instWrapElementsFromAffiliation(affiliation: Affiliation, includeDept =
   return elements;
 }
 
-export function getArticleAffiliations(frontmatter: ProjectFrontmatter): Element[] {
+export function getArticleAffiliations(frontmatter: FrontmatterWithParts): Element[] {
   if (!frontmatter.affiliations?.length) return [];
   // Only add affiliations from authors, not contributors
   const affIds = [
@@ -393,7 +393,7 @@ export function getArticleAffiliations(frontmatter: ProjectFrontmatter): Element
   return affs ? affs : [];
 }
 
-export function getArticlePermissions(frontmatter: ProjectFrontmatter): Element[] {
+export function getArticlePermissions(frontmatter: FrontmatterWithParts): Element[] {
   // copyright-statement: '© 2023, Authors et al'
   // copyright-year: '2023'
   // copyright-holder: 'Authors et al'
@@ -460,14 +460,14 @@ export function getArticlePermissions(frontmatter: ProjectFrontmatter): Element[
     : [];
 }
 
-export function getKwdGroup(frontmatter: ProjectFrontmatter): Element[] {
+export function getKwdGroup(frontmatter: FrontmatterWithParts): Element[] {
   const kwds = frontmatter.keywords?.map((keyword): Element => {
     return { type: 'element', name: 'kwd', elements: [{ type: 'text', text: keyword }] };
   });
   return kwds?.length ? [{ type: 'element', name: 'kwd-group', elements: kwds }] : [];
 }
 
-export function getFundingGroup(frontmatter: ProjectFrontmatter): Element[] {
+export function getFundingGroup(frontmatter: FrontmatterWithParts): Element[] {
   const fundingGroups = frontmatter.funding?.map((fund): Element => {
     const elements: Element[] = [];
     if (fund.awards?.length) {
@@ -588,21 +588,21 @@ export function getFundingGroup(frontmatter: ProjectFrontmatter): Element[] {
   return fundingGroups ? fundingGroups : [];
 }
 
-export function getArticleVolume(frontmatter: ProjectFrontmatter): Element[] {
+export function getArticleVolume(frontmatter: FrontmatterWithParts): Element[] {
   const text = frontmatter.volume?.number;
   return text
     ? [{ type: 'element', name: 'volume', elements: [{ type: 'text', text: `${text}` }] }]
     : [];
 }
 
-export function getArticleIssue(frontmatter: ProjectFrontmatter): Element[] {
+export function getArticleIssue(frontmatter: FrontmatterWithParts): Element[] {
   const text = frontmatter.issue?.number;
   return text
     ? [{ type: 'element', name: 'issue', elements: [{ type: 'text', text: `${text}` }] }]
     : [];
 }
 
-export function getArticlePages(frontmatter: ProjectFrontmatter): Element[] {
+export function getArticlePages(frontmatter: FrontmatterWithParts): Element[] {
   // fpage/lpage, page-range, or elocation-id
   const { first_page, last_page } = frontmatter ?? {};
   const pages: Element[] = [];
@@ -623,7 +623,7 @@ export function getArticlePages(frontmatter: ProjectFrontmatter): Element[] {
   return pages;
 }
 
-export function getArticleIds(frontmatter: ProjectFrontmatter): Element[] {
+export function getArticleIds(frontmatter: FrontmatterWithParts): Element[] {
   const ids: Element[] = [];
   if (doi.validate(frontmatter.doi)) {
     ids.push({
@@ -636,7 +636,10 @@ export function getArticleIds(frontmatter: ProjectFrontmatter): Element[] {
   return ids;
 }
 
-export function getArticleMeta(frontmatter?: ProjectFrontmatter, state?: IJatsSerializer): Element {
+export function getArticleMeta(
+  frontmatter?: FrontmatterWithParts,
+  state?: IJatsSerializer,
+): Element {
   const elements = [];
   if (frontmatter) {
     elements.push(
@@ -690,7 +693,7 @@ export function getArticleMeta(frontmatter?: ProjectFrontmatter, state?: IJatsSe
  *
  * This element must be defined in a JATS article and must include <article-meta>
  */
-export function getFront(frontmatter?: ProjectFrontmatter, state?: IJatsSerializer): Element[] {
+export function getFront(frontmatter?: FrontmatterWithParts, state?: IJatsSerializer): Element[] {
   const elements: Element[] = [];
   const journalMeta = getJournalMeta();
   if (journalMeta) elements.push(journalMeta);

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -1,4 +1,4 @@
-import type { GenericNode, MessageInfo } from 'myst-common';
+import type { GenericNode, GenericParent, MessageInfo } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import type { Root } from 'myst-spec';
 import type { SourceFileKind } from 'myst-spec-ext';
@@ -34,6 +34,7 @@ export type Options = {
   extractAbstract?: boolean;
   abstractParts?: JatsPart[];
   backSections?: JatsPart[];
+  frontmatterParts?: Record<string, GenericParent>;
 };
 
 export type DocumentOptions = Options &
@@ -51,10 +52,14 @@ export type StateData = {
   acknowledgments?: Element;
 };
 
+export type FrontmatterWithParts = Omit<PageFrontmatter, 'parts'> & {
+  parts?: Record<string, GenericParent>;
+};
+
 export type ArticleContent = {
   mdast: Root;
   kind: SourceFileKind;
-  frontmatter?: PageFrontmatter;
+  frontmatter?: FrontmatterWithParts;
   citations?: CitationRenderer;
   slug?: string;
 };

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -1,4 +1,4 @@
-import type { GenericNode, GenericParent, MessageInfo } from 'myst-common';
+import type { FrontmatterParts, GenericNode, MessageInfo } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import type { Root } from 'myst-spec';
 import type { SourceFileKind } from 'myst-spec-ext';
@@ -34,7 +34,7 @@ export type Options = {
   extractAbstract?: boolean;
   abstractParts?: JatsPart[];
   backSections?: JatsPart[];
-  frontmatterParts?: Record<string, GenericParent>;
+  frontmatterParts?: FrontmatterParts;
 };
 
 export type DocumentOptions = Options &
@@ -53,7 +53,7 @@ export type StateData = {
 };
 
 export type FrontmatterWithParts = Omit<PageFrontmatter, 'parts'> & {
-  parts?: Record<string, GenericParent>;
+  parts?: FrontmatterParts;
 };
 
 export type ArticleContent = {

--- a/packages/myst-transforms/src/frontmatter.ts
+++ b/packages/myst-transforms/src/frontmatter.ts
@@ -4,10 +4,10 @@ import { select } from 'unist-util-select';
 import type { Block, Code, Heading } from 'myst-spec';
 import type { GenericParent } from 'myst-common';
 import { RuleId, fileError, toText, fileWarn, normalizeLabel } from 'myst-common';
+import { fillProjectFrontmatter } from 'myst-frontmatter';
 import type { VFile } from 'vfile';
 import { mystTargetsTransform } from './targets.js';
 import { liftMystDirectivesAndRolesTransform } from './liftMystDirectivesAndRoles.js';
-import { fillPageFrontmatter } from 'myst-frontmatter';
 
 type Options = {
   /**
@@ -69,7 +69,7 @@ export function getFrontmatter(
     }
   }
   if (opts.preFrontmatter) {
-    frontmatter = fillPageFrontmatter(opts.preFrontmatter, frontmatter, {
+    frontmatter = fillProjectFrontmatter(opts.preFrontmatter, frontmatter, {
       property: 'frontmatter',
       file: file.path,
       messages: {},

--- a/packages/mystmd/tests/endToEnd.spec.ts
+++ b/packages/mystmd/tests/endToEnd.spec.ts
@@ -28,39 +28,35 @@ function resolve(relative: string) {
 
 const only = '';
 
-describe.concurrent(
-  'End-to-end cli export tests',
-  () => {
-    const cases = loadCases('exports.yml');
-    test.each(
-      cases.filter((c) => !only || c.title === only).map((c): [string, TestCase] => [c.title, c]),
-    )('%s', async (_, { cwd, command, outputs }) => {
-      // Clean expected outputs if they already exist
-      await Promise.all(
-        outputs.map(async (output) => {
-          if (fs.existsSync(resolve(output.path))) {
-            await exec(`rm ${resolve(output.path)}`, { cwd: resolve(cwd) });
-          }
-        }),
-      );
-      // Run CLI command
-      await exec(command, { cwd: resolve(cwd) });
-      // Expect correct output
-      outputs.forEach((output) => {
-        expect(fs.existsSync(resolve(output.path))).toBeTruthy();
-        if (path.extname(output.content) === '.json') {
-          expect(
-            JSON.parse(fs.readFileSync(resolve(output.path), { encoding: 'utf-8' })),
-          ).toMatchObject(
-            JSON.parse(fs.readFileSync(resolve(output.content), { encoding: 'utf-8' })),
-          );
-        } else {
-          expect(fs.readFileSync(resolve(output.path), { encoding: 'utf-8' })).toEqual(
-            fs.readFileSync(resolve(output.content), { encoding: 'utf-8' }),
-          );
+describe.concurrent('End-to-end cli export tests', { timeout: 15000 }, () => {
+  const cases = loadCases('exports.yml');
+  test.each(
+    cases.filter((c) => !only || c.title === only).map((c): [string, TestCase] => [c.title, c]),
+  )('%s', async (_, { cwd, command, outputs }) => {
+    // Clean expected outputs if they already exist
+    await Promise.all(
+      outputs.map(async (output) => {
+        if (fs.existsSync(resolve(output.path))) {
+          await exec(`rm ${resolve(output.path)}`, { cwd: resolve(cwd) });
         }
-      });
+      }),
+    );
+    // Run CLI command
+    await exec(command, { cwd: resolve(cwd) });
+    // Expect correct output
+    outputs.forEach((output) => {
+      expect(fs.existsSync(resolve(output.path))).toBeTruthy();
+      if (path.extname(output.content) === '.json') {
+        expect(
+          JSON.parse(fs.readFileSync(resolve(output.path), { encoding: 'utf-8' })),
+        ).toMatchObject(
+          JSON.parse(fs.readFileSync(resolve(output.content), { encoding: 'utf-8' })),
+        );
+      } else {
+        expect(fs.readFileSync(resolve(output.path), { encoding: 'utf-8' })).toEqual(
+          fs.readFileSync(resolve(output.content), { encoding: 'utf-8' }),
+        );
+      }
     });
-  },
-  { timeout: 15000 },
-);
+  });
+});


### PR DESCRIPTION
This PR addresses part of this issue: https://github.com/jupyter-book/mystmd/issues/1246 - specifically,

> Allow frontmatter part to be a file
>
> Modify behaviour of in-line frontmatter parts be processed as a "pseudo-file" rather than injected into the page tree
>
> Allow site to define parts
>
> Update static export templating logic and extractPart for new part definition locations

The parts of that issue that are not yet addressed in this PR are

> Allow exports to define parts
>
> Update site templating logic to respect parts in template.yml

~Additionally, project-level parts are still _valid_, but are not processed in the same way as page or site parts (i.e. they are still left as text in-line in the frontmatter)~ This PR has been updated so project-level parts are processed to mdast/frontmatter objects, as suggested in the review.
