### PR TITLE
🔧 Typst fixes for tables with divs and non-rgb cell colors

### DIFF
--- a/.changeset/cool-meals-travel.md
+++ b/.changeset/cool-meals-travel.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Support non-rgb colors in table cells

--- a/.changeset/few-bulldogs-enjoy.md
+++ b/.changeset/few-bulldogs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Fix containers with tables inside divs

--- a/packages/myst-to-typst/src/container.ts
+++ b/packages/myst-to-typst/src/container.ts
@@ -34,7 +34,8 @@ export function determineCaptionKind(node: GenericNode): CaptionKind | null {
 }
 
 function renderFigureChild(node: GenericNode, state: ITypstSerializer) {
-  const useBrackets = node.type !== 'image' && node.type !== 'table';
+  const bracketNode = node.type === 'div' && node.children?.length === 1 ? node.children[0] : node;
+  const useBrackets = bracketNode.type !== 'image' && bracketNode.type !== 'table';
   if (node.type === 'legend') {
     state.useMacro('#let legendStyle = (fill: black.lighten(20%), size: 8pt, style: "italic")');
     state.write('text(..legendStyle)');

--- a/packages/myst-to-typst/src/table.ts
+++ b/packages/myst-to-typst/src/table.ts
@@ -63,7 +63,9 @@ export const tableCellHandler: Handler = (node, state) => {
       state.write(`align: ${node.align}, `);
     }
     if (node.style?.backgroundColor) {
-      state.write(`fill: rgb("${node.style.backgroundColor}"), `);
+      const fill = node.style.backgroundColor as string;
+      const rgb = fill.startsWith('#');
+      state.write(`fill: ${rgb ? `rgb("${fill}")` : fill}, `);
     }
     state.write(')');
   }


### PR DESCRIPTION
Typst compiling fails for:
1. tables inside divs
2. tables with non-rgb cell colors (e.g. `"white"`)

This PR makes a couple tiny changes that fix those things.