### PR TITLE
🖐 Support restarting counter for each typst article in multi-article export

### DIFF
--- a/.changeset/nasty-pets-smell.md
+++ b/.changeset/nasty-pets-smell.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Support restarting counter for each typst article in multi-article export

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -104,6 +104,10 @@ export const containerHandler: Handler = (node, state) => {
     return;
   }
 
+  // This resets the typst counter to match MyST numbering.
+  // However, it is dependent on the resolved enumerator value. This will work given
+  // default enumerators, but if the user sets numbering 'template' it will not work.
+  // TODO: persist `numbering` metadata in a way that typst can reset based on that.
   if (node.enumerator?.endsWith('.1')) {
     state.write(`#set figure(numbering: "${node.enumerator}")\n`);
     state.write(`#counter(figure.where(kind: "${kind}")).update(0)\n\n`);

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -104,6 +104,11 @@ export const containerHandler: Handler = (node, state) => {
     return;
   }
 
+  if (node.enumerator?.endsWith('.1')) {
+    state.write(`#set figure(numbering: "${node.enumerator}")\n`);
+    state.write(`#counter(figure.where(kind: "${kind}")).update(0)\n\n`);
+  }
+
   if (nonCaptions && nonCaptions.length > 1) {
     const allSubFigs =
       nonCaptions.filter((item: GenericNode) => item.type === 'container').length ===

--- a/packages/myst-to-typst/src/math.ts
+++ b/packages/myst-to-typst/src/math.ts
@@ -67,6 +67,10 @@ const math: Handler = (node, state) => {
   const { identifier: label } = normalizeLabel(node.label) ?? {};
   addMacrosToState(value, state);
   state.ensureNewLine();
+  if (node.enumerator?.endsWith('.1')) {
+    state.write(`#set math.equation(numbering: "(${node.enumerator})")\n`);
+    state.write(`#counter(math.equation).update(0)\n\n`);
+  }
   // Note: must have spaces $ math $ for the block!
   state.write(`$ ${value} $${label ? ` <${label}>` : ''}\n\n`);
   state.ensureNewLine(true);

--- a/packages/myst-to-typst/src/math.ts
+++ b/packages/myst-to-typst/src/math.ts
@@ -67,6 +67,9 @@ const math: Handler = (node, state) => {
   const { identifier: label } = normalizeLabel(node.label) ?? {};
   addMacrosToState(value, state);
   state.ensureNewLine();
+  // This resets the typst counter to match MyST numbering.
+  // However, it is dependent on the resolved enumerator value. This will work given
+  // default enumerators, but if the user sets numbering 'template' it will not work.
   if (node.enumerator?.endsWith('.1')) {
     state.write(`#set math.equation(numbering: "(${node.enumerator})")\n`);
     state.write(`#counter(math.equation).update(0)\n\n`);


### PR DESCRIPTION
For the most part, typst handles its own numbering. This PR forces typst to reset numbering where myst resets numbering. However, the way this PR determines where numbering resets is by looking at the `enumerator` - if this value is customized with `template` to not look like `#.#.#`, this counter reset will not happen...

(This is a small part of the changes originally in https://github.com/jupyter-book/mystmd/pull/1701)