### PR TITLE
🔗 Improve link formatting

### DIFF
--- a/.changeset/nervous-avocados-tell.md
+++ b/.changeset/nervous-avocados-tell.md
@@ -1,0 +1,5 @@
+---
+"myst-transforms": patch
+---
+
+No trailing slash for end of links

--- a/packages/myst-transforms/src/links/plugin.spec.ts
+++ b/packages/myst-transforms/src/links/plugin.spec.ts
@@ -3,7 +3,7 @@ import { VFile } from 'vfile';
 import type { Link } from 'myst-spec-ext';
 import type { ResolvedExternalReference } from './types';
 import { MystTransformer } from './myst';
-import { linksTransform } from './plugin';
+import { formatLinkText, linksTransform } from './plugin';
 
 export const TEST_REFERENCES: ResolvedExternalReference[] = [
   {
@@ -45,5 +45,23 @@ describe('Link Plugin Transformer', () => {
     expect((link as any).identifier).toEqual('explicit-figure');
     expect((link as any).label).toEqual('explicit-figure');
     expect(link.children).toEqual([]);
+  });
+});
+
+describe('formatLinkText', () => {
+  test.each([
+    ['https://mystmd.com/guide', 'https://​mystmd​.com​/guide'],
+    ['https://mystmd.com/guide#x', 'https://​mystmd​.com​/guide#x'],
+    ['https://mystmd.com/guide#abc', 'https://​mystmd​.com​/guide​#abc'],
+    ['https://mystmd.com/guide/', 'https://​mystmd​.com​/guide/'],
+    ['https://mystmd.com/guide/', 'https://​mystmd​.com​/guide/'],
+    [
+      'https://mystmd.com/guide/citaion-format?test=1#ok',
+      'https://​mystmd​.com​/guide​/citaion​-format​?test​=​1​#ok',
+    ],
+  ])('Link Text — %s', (url, result) => {
+    const node = { type: 'link', children: [{ type: 'text', value: url }] };
+    formatLinkText(node as any);
+    expect(node.children[0].value).toBe(result);
   });
 });

--- a/packages/myst-transforms/src/links/plugin.ts
+++ b/packages/myst-transforms/src/links/plugin.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-irregular-whitespace */
 import type { Plugin } from 'unified';
 import { selectAll } from 'unist-util-select';
 import type { VFile } from 'vfile';
@@ -15,7 +16,7 @@ type Options = {
  * Uses a zero-width space, same as a `<wbr>` but no fancy rendering required.
  * https://css-tricks.com/better-line-breaks-for-long-urls/
  */
-function formatLinkText(link: Link) {
+export function formatLinkText(link: Link) {
   if (link.children?.length !== 1 || link.children[0].type !== 'text') return;
   const url = link.children[0].value;
   // Add an exception for wiki transforms links.
@@ -34,7 +35,8 @@ function formatLinkText(link: Link) {
           .replace(/([=&])/giu, '​$1​'),
       // Reconnect the strings with word break opportunities after double slashes
     )
-    .join('//​');
+    .join('//​')
+    .replace(/​(.{1,2})$/, '$1');
   link.children[0].value = formatted;
 }
 


### PR DESCRIPTION
No hanging single characters on a link.

We put `<wbr/>` in HTML so that long URLs wrap at nice places. This wrapped and is especially noticeable in links ending with slash `mystmd.org/`, and then the slash would be on the next line alone.

This ensures that it needs at least three characters at the end before breaking the URL.