### PR TITLE
☣️ Refactor `transformMdast` and `postProcessMdast` to a single pipeline

### DIFF
--- a/packages/myst-cli/src/build/utils/getFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getFileContent.ts
@@ -8,11 +8,15 @@ import { loadReferences } from '../../process/loadReferences.js';
 import type { TransformFn } from '../../process/mdast.js';
 import { transformMdast } from '../../process/mdast.js';
 import { loadProject, selectPageReferenceStates } from '../../process/site.js';
+import { buildIndexTransform, MultiPageReferenceResolver } from 'myst-transforms';
 import type { ISession } from '../../session/types.js';
 import { selectors } from '../../store/index.js';
 import type { ImageExtensions } from '../../utils/resolveExtension.js';
+import { castSession } from '../../session/cache.js';
+import { VFile } from 'vfile';
+import { logMessagesFromVFile } from '../../utils/logging.js';
 
-function makeSyncPoint(clients: string[]): {
+export function makeSyncPoint(clients: string[]): {
   promises: Promise<void>[];
   dispatch: (client: string) => void;
 } {
@@ -80,8 +84,8 @@ export async function getFileContent(
   // Keep 'files' indices consistent in 'allFiles' as index is used for other fields.
   const allFiles = [...files, ...projectFiles, ...projectParts];
 
-  const { dispatchReferencing, promises: referencingPromises } = makeSyncPoint(allFiles);
-  const { dispatchIndexing, promises: indexingPromises } = makeSyncPoint(allFiles);
+  const { dispatch: dispatchReferencing, promises: referencingPromises } = makeSyncPoint(allFiles);
+  const { dispatch: dispatchIndexing, promises: indexingPromises } = makeSyncPoint(allFiles);
 
   // TODO: maybe move transformMdast into a multi-file function
   const referenceStateContext: {

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -442,9 +442,11 @@ export async function transformMdast(
       }),
     transformOptions,
   );
-  builder.addTransform('ror', (tree) => transformLinkedRORs(session, vfile, tree, file), {
-    skip: !runPostProcess,
-  });
+  builder.addTransform(
+    'ror',
+    (tree) => transformLinkedRORs(session, vfile, tree, file),
+    transformOptions,
+  );
   builder.addTransform(
     'resolve-references',
     (tree) =>

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -459,7 +459,7 @@ export async function fastProcessFile(
     });
   });
   await Promise.all(
-    allFiles.map(async (f) => {
+    allFiles.map((f) => {
       const referenceResolutionBlocker = async () => {
         dispatchReferencing(file);
         await Promise.all(referencingPromises);
@@ -647,7 +647,7 @@ export async function processProject(
       }),
     );
     await Promise.all(
-      pages.map(async (page) => {
+      pages.map((page) => {
         return writeFile(session, {
           file: page.file,
           projectSlug: siteProject.slug as string,

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -119,6 +119,8 @@ export type TransformSpec = {
   name: string;
   doc?: string;
   stage: 'document' | 'project';
+  before?: string;
+  after?: string;
   // context?: 'tex' | 'docx' | 'jats' | 'typst' | 'site';
   plugin: Plugin<
     [PluginOptions | undefined, PluginUtils],


### PR DESCRIPTION
This spike investigates fusing our single and multi-document pipelines. The motivation for this follows from previous conversations at SciPy 2024 about making more responsive MyST `start` builds, and capturing transform dependencies.

We originally discussed building MyST transforms as a directional graph. This PR is much less ambitious; it's not clear that a directional graph is necessarily desirable; MyST would become much harder to reason about if we can't treat it as a linear series of transforms.

There were other reasons not do go as far as a graph, but I can't remember them at this very moment.

1. Support fine-grained `before` and `after` constraints on plugins
2. Reason about MyST "pipeline" in one place
3. Prepare for customisable pipelines e.g. fast and slow passes

We did not have to fuse the pre and post phases; that was a choice to put logic in one place. The rationale is that we can treat the need perform referencing across pages as a "sync" point for builds within a single-document pipeline.