### PR TITLE
⌨️ Code block options can have caption

### DIFF
--- a/.changeset/sixty-swans-pull.md
+++ b/.changeset/sixty-swans-pull.md
@@ -1,0 +1,6 @@
+---
+"myst-directives": patch
+"myst-transforms": patch
+---
+
+Add caption to code-block options

--- a/packages/myst-directives/src/code.ts
+++ b/packages/myst-directives/src/code.ts
@@ -188,6 +188,10 @@ export const codeCellDirective: DirectiveSpec = {
   },
   options: {
     ...commonDirectiveOptions('code-cell'),
+    caption: {
+      type: 'myst',
+      doc: 'A parsed caption for the code output.',
+    },
     tags: {
       type: String,
       alias: ['tag'],
@@ -217,6 +221,12 @@ export const codeCellDirective: DirectiveSpec = {
       data: {},
     };
     addCommonDirectiveOptions(data, block);
+
+    if (data.options?.caption) {
+      // This is changed into a figure/container with a caption in `blockToFigureTransform`
+      // This can also be added using the `#| caption:` metadata in the code directly
+      block.data.caption = [{ type: 'paragraph', children: data.options.caption }];
+    }
 
     const tags = parseTags(data.options?.tags, vfile, data.node);
     if (tags) block.data.tags = tags;

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -114,7 +114,7 @@ export function blockToFigureTransform(
     const caption = block.data?.caption ?? block.data?.['fig-cap'] ?? block.data?.['tbl-cap'];
     if (caption) {
       const kind = block.data?.kind ?? (block.data?.['tbl-cap'] ? 'table' : 'figure');
-      const children = parser(caption).children ?? [];
+      const children = typeof caption === 'string' ? parser(caption).children ?? [] : caption;
       children.push(...block.children);
       const container: GenericParent = {
         type: 'container',


### PR DESCRIPTION
We already allow this for options defined with the `#| caption:` syntax, this expands to being allowed in the code-block options as well. 