### PR TITLE
🎆 Add static figure placeholder for images

### DIFF
--- a/.changeset/kind-lies-kick.md
+++ b/.changeset/kind-lies-kick.md
@@ -1,0 +1,7 @@
+---
+'myst-directives': patch
+'myst-transforms': patch
+'myst-cli': patch
+---
+
+Add static figure placeholder for images that should be used only for PDF exports

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -68,6 +68,8 @@ import {
   transformFilterOutputStreams,
   transformLiftCodeBlocksInJupytext,
   transformMystXRefs,
+  removeStaticImages,
+  removeNonStaticImages,
 } from '../transforms/index.js';
 import type { ImageExtensions } from '../utils/resolveExtension.js';
 import { logMessagesFromVFile } from '../utils/logging.js';
@@ -379,10 +381,13 @@ export async function finalizeMdast(
   const vfile = new VFile(); // Collect errors on this file
   vfile.path = file;
   if (simplifyFigures) {
+    removeNonStaticImages(mdast);
     // Transform output nodes to images / text
     reduceOutputs(session, mdast, file, imageWriteFolder, {
       altOutputFolder: simplifyFigures ? undefined : imageAltOutputFolder,
     });
+  } else {
+    removeStaticImages(mdast);
   }
   transformOutputsToFile(session, mdast, imageWriteFolder, {
     altOutputFolder: simplifyFigures ? undefined : imageAltOutputFolder,

--- a/packages/myst-directives/src/figure.ts
+++ b/packages/myst-directives/src/figure.ts
@@ -56,6 +56,10 @@ export const figureDirective: DirectiveSpec = {
       type: String,
       doc: 'A placeholder image when using a notebook cell as the figure contents. This will be shown in place of the Jupyter output until an execution environment is attached. It will also be used in static outputs, such as a PDF output.',
     },
+    static: {
+      type: String,
+      doc: 'An image only used in static outputs. This image will always take priority for static outputs, such as PDFs, and will never be used in dynamic outputs, such as web builds.',
+    },
     'no-subfigures': {
       type: Boolean,
       doc: 'Disallow implicit subfigure creation from child nodes',
@@ -90,6 +94,17 @@ export const figureDirective: DirectiveSpec = {
         type: 'image',
         placeholder: true,
         url: data.options.placeholder as string,
+        alt: data.options?.alt as string,
+        width: data.options?.width as string,
+        height: data.options?.height as string,
+        align: data.options?.align as Image['align'],
+      });
+    }
+    if (data.options?.static) {
+      children.push({
+        type: 'image',
+        static: true,
+        url: data.options.static as string,
         alt: data.options?.alt as string,
         width: data.options?.width as string,
         height: data.options?.height as string,


### PR DESCRIPTION
This is the subset of the changes from https://github.com/jupyter-book/mystmd/pull/1701 which focuses on the `static` image field, an alternative to `placeholder` that will only be used in static exports, e.g. PDF. There is a little more discussion in that previous PR.