### PR TITLE
⏬ Add mechanism for downgrading MyST AST

### DIFF
--- a/packages/myst-cli/src/transforms/crossReferences.ts
+++ b/packages/myst-cli/src/transforms/crossReferences.ts
@@ -86,7 +86,17 @@ export async function fetchMystXRefData(session: ISession, node: CrossReference,
   const rawData = await fetchMystData(session, dataUrl, node.urlSource, vfile);
   let data: MystData | undefined;
   if (node.remoteBaseUrl) {
-    // TODO
+    const cachePath = mystXRefsCacheFilename(node.remoteBaseUrl);
+    const mystXRefData = loadFromCache(session, cachePath, {
+      maxAge: XREF_MAX_AGE,
+    });
+    if (!mystXRefData) {
+      fileWarn(vfile, `Unable to load external MyST reference data: ${node.remoteBaseUrl}`);
+    } else {
+      const { version } = JSON.parse(mystXRefData) as { version: string };
+      console.log(`Loading xref ${node.urlSource} with version ${version}`);
+    }
+    data = rawData;
   } else {
     fileWarn(
       vfile,

--- a/packages/myst-cli/src/transforms/crossReferences.ts
+++ b/packages/myst-cli/src/transforms/crossReferences.ts
@@ -32,6 +32,10 @@ export type MystData = {
   references?: References;
 };
 
+async function maybeDowngradeMystData(rawData: MystData): Promise<MystData> {
+  return rawData;
+}
+
 async function fetchMystData(
   session: ISession,
   dataUrl: string | undefined,
@@ -48,7 +52,8 @@ async function fetchMystData(
     try {
       const resp = await session.fetch(dataUrl);
       if (resp.ok) {
-        const data = (await resp.json()) as MystData;
+        const rawData = (await resp.json()) as MystData;
+        const data = await maybeDowngradeMystData(rawData);
         writeToCache(session, filename, JSON.stringify(data));
         return data;
       }

--- a/packages/myst-cli/src/transforms/crossReferences.ts
+++ b/packages/myst-cli/src/transforms/crossReferences.ts
@@ -7,13 +7,17 @@ import { addChildrenFromTargetNode } from 'myst-transforms';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import type { CrossReference, Dependency, Link, SourceFileKind } from 'myst-spec-ext';
 import type { ISession } from '../session/types.js';
-import { loadFromCache, writeToCache } from '../session/cache.js';
+import { loadFromCache, writeToCache, checkCache } from '../session/cache.js';
 import type { SiteAction, SiteExport } from 'myst-config';
 
 export const XREF_MAX_AGE = 1; // in days
 
 function mystDataFilename(dataUrl: string) {
   return `myst-${computeHash(dataUrl)}.json`;
+}
+
+export function mystXRefsCacheFilename(url: string) {
+  return `xrefs-myst-${computeHash(url)}.json`;
 }
 
 export type MystData = {


### PR DESCRIPTION
As outlined in #1724, as the MyST user-base grows, we are increasingly likely to find ourselves in a situation whereby we feel reluctant to make breaking changes to our AST due to the impact upon the wider ecosystem of published knowledge. 

We already know of one breaking change (e.g. #1671), and it is not unlikely that there will be more in coming releases.

This PR introduces a mechanism for legacy `mystmd` applications to handle newer AST through a downgrade process. We would also need to use the same approach for `myst-theme`. Ideally, these will use the same downgrade bundles (with different build targets if needs be).

Closes #1724