### PR TITLE
👩‍💻 Proposed notes on versioning for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,12 @@ Running in live-changes mode: depending on the package you are working in we hav
 
 `mystmd` uses [changesets](https://github.com/changesets/changesets) to document changes to this monorepo, call `npm run changeset` and follow the prompts. Later, `npm run version` will be called and then `npm run publish`.
 
+Our current versioning procedure is a little loose compared to strict semantic versioning; as `mystmd` continues to mature, this policy may need to update. For now, we try to abide by the following rules for version bumps:
+
+- **major**: Backwards incompatible change to the underlying supported MyST data. These would be cases where a non-developer MyST user's project or site built with major version _N_ would not work with major version _N+1_. Currently, we never intentionally make these changes.
+- **minor**: Backwards incompatible change to the Javascript API, for example, changing the call signature or deleting an exported function. These can be a headache for developers consuming MyST libraries, but they do not break MyST content.
+- **patch**: For now, everything else is a patch: bug fixes, new features, refactors. This means some patch releases have a huge, positive impact on users and other patch releases are basically invisible.
+
 ### Packages in the mystmd repository
 
 All packages for `mystmd` are included in this repository (a monorepo!).


### PR DESCRIPTION
This PR is an attempt to slightly formalize my answer to this: https://github.com/jupyter-book/mystmd/pull/1650#issuecomment-2485557941

I'm totally open to feedback here - this is just the general rules I personally follow when bumping versions (and I always try to avoid any changes that don't just fall under `patch`...).

These rules are different from "official" semantic versioning which is basically - major: any breaking change, minor: any feature, patch: bugfix. But I'd argue in favor of maintaining the distinction between user-facing breaking change vs. developer-facing breaking change. (Possibly this suggests we should have different versioning on `mystmd` - "user-facing" - and `myst-cli` - "dev-facing" - where breaking changes can imply different levels of impact...)