### PR TITLE
🚀 Update the `SPEC_VERSION` for `block.class`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
     ["myst-to-jats", "jats-to-myst"],
     ["myst-to-tex", "tex-to-myst"],
     ["myst-parser", "myst-roles", "myst-directives", "myst-to-html"],
-    ["mystmd", "myst-cli"]
+    ["mystmd", "myst-cli", "myst-migrate"]
   ],
   "linked": [],
   "access": "public",

--- a/.changeset/thick-terms-dance.md
+++ b/.changeset/thick-terms-dance.md
@@ -1,0 +1,7 @@
+---
+"myst-cli": patch
+"myst-transforms": patch
+"myst-migrate": patch
+---
+
+block data class

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -8,6 +8,10 @@ The version is a string integer (i.e. `'1'` or `'2'`) and is incremented with ev
 
 # MyST Versions
 
+## Version 2 - 2025-03-05 - Block classes
+
+Blocks could previously define class on `block.data?.class`, this has been explicitly moved to `block.class`.
+
 ## Version 1 - 2025-02-07 - Footnote Numbering
 
 The footnotes have dropped backwards compatibility with `number`, instead using `enumerator` on both the `FootnoteReference` and `FootnoteDefinition` nodes.

--- a/packages/myst-cli/src/spec-version.ts
+++ b/packages/myst-cli/src/spec-version.ts
@@ -1,1 +1,1 @@
-export const SPEC_VERSION = 1;
+export const SPEC_VERSION = 2;

--- a/packages/myst-migrate/src/migrations.ts
+++ b/packages/myst-migrate/src/migrations.ts
@@ -1,4 +1,5 @@
 import type { Migration } from './types.js';
 import * as v1 from './v1_footnotes.js';
+import * as v2 from './v2_blockClasses.js';
 
-export const MIGRATIONS: Migration[] = [v1];
+export const MIGRATIONS: Migration[] = [v1, v2];

--- a/packages/myst-migrate/src/tests/version_1_2.spec.ts
+++ b/packages/myst-migrate/src/tests/version_1_2.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { migrate } from '../index';
+import type { Parent } from 'mdast';
+
+const SIMPLE_AST: Parent = {
+  type: 'root',
+  children: [
+    {
+      // @ts-expect-error: unknown type
+      type: 'block',
+      class: 'block-cn',
+      data: { class: 'data-cn' },
+    },
+  ],
+};
+
+describe('update 1->2', () => {
+  it('leaves a simple AST unchanged', async () => {
+    const mdast = structuredClone(SIMPLE_AST) as any;
+    const result = await migrate({ version: 1, mdast }, { to: 2 });
+    expect(result.version).toBe(2);
+    expect(mdast.children[0].class).toStrictEqual('block-cn data-cn');
+    expect(mdast.children[0].data).toBe(undefined);
+    expect(mdast.children[0].data?.class).toBe(undefined);
+  });
+});

--- a/packages/myst-migrate/src/v2_blockClasses.ts
+++ b/packages/myst-migrate/src/v2_blockClasses.ts
@@ -1,0 +1,35 @@
+import { selectAll } from 'unist-util-select';
+import { assert } from 'console';
+import type { IFile } from './types.js';
+
+export const description = `
+Blocks could previously define class on \`block.data?.class\`, this has been explicitly moved to \`block.class\`.
+`;
+
+type Block = {
+  type: 'block';
+  class?: string;
+  data?: {
+    /** @deprecated this is moved to node.class */
+    class: string | any;
+  };
+};
+
+export function upgrade(file: IFile): IFile {
+  const { version, mdast } = file;
+  assert(version === 1, 'Version must be 1');
+  const nodes = selectAll('block', mdast) as Block[];
+  nodes.forEach((node) => {
+    if (typeof node.data?.class === 'string') {
+      node.class = `${node.class ?? ''} ${node.data.class}`.trim();
+      delete node.data.class;
+      if (Object.keys(node.data).length === 0) delete node.data;
+    }
+  });
+  return file;
+}
+
+export function downgrade(file: IFile): IFile {
+  // Nothing to do, as both were compatible before.
+  return file;
+}

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -60,11 +60,13 @@ export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
     }
 
     // Customiseable class
-    const className = block.data?.class;
-    if (className) {
-      block.class = className;
+    if (typeof block.data?.class === 'string') {
+      block.class = `${block.class ?? ''} ${block.data.class}`.trim();
       delete block.data.class;
     }
+
+    // Minor cleanup
+    if (block.data && Object.keys(block.data).length === 0) delete block.data;
 
     const label = block.data?.label ?? block.data?.id;
     if (typeof label === 'string') {


### PR DESCRIPTION
Blocks could previously define class on `block.data?.class`, this has been explicitly moved to `block.class`.