### PR TITLE
📄 Prioritize project-level parts for project-level typst export

### DIFF
--- a/.changeset/rare-months-rest.md
+++ b/.changeset/rare-months-rest.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Prioritize project-level parts for project-level typst export

--- a/packages/myst-cli/src/build/typst.ts
+++ b/packages/myst-cli/src/build/typst.ts
@@ -267,6 +267,31 @@ export async function localArticleToTypstTemplated(
     macros: [],
     commands: {},
   };
+  const state = session.store.getState();
+  const projectFrontmatter = selectors.selectLocalProjectConfig(state, projectPath ?? '.') ?? {};
+  if (file === selectors.selectCurrentProjectFile(state)) {
+    // If export is defined at the project level, prioritize project parts over page parts
+    partDefinitions.forEach((def) => {
+      const part = extractTypstPart(
+        session,
+        { type: 'root', children: [] },
+        {},
+        def,
+        projectFrontmatter,
+        templateYml,
+      );
+      if (Array.isArray(part)) {
+        // This is the case if def.as_list is true
+        part.forEach((item) => {
+          collected = mergeTypstTemplateImports(collected, item);
+        });
+        parts[def.id] = part.map(({ value }) => value);
+      } else if (part != null) {
+        collected = mergeTypstTemplateImports(collected, part);
+        parts[def.id] = part?.value ?? '';
+      }
+    });
+  }
   const hasGlossaries = false;
   const results = await Promise.all(
     content.map(async ({ mdast, frontmatter, references }, ind) => {
@@ -311,8 +336,7 @@ export async function localArticleToTypstTemplated(
     frontmatter = content[0].frontmatter;
     typstContent = results[0].value;
   } else {
-    const state = session.store.getState();
-    frontmatter = selectors.selectLocalProjectConfig(state, projectPath ?? '.') ?? {};
+    frontmatter = projectFrontmatter;
     const { dir, name, ext } = path.parse(output);
     typstContent = '';
     let fileInd = 0;


### PR DESCRIPTION
`parts` are allowed to be defined at the project level. For static exports, these were previously always ignored. This PR allows typst export to pick up on these `parts` when the typst export is also defined in the `myst.yml` file. In these cases, it is prioritized over page-level `parts`.

(This is a small part of the changes originally in https://github.com/jupyter-book/mystmd/pull/1701)