### PR TITLE
🔧 Fix errors about missing images on non-first builds

### DIFF
--- a/.changeset/slimy-pumas-join.md
+++ b/.changeset/slimy-pumas-join.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fix errors about missing images on non-first builds

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -501,7 +501,7 @@ export async function fastProcessFile(
           imageAltOutputFolder: imageAltOutputFolder ?? '/',
           imageExtensions: imageExtensions ?? WEB_IMAGE_EXTENSIONS,
           optimizeWebp: true,
-          processThumbnail: true,
+          processThumbnail: f === file,
           maxSizeWebp,
         });
       }


### PR DESCRIPTION
This addresses #1854 - With the introduction of continuous numbering, we now need to partially reprocess all pages if one changes (new numbering on one page may impact numbering on another). During this reprocessing, transformed thumbnails were attempting to re-transform, but the thumbnail transform is non-idempotent, so it was raising an error.

For this change, we now say "if one page changes, only reprocess the thumbnail for that page (even if you are doing other reprocessing for other pages)"