### PR TITLE
🚫 Add page frontmatter option to disable execution

### DIFF
--- a/.changeset/dirty-ducks-tie.md
+++ b/.changeset/dirty-ducks-tie.md
@@ -1,0 +1,6 @@
+---
+"myst-frontmatter": patch
+"myst-cli": patch
+---
+
+Add support for skipping execution of individual notebooks

--- a/docs/execute-notebooks.md
+++ b/docs/execute-notebooks.md
@@ -65,6 +65,24 @@ name = input("What is your name?")
 
 Additional [cell tags](#tbl:notebook-cell-tags) to hide, remove, or raise exceptions are also possible.
 
+## Skip entire notebooks
+
+You may wish to disable execution for certain notebooks. This can be done by setting the top-level `skip_execution` frontmatter option to `true`, e.g.
+
+````markdown
+---
+kernelspec:
+  name: python3
+  display_name: Python 3
+
+skip_execution: true
+---
+
+```{code-cell}
+print("This will never be executed!")
+```
+````
+
 ## Cache execution outputs
 
 When MyST executes your notebook, it will store the outputs in a cache in a folder called `execute/` in your MyST build folder.

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -229,6 +229,9 @@ The following table lists the available frontmatter fields, a brief description 
 * - `kernelspec`
   - configuration for the kernel (see [](#kernel-specification))
   - page only
+* - `skip_execution`
+  - opt-out of execution for a particular document (see [](./execute-notebooks))
+  - page only
 ```
 
 +++

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -219,7 +219,7 @@ export async function transformMdast(
   // Combine file-specific citation renderers with project renderers from bib files
   const fileCitationRenderer = combineCitationRenderers(cache, ...rendererFiles);
 
-  if (execute) {
+  if (execute && !frontmatter.skip_execution) {
     const cachePath = path.join(session.buildPath(), 'execute');
     await kernelExecutionTransform(mdast, vfile, {
       basePath: session.sourcePath(),

--- a/packages/myst-frontmatter/src/page/types.ts
+++ b/packages/myst-frontmatter/src/page/types.ts
@@ -13,6 +13,7 @@ export const PAGE_FRONTMATTER_KEYS = [
   'site',
   'enumerator',
   'content_includes_title',
+  'skip_execution',
 ];
 
 export type PageFrontmatter = ProjectAndPageFrontmatter & {
@@ -21,6 +22,8 @@ export type PageFrontmatter = ProjectAndPageFrontmatter & {
   jupytext?: Jupytext;
   tags?: string[];
   enumerator?: string;
+  // Disable execution for this page
+  skip_execution?: boolean;
   /** Flag if frontmatter title is duplicated in content
    *
    * Set during initial file/frontmatter load

--- a/packages/myst-frontmatter/src/page/validators.ts
+++ b/packages/myst-frontmatter/src/page/validators.ts
@@ -51,6 +51,12 @@ export function validatePageFrontmatterKeys(value: Record<string, any>, opts: Va
   if (defined(value.jupytext)) {
     output.jupytext = validateJupytext(value.jupytext, incrementOptions('jupytext', opts));
   }
+  if (defined(value.skip_execution)) {
+    output.skip_execution = validateBoolean(
+      value.skip_execution,
+      incrementOptions('skip_execution', opts),
+    );
+  }
   if (defined(value.enumerator)) {
     output.enumerator = validateString(value.enumerator, incrementOptions('enumerator', opts));
   }


### PR DESCRIPTION
This PR closes #1619 by adding a new `skip_execution` field to the page frontmatter. I don't anticipate it being a stable addition — we'll probably rethink at the very least _where_ it lives when we tackle #1498 and #1373. But, let's just get something in for now.
