### PR TITLE
Handle unsupported options for include directive

### DIFF
--- a/.changeset/hot-panthers-roll.md
+++ b/.changeset/hot-panthers-roll.md
@@ -1,0 +1,6 @@
+---
+"myst-directives": patch
+"myst-parser": patch
+---
+
+Added support for include directive options when not using the literal option.

--- a/packages/myst-directives/src/include.ts
+++ b/packages/myst-directives/src/include.ts
@@ -111,13 +111,15 @@ export const includeDirective: DirectiveSpec = {
         ];
       }
     }
+    // Are any filter properties set?
+    const usesFilter = Object.values(filter).some((value) => value !== undefined);
     const include: Include = {
       type: 'include',
       file,
       literal,
       lang,
       caption: data.options?.caption as any[],
-      filter: Object.keys(filter).length > 0 ? filter : undefined,
+      filter: usesFilter ? filter : undefined,
       ...opts,
     };
     addCommonDirectiveOptions(data, include);

--- a/packages/myst-directives/src/include.ts
+++ b/packages/myst-directives/src/include.ts
@@ -82,6 +82,7 @@ export const includeDirective: DirectiveSpec = {
           file.split(/\/|\\/).pop(),
         )
       : {};
+    const caption = literal ? (data.options?.caption as any[]) : undefined;
     const filter: Include['filter'] = {};
     ensureOnlyOneOf(data, vfile, ['start-at', 'start-line', 'start-after', 'lines']);
     ensureOnlyOneOf(data, vfile, ['end-at', 'end-line', 'end-before', 'lines']);
@@ -118,7 +119,7 @@ export const includeDirective: DirectiveSpec = {
       file,
       literal,
       lang,
-      caption: data.options?.caption as any[],
+      caption,
       filter: usesFilter ? filter : undefined,
       ...opts,
     };

--- a/packages/myst-directives/src/include.ts
+++ b/packages/myst-directives/src/include.ts
@@ -1,5 +1,5 @@
 import type { DirectiveData, DirectiveSpec, GenericNode } from 'myst-common';
-import { RuleId, fileWarn, normalizeLabel } from 'myst-common';
+import { RuleId, fileWarn } from 'myst-common';
 import { CODE_DIRECTIVE_OPTIONS, getCodeBlockOptions } from './code.js';
 import type { Include } from 'myst-spec-ext';
 import type { VFile } from 'vfile';
@@ -73,7 +73,13 @@ export const includeDirective: DirectiveSpec = {
 
     const file = data.arg as string;
     if (!literal) {
-      // TODO: warn on unused options
+      for (const key in data.options) {
+        if (key) {
+          fileWarn(vfile, `Option "${key}" is not supported for non-literal include.`, {
+            node: data.node,
+          });
+        }
+      }
       const include: Include = {
         type: 'include',
         file,

--- a/packages/myst-directives/src/include.ts
+++ b/packages/myst-directives/src/include.ts
@@ -74,12 +74,14 @@ export const includeDirective: DirectiveSpec = {
 
     const file = data.arg as string;
     const lang = (data.options?.lang as string) ?? extToLanguage(file.split('.').pop());
-    const opts = getCodeBlockOptions(
-      data,
-      vfile,
-      // Set the filename in the literal include by default
-      file.split(/\/|\\/).pop(),
-    );
+    const opts = literal
+      ? getCodeBlockOptions(
+          data,
+          vfile,
+          // Set the filename in the literal include by default
+          file.split(/\/|\\/).pop(),
+        )
+      : {};
     const filter: Include['filter'] = {};
     ensureOnlyOneOf(data, vfile, ['start-at', 'start-line', 'start-after', 'lines']);
     ensureOnlyOneOf(data, vfile, ['end-at', 'end-line', 'end-before', 'lines']);

--- a/packages/myst-directives/src/include.ts
+++ b/packages/myst-directives/src/include.ts
@@ -68,25 +68,11 @@ export const includeDirective: DirectiveSpec = {
     },
   },
   run(data, vfile): Include[] {
+    // Make a literal include if any of "literal", "lang" are defined or "literalinclude" directive is used
     const literal =
       data.name === 'literalinclude' || !!data.options?.literal || !!data.options?.lang;
 
     const file = data.arg as string;
-    if (!literal) {
-      for (const key in data.options) {
-        if (key) {
-          fileWarn(vfile, `Option "${key}" is not supported for non-literal include.`, {
-            node: data.node,
-          });
-        }
-      }
-      const include: Include = {
-        type: 'include',
-        file,
-      };
-      addCommonDirectiveOptions(data, include);
-      return [include];
-    }
     const lang = (data.options?.lang as string) ?? extToLanguage(file.split('.').pop());
     const opts = getCodeBlockOptions(
       data,

--- a/packages/myst-parser/tests/directives/include.yml
+++ b/packages/myst-parser/tests/directives/include.yml
@@ -13,3 +13,5 @@ cases:
           children:
             - type: include
               file: my_file.md
+              lang: markdown
+              literal: false


### PR DESCRIPTION
Closes #813

- [x] Add warnings for unused options in non-literal include
- [x] Add support for some/all start/end options for non-literal includes (requested in #813 and https://github.com/the-turing-way/the-turing-way/pull/4049

The filters get applied for non-literal includes. The code change is just removing a conditional block which made an early return when `literal === false`. This does mean includes are slightly more expensive now, and I think some of the processing of filter/options doesn't make sense when `literal === false`. It does keep the code quite clean and simple though.

I've tested this locally, but haven't added any tests.

````markdown
# index.md
start-after and end-before

```{include} ./data.txt
:filename: true
:start-after: BEGIN
:end-before: END
```

lines

```{include} ./data.txt
:lines: 2,3
```

literal with start-after and end-before

```{include} ./data.txt
:literal: true
:start-after: BEGIN
:end-before: END
```

Test "upgrading" to literal when `lang` is defined

```{include} ./data.txt
:lang: Python
:start-after: BEGIN
:end-before: END
```
````

```
# data.txt
BEGIN
Hello
World!

*emphasis*
**bold**
END

```

<img width="753" alt="Screenshot 2025-02-26 at 11 50 06" src="https://github.com/user-attachments/assets/e65c71e4-d37c-49c0-a9ea-51afbf6c2976" />
