### PR TITLE
🗪 Removes quotes around `{eval}` outputs

### DIFF
--- a/.changeset/spotty-melons-hug.md
+++ b/.changeset/spotty-melons-hug.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Remove quotes around plain text for eval outputs

--- a/packages/myst-cli/src/transforms/inlineExpression.spec.ts
+++ b/packages/myst-cli/src/transforms/inlineExpression.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { transformRenderInlineExpressions } from './inlineExpressions';
+import { VFile } from 'vfile';
+import type { InlineExpression } from 'myst-spec-ext';
+
+describe('fileFromRelativePath', () => {
+  it('inline text is not quoted', async () => {
+    const vfile = new VFile();
+    const expr = {
+      type: 'inlineExpression',
+      value: '"hello " + "there"',
+      result: {
+        status: 'ok',
+        data: {
+          // Note the wrapping quotes!
+          'text/plain': "'hello there'",
+        },
+        metadata: {},
+      },
+    } as InlineExpression;
+    const tree = { type: 'root', children: [expr] };
+    transformRenderInlineExpressions(tree, vfile);
+    // Children are added and quotes are removed
+    expect(expr.children).toEqual([{ type: 'text', value: 'hello there' }]);
+  });
+});

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -33,6 +33,10 @@ function processLatex(value: string) {
     .trim();
 }
 
+function processPlainText(content: string) {
+  return content.replace(/^(["'])(.*)\1$/, '$2');
+}
+
 function renderExpression(node: InlineExpression, file: VFile): StaticPhrasingContent[] {
   const result = node.result as IExpressionResult;
   if (!result) return [];
@@ -53,7 +57,7 @@ function renderExpression(node: InlineExpression, file: VFile): StaticPhrasingCo
       } else if (mimeType === 'text/html') {
         content = [{ type: 'html', value: value as string }];
       } else if (mimeType === 'text/plain') {
-        content = [{ type: 'text', value: value as string }];
+        content = [{ type: 'text', value: processPlainText(value as string) }];
       }
     });
     if (content) return content;


### PR DESCRIPTION
Fixes #1797