### PR TITLE
💬 Preserve quotes in inline expressions upon request

### DIFF
--- a/.changeset/shy-spoons-exist.md
+++ b/.changeset/shy-spoons-exist.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Add support for `strip-quotes` metadata

--- a/packages/myst-cli/src/transforms/inlineExpression.spec.ts
+++ b/packages/myst-cli/src/transforms/inlineExpression.spec.ts
@@ -41,7 +41,7 @@ describe('transformRenderInlineExpressions', () => {
     } as InlineExpression;
     const tree = { type: 'root', children: [expr] };
     transformRenderInlineExpressions(tree, vfile);
-    // Children are added and quotes are removed
+    // Children are added and quotes are preserved
     expect(expr.children).toEqual([{ type: 'text', value: "'hello there'" }]);
   });
 });

--- a/packages/myst-cli/src/transforms/inlineExpression.spec.ts
+++ b/packages/myst-cli/src/transforms/inlineExpression.spec.ts
@@ -3,8 +3,8 @@ import { transformRenderInlineExpressions } from './inlineExpressions';
 import { VFile } from 'vfile';
 import type { InlineExpression } from 'myst-spec-ext';
 
-describe('fileFromRelativePath', () => {
-  it('inline text is not quoted', async () => {
+describe('transformRenderInlineExpressions', () => {
+  it('inline text is not quoted by default', async () => {
     const vfile = new VFile();
     const expr = {
       type: 'inlineExpression',
@@ -22,5 +22,26 @@ describe('fileFromRelativePath', () => {
     transformRenderInlineExpressions(tree, vfile);
     // Children are added and quotes are removed
     expect(expr.children).toEqual([{ type: 'text', value: 'hello there' }]);
+  });
+  it('inline text is quoted when requested', async () => {
+    const vfile = new VFile();
+    const expr = {
+      type: 'inlineExpression',
+      value: '"hello " + "there"',
+      result: {
+        status: 'ok',
+        data: {
+          // Note the wrapping quotes!
+          'text/plain': "'hello there'",
+        },
+        metadata: {
+          'strip-quotes': false,
+        },
+      },
+    } as InlineExpression;
+    const tree = { type: 'root', children: [expr] };
+    transformRenderInlineExpressions(tree, vfile);
+    // Children are added and quotes are removed
+    expect(expr.children).toEqual([{ type: 'text', value: "'hello there'" }]);
   });
 });

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -33,7 +33,7 @@ function processLatex(value: string) {
     .trim();
 }
 
-function processPlainText(content: string) {
+function stripTextQuotes(content: string) {
   return content.replace(/^(["'])(.*)\1$/, '$2');
 }
 
@@ -57,7 +57,14 @@ function renderExpression(node: InlineExpression, file: VFile): StaticPhrasingCo
       } else if (mimeType === 'text/html') {
         content = [{ type: 'html', value: value as string }];
       } else if (mimeType === 'text/plain') {
-        content = [{ type: 'text', value: processPlainText(value as string) }];
+        // Allow the user / libraries to explicitly indicate that quotes should be preserved
+        const stripQuotes = result.metadata?.['strip-quotes'] ?? true;
+        content = [
+          {
+            type: 'text',
+            value: stripQuotes ? stripTextQuotes(value as string) : (value as string),
+          },
+        ];
       }
     });
     if (content) return content;


### PR DESCRIPTION
Quotes are semantically important things, so we should provide a way for users to preserve them if necessary. This PR ensures that we only strip quotes if the user does not specify (through various channels) that they should not be stripped.

I have no strong feelings on whether this field should be `strip-quotes` or `keep-quotes`.

Example notebook:
````markdown
---
kernelspec:
  name: python3
  display_name: python3
---


```{code-cell} python3
from IPython.utils.capture import capture_output

with capture_output() as c1:
    display("hi", metadata={"strip-quotes": False})

with capture_output() as c2:
    display("hi")


class CustomString:
    def __init__(self, text: str, keep_quotes: bool):
        self._text = text
        self._keep_quotes = keep_quotes
      
    def _repr_mimebundle_(self, include=None, exclude=None):
        return (
          {"text/plain": self._text},
          {"strip-quotes": not self._keep_quotes}
    )
c3 = CustomString("'with quotes'", True)
c4 = CustomString("'without quotes'", False)
```

With quotes, we have {eval}`c1.outputs[0]`. Without quotes, we have {eval}`c2.outputs[0]`

With custom objects, we have {eval}`c3`. Without quotes, we have {eval}`c4`

````