### PR TITLE
🔧 More typst export improvements

### DIFF
--- a/.changeset/beige-ways-learn.md
+++ b/.changeset/beige-ways-learn.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Allow overriding default breakable value for typst figures

--- a/.changeset/clean-toys-work.md
+++ b/.changeset/clean-toys-work.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Add hook for customizing table columns in typst

--- a/.changeset/heavy-melons-count.md
+++ b/.changeset/heavy-melons-count.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Render table legends below tables in typst

--- a/.changeset/soft-shrimps-brake.md
+++ b/.changeset/soft-shrimps-brake.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Support lists that do not start at 1 in typst

--- a/.changeset/tidy-crabs-rhyme.md
+++ b/.changeset/tidy-crabs-rhyme.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Render cross-references with correct text in typst

--- a/.changeset/unlucky-adults-fry.md
+++ b/.changeset/unlucky-adults-fry.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Support table cell background color in typst

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -99,7 +99,10 @@ export const containerHandler: Handler = (node, state) => {
       nonCaptions.filter((item: GenericNode) => item.type === 'container').length ===
       nonCaptions.length;
     state.useMacro('#import "@preview/subpar:0.1.1"');
-    state.write(`#show figure: set block(breakable: ${allSubFigs ? 'false' : 'true'})\n`);
+    state.useMacro('#let breakableDefault = true');
+    state.write(
+      `#show figure: set block(breakable: ${allSubFigs ? 'false' : 'breakableDefault'})\n`,
+    );
     state.write('#subpar.grid(');
     let columns = nonCaptions.length <= 3 ? nonCaptions.length : 2; // TODO: allow this to be customized
     nonCaptions.forEach((item: GenericNode) => {
@@ -123,12 +126,14 @@ export const containerHandler: Handler = (node, state) => {
       label = undefined;
     }
   } else if (nonCaptions && nonCaptions.length === 1) {
-    state.write('#show figure: set block(breakable: true)\n');
+    state.useMacro('#let breakableDefault = true');
+    state.write('#show figure: set block(breakable: breakableDefault)\n');
     state.write('#figure(');
     renderFigureChild(nonCaptions[0], state);
     state.write(',');
   } else {
-    state.write('#show figure: set block(breakable: true)\n');
+    state.useMacro('#let breakableDefault = true');
+    state.write('#show figure: set block(breakable: breakableDefault)\n');
     state.write('#figure([\n  ');
     state.renderChildren(node, 1);
     state.write('],');

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -352,7 +352,7 @@ const handlers: Record<string, Handler> = {
   caption: captionHandler,
   legend: captionHandler,
   captionNumber: () => undefined,
-  crossReference(node: CrossReference, state, parent) {
+  crossReference(node: CrossReference, state) {
     if (node.remote) {
       // We don't want to handle remote references, treat them as links
       const url =
@@ -362,13 +362,10 @@ const handlers: Record<string, Handler> = {
       linkHandler({ ...node, url: url }, state);
       return;
     }
-    // Look up reference and add the text
-    // const usedTemplate = node.template?.includes('%s') ? node.template : undefined;
-    // const text = (usedTemplate ?? toText(node))?.replace(/\s/g, '~') || '%s';
     const id = node.identifier;
-    // state.write(text.replace(/%s/g, `@${id}`));
-    const next = nextCharacterIsText(parent, node);
-    state.write(next ? `#[@${id}]` : `@${id}`);
+    state.write(`#link(<${id}>)[`);
+    state.renderChildren(node);
+    state.write(']');
   },
   citeGroup(node, state) {
     state.renderChildren(node, 0, { delim: ' ' });

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -189,10 +189,17 @@ const handlers: Record<string, Handler> = {
     state.addNewLine();
   },
   list(node, state) {
+    const setStart = node.ordered && node.start && node.start !== 1;
+    if (setStart) {
+      state.write(`#set enum(start: ${node.start})`);
+    }
     state.data.list ??= { env: [] };
     state.data.list.env.push(node.ordered ? '+' : '-');
-    state.renderChildren(node, 2);
+    state.renderChildren(node, setStart ? 1 : 2);
     state.data.list.env.pop();
+    if (setStart) {
+      state.write('#set enum(start: 1)\n\n');
+    }
   },
   listItem(node, state) {
     const listEnv = state.data.list?.env ?? [];

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -352,7 +352,7 @@ const handlers: Record<string, Handler> = {
   caption: captionHandler,
   legend: captionHandler,
   captionNumber: () => undefined,
-  crossReference(node: CrossReference, state) {
+  crossReference(node: CrossReference, state, parent) {
     if (node.remote) {
       // We don't want to handle remote references, treat them as links
       const url =
@@ -363,9 +363,14 @@ const handlers: Record<string, Handler> = {
       return;
     }
     const id = node.identifier;
-    state.write(`#link(<${id}>)[`);
-    state.renderChildren(node);
-    state.write(']');
+    if (node.children && node.children.length > 0) {
+      state.write(`#link(<${id}>)[`);
+      state.renderChildren(node);
+      state.write(']');
+    } else {
+      const next = nextCharacterIsText(parent, node);
+      state.write(next ? `#[@${id}]` : `@${id}`);
+    }
   },
   citeGroup(node, state) {
     state.renderChildren(node, 0, { delim: ' ' });

--- a/packages/myst-to-typst/src/table.ts
+++ b/packages/myst-to-typst/src/table.ts
@@ -34,6 +34,8 @@ export const tableHandler: Handler = (node, state) => {
     return;
   }
   state.useMacro('#import "@preview/tablex:0.0.9": tablex, cellx, hlinex, vlinex');
+  // These two separate style hooks are somewhat redundant, but they allow defining
+  // article-wide styles and single-table styles separately
   state.useMacro('#let tableStyle = (:)');
   state.useMacro('#let columnStyle = (:)');
   state.write(

--- a/packages/myst-to-typst/src/table.ts
+++ b/packages/myst-to-typst/src/table.ts
@@ -48,7 +48,7 @@ export const tableRowHandler: Handler = (node, state) => {
 };
 
 export const tableCellHandler: Handler = (node, state) => {
-  if (node.rowspan || node.colspan || node.align) {
+  if (node.rowspan || node.colspan || node.align || node.style?.backgroundColor) {
     state.write('cellx(');
     if (node.rowspan) {
       state.write(`rowspan: ${node.rowspan}, `);
@@ -58,6 +58,9 @@ export const tableCellHandler: Handler = (node, state) => {
     }
     if (node.align) {
       state.write(`align: ${node.align}, `);
+    }
+    if (node.style?.backgroundColor) {
+      state.write(`fill: rgb("${node.style.backgroundColor}"), `);
     }
     state.write(')');
   }

--- a/packages/myst-to-typst/src/table.ts
+++ b/packages/myst-to-typst/src/table.ts
@@ -35,8 +35,9 @@ export const tableHandler: Handler = (node, state) => {
   }
   state.useMacro('#import "@preview/tablex:0.0.9": tablex, cellx, hlinex, vlinex');
   state.useMacro('#let tableStyle = (:)');
+  state.useMacro('#let columnStyle = (:)');
   state.write(
-    `${command}(columns: ${columns}, header-rows: ${countHeaderRows(node)}, repeat-header: true, ..tableStyle,\n`,
+    `${command}(columns: ${columns}, header-rows: ${countHeaderRows(node)}, repeat-header: true, ..tableStyle, ..columnStyle,\n`,
   );
   state.renderChildren(node, 1);
   state.write(')\n');

--- a/packages/myst-to-typst/tests/cross-references.yml
+++ b/packages/myst-to-typst/tests/cross-references.yml
@@ -21,7 +21,7 @@ cases:
     typst: |-
       = My Heading <section-one>
 
-      Please see @section-one for more information!
+      Please see #link(<section-one>)[] for more information!
   - title: references followed by text
     mdast:
       type: root
@@ -35,4 +35,4 @@ cases:
             - type: text
               value: 'a for the first part of the figure!'
     typst: |-
-      See #[@fig1]a for the first part of the figure!
+      See #link(<fig1>)[]a for the first part of the figure!

--- a/packages/myst-to-typst/tests/cross-references.yml
+++ b/packages/myst-to-typst/tests/cross-references.yml
@@ -21,7 +21,7 @@ cases:
     typst: |-
       = My Heading <section-one>
 
-      Please see #link(<section-one>)[] for more information!
+      Please see @section-one for more information!
   - title: references followed by text
     mdast:
       type: root
@@ -35,4 +35,21 @@ cases:
             - type: text
               value: 'a for the first part of the figure!'
     typst: |-
-      See #link(<fig1>)[]a for the first part of the figure!
+      See #[@fig1]a for the first part of the figure!
+  - title: references followed by text with children
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'See '
+            - type: crossReference
+              identifier: fig1
+              children:
+                - type: text
+                  value: 'Figure 56'
+            - type: text
+              value: 'a for the first part of the figure!'
+    typst: |-
+      See #link(<fig1>)[Figure 56]a for the first part of the figure!

--- a/packages/myst-to-typst/tests/figures.yml
+++ b/packages/myst-to-typst/tests/figures.yml
@@ -21,7 +21,7 @@ cases:
               url: glacier.jpg
               width: 500px
     typst: |-
-      #show figure: set block(breakable: true)
+      #show figure: set block(breakable: breakableDefault)
       #figure(
         image("glacier.jpg", width: 62.5%),
         kind: "figure",
@@ -45,7 +45,7 @@ cases:
                     - type: text
                       value: A curious figure.
     typst: |-
-      #show figure: set block(breakable: true)
+      #show figure: set block(breakable: breakableDefault)
       #figure(
         image("glacier.jpg", width: 62.5%),
         caption: [

--- a/packages/myst-to-typst/tests/tables.yml
+++ b/packages/myst-to-typst/tests/tables.yml
@@ -31,7 +31,7 @@ cases:
                       value: Row 1, Column 2
 
     typst: |-
-      #tablex(columns: 2, header-rows: 1, repeat-header: true, ..tableStyle,
+      #tablex(columns: 2, header-rows: 1, repeat-header: true, ..tableStyle, ..columnStyle,
       [
       Head 1, Column 1
       ],
@@ -78,7 +78,7 @@ cases:
                       value: Row 1, Column 2
 
     typst: |-
-      #tablex(columns: 2, header-rows: 1, repeat-header: true, ..tableStyle,
+      #tablex(columns: 2, header-rows: 1, repeat-header: true, ..tableStyle, ..columnStyle,
       [
       Head 1, Column 1
       ],
@@ -119,7 +119,7 @@ cases:
                       value: Row 1, Column 2
 
     typst: |-
-      #tablex(columns: 2, header-rows: 0, repeat-header: true, ..tableStyle,
+      #tablex(columns: 2, header-rows: 0, repeat-header: true, ..tableStyle, ..columnStyle,
       cellx(rowspan: 2, )[
       Head 1, Column 1
       ],
@@ -156,7 +156,7 @@ cases:
                       value: Row 1, Column 2
 
     typst: |-
-      #tablex(columns: 2, header-rows: 0, repeat-header: true, ..tableStyle,
+      #tablex(columns: 2, header-rows: 0, repeat-header: true, ..tableStyle, ..columnStyle,
       cellx(colspan: 2, )[
       Head 1, Column 1
       ],


### PR DESCRIPTION
This PR just has a handful of typst improvements from working on formatting a PDF export:

Newly supported small typst features include:
- ordered lists that do not start at 1
- table cell background color

Areas where typst now matches other myst exports better:
- cross-references maintain their children (e.g. `[see here](#fig1)` will render as "see here" in typst instead of the default "Figure 1")
- table legends now appear below tables

Areas where it is easier to customize typst:
- default "breakable" value for figures may be set in your source content
- "columnStyle" can be defined on a per-table basis, allowing injecting specific column widths (and possibly other table styles)