### PR TITLE
📋 New lines in markdown lists are not written to typst

### DIFF
--- a/.changeset/three-moles-give.md
+++ b/.changeset/three-moles-give.md
@@ -1,0 +1,5 @@
+---
+"myst-to-typst": patch
+---
+
+New lines in lists are not written to typst

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -106,7 +106,9 @@ function nextCharacterIsText(parent: GenericNode, node: GenericNode): boolean {
 
 const handlers: Record<string, Handler> = {
   text(node, state) {
-    state.text(node.value);
+    // We do not want markdown formatting to be carried over to typst
+    // As the meaning in lists, etc. is different
+    state.text(node.value.replaceAll('\n', ' '));
   },
   paragraph(node, state) {
     const { identifier } = node;

--- a/packages/myst-to-typst/tests/lists.yml
+++ b/packages/myst-to-typst/tests/lists.yml
@@ -1,6 +1,6 @@
-title: myst-to-typst admonitions
+title: myst-to-typst lists
 cases:
-  - title: important admonition
+  - title: important list
     mdast:
       type: root
       children:
@@ -25,3 +25,27 @@ cases:
       - This is a list
         + My other, nested
         + bullet point list!
+  - title: List with new lines
+    mdast:
+      type: root
+      children:
+        - type: list
+          children:
+            - type: listItem
+              spread: true
+              children:
+                - type: text
+                  value: |-
+                    A list
+                    with a new line
+            - type: listItem
+              spread: true
+              children:
+                - type: text
+                  value: |
+                    And math
+                - type: inlineMath
+                  value: Ax=b
+    typst: |-
+      - A list with a new line
+      - And math $A x = b$


### PR DESCRIPTION
Fixes #1767