### PR TITLE
🔧 Add edit url to file frontmatter

### DIFF
--- a/.changeset/quiet-toys-dream.md
+++ b/.changeset/quiet-toys-dream.md
@@ -1,0 +1,6 @@
+---
+'myst-frontmatter': patch
+'myst-cli': patch
+---
+
+Add edit url to file frontmatter

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -175,8 +175,8 @@ The following table lists the available frontmatter fields, a brief description 
 * - `github`
   - a valid GitHub URL or `owner/reponame`
   - page can override project
-* - `edit`
-  - URL to edit the page source. If this value is unset but `github` is specified, MyST will attempt to compute the specific github URL for the page. You may disable this behavior by explicitly setting `edit` to `null`.
+* - `edit_url`
+  - URL to edit the page source. If this value is unset but `github` is specified, MyST will attempt to compute the specific github URL for the page. You may disable this behavior by explicitly setting `edit_url` to `null`.
   - page can override project
 * - `binder`
   - any valid URL

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -175,6 +175,9 @@ The following table lists the available frontmatter fields, a brief description 
 * - `github`
   - a valid GitHub URL or `owner/reponame`
   - page can override project
+* - `edit`
+  - URL to edit the page source. If this value is unset but `github` is specified, MyST will attempt to compute the specific github URL for the page. You may disable this behavior by explicitly setting `edit` to `null`.
+  - page can override project
 * - `binder`
   - any valid URL
   - page can override project

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -75,6 +75,7 @@ import { parseMyst } from './myst.js';
 import { kernelExecutionTransform, LocalDiskCache } from 'myst-execute';
 import type { IOutput } from '@jupyterlab/nbformat';
 import { rawDirectiveTransform } from '../transforms/raw.js';
+import { addEditUrl } from '../utils/addEditUrl.js';
 
 const LINKS_SELECTOR = 'link,card,linkBlock';
 
@@ -164,6 +165,7 @@ export async function transformMdast(
     if (!frontmatter.numbering.title) frontmatter.numbering.title = {};
     if (frontmatter.numbering.title.offset == null) frontmatter.numbering.title.offset = offset;
   }
+  await addEditUrl(session, frontmatter, file);
   const references: References = {
     cite: { order: [], data: {} },
   };

--- a/packages/myst-cli/src/utils/addEditUrl.ts
+++ b/packages/myst-cli/src/utils/addEditUrl.ts
@@ -1,0 +1,30 @@
+import which from 'which';
+import type { PageFrontmatter } from 'myst-frontmatter';
+import { makeExecutable, silentLogger } from 'myst-cli-utils';
+import type { ISession } from '../session/types.js';
+
+function gitCommandAvailable(): boolean {
+  return !!which.sync('git', { nothrow: true });
+}
+
+export async function addEditUrl(session: ISession, frontmatter: PageFrontmatter, file: string) {
+  if (frontmatter.edit || frontmatter.edit === null) return;
+  if (!gitCommandAvailable()) return;
+  try {
+    const gitLog = silentLogger();
+    const getGitOrigin = makeExecutable('git config --get remote.origin.url', gitLog);
+    const gitOrigin =
+      frontmatter.github ??
+      (await getGitOrigin()).trim().replace('git@github.com:', 'https://github.com/');
+    const getGitBranch = makeExecutable('git rev-parse --abbrev-ref HEAD', gitLog);
+    const gitBranch = (await getGitBranch()).trim();
+    const getGitRoot = makeExecutable('git rev-parse --show-toplevel', gitLog);
+    const gitRoot = (await getGitRoot()).trim();
+    if (gitOrigin && gitBranch && gitRoot && file.startsWith(gitRoot)) {
+      frontmatter.edit = `${gitOrigin}/blob/${gitBranch}${file.replace(gitRoot, '')}`;
+      session.log.debug(`Added edit URL ${frontmatter.edit} to ${file}`);
+    }
+  } catch {
+    session.log.debug(`Unable to add edit URL to ${file}`);
+  }
+}

--- a/packages/myst-cli/src/utils/addEditUrl.ts
+++ b/packages/myst-cli/src/utils/addEditUrl.ts
@@ -7,22 +7,26 @@ function gitCommandAvailable(): boolean {
   return !!which.sync('git', { nothrow: true });
 }
 
