### PR TITLE
 📂 Set `site.options.folders: true` for JB upgrades

### DIFF
--- a/.changeset/forty-radios-hide.md
+++ b/.changeset/forty-radios-hide.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Set site.options.folders in JB2 upgrade

--- a/docs/website-templates.md
+++ b/docs/website-templates.md
@@ -80,7 +80,16 @@ Below is a table of options for each theme bundled with MyST.
 
 ### Site URL Options
 
-By default, MyST URLs only contain the file name for each page; folder structure is respected in the table of contents but is not reflected in URLs. If you would like to maintain nested folder structure in the URLs, you may provide the site option `folders: true`. This causes each folder in your MyST directory to become a path segment. For this feature to work correctly, your chosen theme must also support `folders` as an option. Both `book-theme` and `article-theme` bundled with MyST support this.
+By default, MyST URLs only contain the file name for each page; folder structure is respected in the table of contents but is not reflected in URLs. If you would like to maintain nested folder structure in the URLs, you may set the site option `folders` to `true`. This causes each folder in your MyST directory to become a path segment. For this feature to work correctly, your chosen theme must also support `folders` as an option. Both `book-theme` and `article-theme` bundled with MyST support this.
+
+```{code-block} yaml
+:filename: myst.yml
+:linenos:
+:emphasize-lines: 3
+site:
+  options:
+    folders: true
+```
 
 ### Page Options
 

--- a/packages/myst-cli/src/init/jupyter-book/upgrade.ts
+++ b/packages/myst-cli/src/init/jupyter-book/upgrade.ts
@@ -41,6 +41,14 @@ export async function upgradeJupyterBook(session: ISession, configFile: string) 
     (config as any).project.toc = upgradeTOC(session, tocData);
   }
 
+  config.site = config.site ?? {};
+  config.site.options = config.site.options ?? {};
+
+  // Ensure we enable folders
+  session.log.debug(
+    chalk.dim(`Setting ${chalk.blue('site.options.folders')} to ${chalk.blue('true')}`),
+  );
+  config.site.options.folders = true;
 
   // Upgrade legacy syntax
   await upgradeProjectSyntax(session);

--- a/packages/myst-cli/src/init/jupyter-book/upgrade.ts
+++ b/packages/myst-cli/src/init/jupyter-book/upgrade.ts
@@ -30,15 +30,17 @@ export async function upgradeJupyterBook(session: ISession, configFile: string) 
   }
 
   // Does TOC exist?
-  if (await fsExists('_toc.yml')) {
-    const tocContent = await fs.readFile('_toc.yml', { encoding: 'utf-8' });
-    const tocData = validateSphinxExternalTOC(yaml.load(tocContent));
-    if (defined(tocData)) {
-      session.log.info(`Migrating TOC to ${chalk.blue('myst.yml')}`);
-
-      (config as any).project.toc = upgradeTOC(session, tocData);
-    }
+  if (!(await fsExists('_toc.yml'))) {
+    throw new Error(`${chalk.blue('_toc.yml')} is a required Jupyter Book configuration file`);
   }
+  const tocContent = await fs.readFile('_toc.yml', { encoding: 'utf-8' });
+  const tocData = validateSphinxExternalTOC(yaml.load(tocContent));
+  if (defined(tocData)) {
+    session.log.info(`Migrating TOC to ${chalk.blue('myst.yml')}`);
+
+    (config as any).project.toc = upgradeTOC(session, tocData);
+  }
+
 
   // Upgrade legacy syntax
   await upgradeProjectSyntax(session);


### PR DESCRIPTION
Fixes #1866 

I made `_toc.yml` a requirement for upgrading too, as this is a required file in JB1. I'm not sure why I didn't do this to begin with.