### PR TITLE
🎆 Prevent html outputs that translate to empty images

### DIFF
--- a/.changeset/large-countries-cheer.md
+++ b/.changeset/large-countries-cheer.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Prevent html outputs that translate to empty images

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -279,6 +279,9 @@ export function reduceOutputs(
             ],
           };
           htmlTransform(htmlTree);
+          if ((selectAll('image', htmlTree) as GenericNode[]).find((htmlImage) => !htmlImage.url)) {
+            return undefined;
+          }
           return htmlTree.children;
         } else if (content_type.startsWith('image/')) {
           const path = writeCachedOutputToFile(session, hash, cache.$outputs[hash], writeFolder, {


### PR DESCRIPTION
If `output` has `html` media type that includes `image` node with no `url`, that output is entirely ignored. This approach is a little heavy-handed, but likely if we encounter an image with no url, the html is too complex to convert to markdown at all.

(This is a small part of the changes originally in https://github.com/jupyter-book/mystmd/pull/1701)