+/**
+ * Compute edit_url and add to frontmatter
+ * 
+ * If edit_url is already defined on the page it will remain unchanged.
+ * If edit_url is explicitly null or if github url is not defined, edit_url will not be set.
+ * If git is not available to determine branch and top-level folder, edit_url will not be set.
+ */
 export async function addEditUrl(session: ISession, frontmatter: PageFrontmatter, file: string) {
-  if (frontmatter.edit || frontmatter.edit === null) return;
+  if (!frontmatter.github) return
+  if (frontmatter.edit_url || frontmatter.edit_url === null) return;
   if (!gitCommandAvailable()) return;
   try {
     const gitLog = silentLogger();
-    const getGitOrigin = makeExecutable('git config --get remote.origin.url', gitLog);
-    const gitOrigin =
-      frontmatter.github ??
-      (await getGitOrigin()).trim().replace('git@github.com:', 'https://github.com/');
     const getGitBranch = makeExecutable('git rev-parse --abbrev-ref HEAD', gitLog);
     const gitBranch = (await getGitBranch()).trim();
     const getGitRoot = makeExecutable('git rev-parse --show-toplevel', gitLog);
     const gitRoot = (await getGitRoot()).trim();
-    if (gitOrigin && gitBranch && gitRoot && file.startsWith(gitRoot)) {
-      frontmatter.edit = `${gitOrigin}/blob/${gitBranch}${file.replace(gitRoot, '')}`;
-      session.log.debug(`Added edit URL ${frontmatter.edit} to ${file}`);
+    if (gitBranch && gitRoot && file.startsWith(gitRoot)) {
+      frontmatter.edit_url = `${frontmatter.github}/blob/${gitBranch}${file.replace(gitRoot, '')}`;
+      session.log.debug(`Added edit URL ${frontmatter.edit_url} to ${file}`);
     }
   } catch {
     session.log.debug(`Unable to add edit URL to ${file}`);

--- a/packages/myst-cli/src/utils/addEditUrl.ts
+++ b/packages/myst-cli/src/utils/addEditUrl.ts
@@ -9,13 +9,13 @@ function gitCommandAvailable(): boolean {
 
 /**
  * Compute edit_url and add to frontmatter
- * 
+ *
  * If edit_url is already defined on the page it will remain unchanged.
  * If edit_url is explicitly null or if github url is not defined, edit_url will not be set.
  * If git is not available to determine branch and top-level folder, edit_url will not be set.
  */
 export async function addEditUrl(session: ISession, frontmatter: PageFrontmatter, file: string) {
-  if (!frontmatter.github) return
+  if (!frontmatter.github) return;
   if (frontmatter.edit_url || frontmatter.edit_url === null) return;
   if (!gitCommandAvailable()) return;
   try {

--- a/packages/myst-frontmatter/src/project/types.ts
+++ b/packages/myst-frontmatter/src/project/types.ts
@@ -33,6 +33,7 @@ export const PROJECT_AND_PAGE_FRONTMATTER_KEYS = [
   'exports',
   'downloads',
   'settings', // We maybe want to move this into site frontmatter in the future
+  'edit',
   ...KNOWN_EXTERNAL_IDENTIFIERS,
   // Do not add any project specific keys here!
   ...SITE_FRONTMATTER_KEYS,
@@ -73,6 +74,7 @@ export type ProjectAndPageFrontmatter = SiteFrontmatter & {
   exports?: Export[];
   downloads?: Download[];
   settings?: ProjectSettings;
+  edit?: string | null;
 };
 
 export type ProjectFrontmatter = ProjectAndPageFrontmatter & {

--- a/packages/myst-frontmatter/src/project/types.ts
+++ b/packages/myst-frontmatter/src/project/types.ts
@@ -33,7 +33,7 @@ export const PROJECT_AND_PAGE_FRONTMATTER_KEYS = [
   'exports',
   'downloads',
   'settings', // We maybe want to move this into site frontmatter in the future
-  'edit',
+  'edit_url',
   ...KNOWN_EXTERNAL_IDENTIFIERS,
   // Do not add any project specific keys here!
   ...SITE_FRONTMATTER_KEYS,
@@ -74,7 +74,7 @@ export type ProjectAndPageFrontmatter = SiteFrontmatter & {
   exports?: Export[];
   downloads?: Download[];
   settings?: ProjectSettings;
-  edit?: string | null;
+  edit_url?: string | null;
 };
 
 export type ProjectFrontmatter = ProjectAndPageFrontmatter & {

--- a/packages/myst-frontmatter/src/project/validators.ts
+++ b/packages/myst-frontmatter/src/project/validators.ts
@@ -235,6 +235,11 @@ export function validateProjectAndPageFrontmatterKeys(
     );
     if (settings) output.settings = settings;
   }
+  if (value.edit === null) {
+    output.edit = null;
+  } else if (defined(value.edit)) {
+    output.edit = validateUrl(value.edit, incrementOptions('edit', opts));
+  }
   return output;
 }
 

--- a/packages/myst-frontmatter/src/project/validators.ts
+++ b/packages/myst-frontmatter/src/project/validators.ts
@@ -235,10 +235,10 @@ export function validateProjectAndPageFrontmatterKeys(
     );
     if (settings) output.settings = settings;
   }
-  if (value.edit === null) {
-    output.edit = null;
-  } else if (defined(value.edit)) {
-    output.edit = validateUrl(value.edit, incrementOptions('edit', opts));
+  if (value.edit_url === null) {
+    output.edit_url = null;
+  } else if (defined(value.edit_url)) {
+    output.edit_url = validateUrl(value.edit_url, incrementOptions('edit_url', opts));
   }
   return output;
 }


### PR DESCRIPTION
This is to enable an `Edit on Github` button in the theme. The `edit` url will be computed `github` is provided in the frontmatter and `git` is available (unless `edit` is explicitly set to `null`)