### PR TITLE
🐛 Improve error message for missing javascript and python plugins

### DIFF
--- a/.changeset/weak-readers-rule.md
+++ b/.changeset/weak-readers-rule.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Improve error message for missing javascript plugins

--- a/packages/myst-cli/src/plugins.ts
+++ b/packages/myst-cli/src/plugins.ts
@@ -84,7 +84,7 @@ export async function loadPlugins(session: ISession): Promise<ValidatedMystPlugi
           return { path, module: { plugin } };
         }
         case 'javascript': {
-          if (!fs.statSync(path, {throwIfNoEntry: false})?.isFile() || !path.endsWith('.mjs')) {
+          if (!fs.statSync(path, { throwIfNoEntry: false })?.isFile() || !path.endsWith('.mjs')) {
             addWarningForFile(
               session,
               path,

--- a/packages/myst-cli/src/plugins.ts
+++ b/packages/myst-cli/src/plugins.ts
@@ -46,7 +46,7 @@ export async function loadPlugins(session: ISession): Promise<ValidatedMystPlugi
       switch (type) {
         case 'executable': {
           // Ensure the plugin is a file
-          if (!fs.statSync(path).isFile) {
+          if (!fs.statSync(path, { throwIfNoEntry: false })?.isFile()) {
             addWarningForFile(
               session,
               path,

--- a/packages/myst-cli/src/plugins.ts
+++ b/packages/myst-cli/src/plugins.ts
@@ -84,7 +84,7 @@ export async function loadPlugins(session: ISession): Promise<ValidatedMystPlugi
           return { path, module: { plugin } };
         }
         case 'javascript': {
-          if (!fs.statSync(path).isFile || !path.endsWith('.mjs')) {
+          if (!fs.statSync(path, {throwIfNoEntry: false})?.isFile() || !path.endsWith('.mjs')) {
             addWarningForFile(
               session,
               path,

--- a/packages/mystmd/tests/math-macros/outputs/index.typ
+++ b/packages/mystmd/tests/math-macros/outputs/index.typ
@@ -1,14 +1,6 @@
 #import "lapreprint.typ": *
 #show: template.with(
   title: "Testing Math Plugins",
-  abstract: (
-    (
-      title: "Abstract",
-      content: [
-
-      ]
-    ),
-  ),
   date: datetime(
     year: 2024,
     month: 1,


### PR DESCRIPTION
Closes #1813

It looks like the problem was here

https://github.com/jupyter-book/mystmd/blob/d1f8768eb4dbada0a370765ba696fbb3c00ba66f/packages/myst-cli/src/plugins.ts#L87

`fs.statSync` raises an error if there is no file/directory.
This PR adds an option so that `fs.statSync` returns `undefined` if there is no file, then handles that possibility when calling `isFile()`.

I see that there is another instance of `fs.statSync(...).isFile()` in `plugins.ts` that might cause similar problems.