### PR TITLE
🌎 Remove TLD of `.java` and `.zip` from linkify

### DIFF
--- a/.changeset/large-clouds-mix.md
+++ b/.changeset/large-clouds-mix.md
@@ -1,0 +1,5 @@
+---
+"myst-parser": patch
+---
+
+Remove java and zip from linkified TLDs.

--- a/packages/myst-parser/src/config.ts
+++ b/packages/myst-parser/src/config.ts
@@ -69,4 +69,4 @@ export const MARKDOWN_IT_CONFIG = {
 };
 
 // List of valid TLDs to exclude from linkify
-export const EXCLUDE_TLDS = ['py', 'md', 'dot', 'next', 'so', 'es'];
+export const EXCLUDE_TLDS = ['py', 'md', 'dot', 'next', 'so', 'es', 'java', 'zip'];


### PR DESCRIPTION
See #1809

cc @glaebhoerl