### PR TITLE
🐛 Fix unwanted continuous numbering for some enumerated types

### DIFF
--- a/.changeset/mean-seals-invent.md
+++ b/.changeset/mean-seals-invent.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Fix unwanted continuous numbering for some enumerated types

--- a/packages/myst-transforms/src/enumerate.spec.ts
+++ b/packages/myst-transforms/src/enumerate.spec.ts
@@ -157,7 +157,7 @@ describe('initializeTargetCounts', () => {
     const previousCounts = {
       heading: [5, 3, 1, 0, null, null],
       figure: { main: 7, sub: 2 },
-      other: { main: 0, sub: 0 },
+      other: { main: 3, sub: 0 },
     };
     expect(
       initializeTargetCounts(
@@ -172,7 +172,6 @@ describe('initializeTargetCounts', () => {
           other: { continue: true, enabled: true },
         },
         previousCounts as any,
-        undefined,
       ),
     ).toEqual(previousCounts);
   });
@@ -180,7 +179,6 @@ describe('initializeTargetCounts', () => {
     const previousCounts = {
       heading: [5, 3, 1, 0, null, null],
       figure: { main: 7, sub: 2 },
-      other: { main: 0, sub: 0 },
     };
     const numbering = {
       heading_1: { enabled: true, start: 5, continue: true },
@@ -192,8 +190,24 @@ describe('initializeTargetCounts', () => {
     expect(initializeTargetCounts(numbering, previousCounts as any)).toEqual({
       heading: [4, null, 0, 0, 1, 0],
       figure: { main: 4, sub: 0 },
-      other: { main: 0, sub: 0 },
       code: { main: 7, sub: 0 },
+    });
+  });
+  test('unknown numberings reset from previousCounts', () => {
+    const previousCounts = {
+      heading: [5, 3, 1, 0, null, null],
+      figure: { main: 7, sub: 2 },
+      exercise: { main: 5, sub: 0 },
+    };
+    const numbering = {
+      heading_1: { enabled: true, start: 5, continue: true },
+      heading_2: { enabled: false, start: 2, continue: true },
+      heading_5: { enabled: true, start: 2, continue: true },
+      figure: { enabled: true, start: 5, continue: true },
+    };
+    expect(initializeTargetCounts(numbering, previousCounts as any)).toEqual({
+      heading: [4, null, 0, 0, 1, 0],
+      figure: { main: 4, sub: 0 },
     });
   });
 });

--- a/packages/myst-transforms/src/enumerate.ts
+++ b/packages/myst-transforms/src/enumerate.ts
@@ -286,7 +286,7 @@ export function initializeTargetCounts(
   // Update with other initial values
   Object.entries(previousCounts ?? {})
     .filter(([key]) => key !== 'heading')
-    .filter(([key]) => !numbering[key] || numbering[key]?.continue || numbering.all?.continue)
+    .filter(([key]) => numbering[key]?.continue || numbering.all?.continue)
     .forEach(([key, val]) => {
       targetCounts[key] = { ...(val as { main: number; sub: number }) };
     });


### PR DESCRIPTION
Addresses the issue brought up here: https://github.com/jupyter-book/mystmd/pull/1391#issuecomment-2616782516 - where `exercises` switched to continuous numbering with no change to the frontmatter.