### PR TITLE
🏷️ Do not label implicit heading nodes

### DIFF
--- a/.changeset/dull-ravens-knock.md
+++ b/.changeset/dull-ravens-knock.md
@@ -1,0 +1,5 @@
+---
+"myst-to-typst": patch
+---
+
+Do not label implicit heading nodes in typst

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -133,10 +133,11 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node, 2, { after });
   },
   heading(node, state) {
-    const { depth, identifier, enumerated } = node;
+    const { depth, identifier, enumerated, implicit } = node;
     state.write(`${Array(depth).fill('=').join('')} `);
     state.renderChildren(node);
-    if (enumerated !== false && identifier) {
+    if (enumerated !== false && identifier && !implicit) {
+      // Implicit labels can have duplicates and stop typst from compiling
       state.write(` <${identifier}>`);
     }
     state.write('\n\n');

--- a/packages/mystmd/tests/include-recursive/three.md
+++ b/packages/mystmd/tests/include-recursive/three.md
@@ -1,3 +1,5 @@
+(pg-3)=
+
 # Page three
 
 This page does not include any other pages.

--- a/packages/mystmd/tests/math-macros/outputs/index.typ
+++ b/packages/mystmd/tests/math-macros/outputs/index.typ
@@ -31,10 +31,10 @@
 #let six = $d = d$
 #let seven = $d = d = d$
 
-= No plugins <no-plugins>
+= No plugins
 
 $ a^2 + b^2 = c^2 $
-= Simple plugin <simple-plugin>
+= Simple plugin
 
 Project frontmatter should give us `d`
 
@@ -42,7 +42,7 @@ $ d = three $
 Page should override and we should see `x`
 
 $ x = one $
-= Macros should recurse <macros-should-recurse>
+= Macros should recurse
 
 Page frontmatter should fill in this project macro
 

--- a/packages/mystmd/tests/outputs/include-circular.typ
+++ b/packages/mystmd/tests/outputs/include-circular.typ
@@ -1,21 +1,21 @@
 This page includes content from page two:
 
-= Page two <page-two>
+= Page two
 
 This page includes content from page three:
 
-= Page three <page-three>
+= Page three
 
 This page includes content from page one:
 
 and content from page three:
 
-= Page three <page-three>
+= Page three
 
 This page includes content from page one:
 
 and page four:
 
-= Page four <page-four>
+= Page four
 
 This page includes content from itself:

--- a/packages/mystmd/tests/outputs/include-recursive.typ
+++ b/packages/mystmd/tests/outputs/include-recursive.typ
@@ -1,15 +1,15 @@
 This page includes content from page two:
 
-= Page two <page-two>
+= Page two
 
 This page includes content from page three:
 
-= Page three <page-three>
+= Page three <pg-3>
 
 This page does not include any other pages.
 
 and content from page three:
 
-= Page three <page-three>
+= Page three <pg-3>
 
 This page does not include any other pages.


### PR DESCRIPTION
These lead to duplicates in multi-article exports.