### PR TITLE
🔧 Fix project cross-references in typst

### DIFF
--- a/.changeset/new-birds-bake.md
+++ b/.changeset/new-birds-bake.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Fix typst crossreferences to other pages

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -363,10 +363,10 @@ const handlers: Record<string, Handler> = {
   legend: captionHandler,
   captionNumber: () => undefined,
   crossReference(node: CrossReference, state, parent) {
-    if (node.remote) {
+    if (node.remoteBaseUrl) {
       // We don't want to handle remote references, treat them as links
       const url =
-        (node.remoteBaseUrl ?? '') +
+        node.remoteBaseUrl +
         (node.url === '/' ? '' : node.url ?? '') +
         (node.html_id ? `#${node.html_id}` : '');
       linkHandler({ ...node, url: url }, state);


### PR DESCRIPTION
This prevents cross-references to other pages in typst from being written as (invalid) links. They now remain as (correct) cross-references.

(This is a small part of the changes originally in https://github.com/jupyter-book/mystmd/pull/1701)