### PR TITLE
⌨️ Add `keyboard` support to `myst-to-html`

### DIFF
--- a/.changeset/cold-elephants-vanish.md
+++ b/.changeset/cold-elephants-vanish.md
@@ -1,0 +1,5 @@
+---
+"myst-to-html": patch
+---
+
+Support keyboard nodes in HTML export

--- a/package-lock.json
+++ b/package-lock.json
@@ -16016,6 +16016,51 @@
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.3",
         "unist-util-visit": "^4.1.0"
+      },
+      "devDependencies": {
+        "hastscript": "^7.0.0"
+      }
+    },
+    "packages/myst-to-html/node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "packages/myst-to-html/node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "packages/myst-to-html/node_modules/hastscript": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.0.tgz",
+      "integrity": "sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "packages/myst-to-html/node_modules/unist-builder": {

--- a/packages/myst-to-html/package.json
+++ b/packages/myst-to-html/package.json
@@ -51,9 +51,12 @@
     "rehype-stringify": "^9.0.3",
     "unified": "^10.1.2",
     "unist-builder": "^3.0.0",
+    "unist-util-find-after": "^4.0.0",
     "unist-util-remove": "^3.1.0",
     "unist-util-select": "^4.0.3",
-    "unist-util-visit": "^4.1.0",
-    "unist-util-find-after": "^4.0.0"
+    "unist-util-visit": "^4.1.0"
+  },
+  "devDependencies": {
+    "hastscript": "^7.0.0"
   }
 }

--- a/packages/myst-to-html/src/schema.ts
+++ b/packages/myst-to-html/src/schema.ts
@@ -161,6 +161,7 @@ const mdast: Handler = (h, node) => h(node, 'div', { id: node.id });
 const mermaid: Handler = (h, node) => h(node, 'div', { class: 'margin' });
 const myst: Handler = (h, node) => h(node, 'div', { class: 'margin' });
 const output: Handler = (h, node) => h(node, 'div', { class: 'output' });
+const keyboard: Handler = (h, node) => h(node, 'kbd', all(h, node));
 
 export const mystToHast: Plugin<[Options?], string, GenericParent> =
   (opts) => (tree: GenericParent) => {
@@ -202,6 +203,7 @@ export const mystToHast: Plugin<[Options?], string, GenericParent> =
         mermaid,
         myst,
         output,
+	keyboard,
         ...opts?.handlers,
       },
     });

--- a/packages/myst-to-html/src/schema.ts
+++ b/packages/myst-to-html/src/schema.ts
@@ -203,7 +203,7 @@ export const mystToHast: Plugin<[Options?], string, GenericParent> =
         mermaid,
         myst,
         output,
-	keyboard,
+        keyboard,
         ...opts?.handlers,
       },
     });

--- a/packages/myst-to-html/tests/schema.spec.ts
+++ b/packages/myst-to-html/tests/schema.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { mystToHast } from '../src/schema';
+import { u } from 'unist-builder';
+import { h } from 'hastscript';
+
+// @ts-expect-error this
+const toHast: (node: any) => any = mystToHast();
+
+describe('mystToHast', () => {
+  it('Converts a keyboard node to kbd', () => {
+    const hast = toHast(
+      u('root', [u('paragraph', [u('keyboard', [u('text', { value: 'Ctrl' })])])]),
+    );
+    expect(hast).toStrictEqual(h(null, [h('p', [h('kbd', 'Ctrl')])]));
+  });
+});

--- a/packages/myst-to-html/tests/schema.spec.ts
+++ b/packages/myst-to-html/tests/schema.spec.ts
@@ -3,7 +3,6 @@ import { mystToHast } from '../src/schema';
 import { u } from 'unist-builder';
 import { h } from 'hastscript';
 
-// @ts-expect-error this
 const toHast: (node: any) => any = mystToHast();
 
 describe('mystToHast', () => {


### PR DESCRIPTION
Addresses a sub-issue in #1676 for HTML exports of `keyboard` nodes.

I only test the hast here, because we should be able to rely on the ecosystem tests for hast-to-html imo.