### PR TITLE
⌨️ Add command line argument to `myst start` for selecting template

### DIFF
--- a/.changeset/brave-cameras-count.md
+++ b/.changeset/brave-cameras-count.md
@@ -1,0 +1,6 @@
+---
+"myst-templates": patch
+"myst-cli": patch
+---
+
+Add a `--template` flag to `myst` that allows the user to specify a custom location for `template.yml`. When that flag is specified, the template is local, and therefore we do not validate the `files` section of the template.

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ _build
 yalc.lock
 
 *.docx
+
+# backup files
+*~

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -125,7 +125,7 @@ export async function startServer(
   await session.reload();
   warnOnHostEnvironmentVariable(session, opts);
   const mystTemplate = await getSiteTemplate(session, opts);
-  if (!opts.headless) await installSiteTemplate(session, mystTemplate);
+  if (!opts.headless && !opts.template) await installSiteTemplate(session, mystTemplate);
   await buildSite(session, opts);
   const server = await startContentServer(session, opts);
   if (!opts.buildStatic) {

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -27,6 +27,7 @@ export type StartOptions = ProcessSiteOptions &
     buildStatic?: boolean;
     headless?: boolean;
     port?: number;
+    template?: string;
     baseurl?: string;
     keepHost?: boolean;
   };

--- a/packages/myst-cli/src/build/site/template.ts
+++ b/packages/myst-cli/src/build/site/template.ts
@@ -11,7 +11,7 @@ import { castSession } from '../../session/cache.js';
 const DEFAULT_TEMPLATE = 'book-theme';
 const DEFAULT_INSTALL_COMMAND = 'npm install';
 
-export async function getSiteTemplate(session: ISession, opts?: { defaultTemplate?: string }) {
+export async function getSiteTemplate(session: ISession, opts?: { template?: string, defaultTemplate?: string }) {
   const cache = castSession(session);
   const state = cache.store.getState();
   if (cache.$siteTemplate) return cache.$siteTemplate;
@@ -19,7 +19,7 @@ export async function getSiteTemplate(session: ISession, opts?: { defaultTemplat
   const file = selectors.selectCurrentSiteFile(state) ?? session.configFiles[0];
   const mystTemplate = new MystTemplate(session, {
     kind: TemplateKind.site,
-    template: siteConfig?.template ?? opts?.defaultTemplate ?? DEFAULT_TEMPLATE,
+    template: opts?.template ?? siteConfig?.template ?? opts?.defaultTemplate ?? DEFAULT_TEMPLATE,
     buildDir: session.buildPath(),
     errorLogFn: (message: string) => {
       addWarningForFile(session, file, message, 'error', {
@@ -41,7 +41,7 @@ export async function installSiteTemplate(
   session: ISession,
   mystTemplate: MystTemplate,
 ): Promise<void> {
-  if (fs.existsSync(join(mystTemplate.templatePath, 'node_modules'))) return;
+  if (fs.existsSync(mystTemplate.templatePath)) return;
   const toc = tic();
   session.log.info('⤵️  Installing web libraries (can take up to 60 s)');
   await makeExecutable(

--- a/packages/myst-cli/src/build/site/template.ts
+++ b/packages/myst-cli/src/build/site/template.ts
@@ -31,6 +31,7 @@ export async function getSiteTemplate(session: ISession, opts?: { template?: str
         ruleId: RuleId.validSiteConfig,
       });
     },
+    validateFiles: false
   });
   await mystTemplate.ensureTemplateExistsOnPath();
   cache.$siteTemplate = mystTemplate;
@@ -41,7 +42,7 @@ export async function installSiteTemplate(
   session: ISession,
   mystTemplate: MystTemplate,
 ): Promise<void> {
-  if (fs.existsSync(mystTemplate.templatePath)) return;
+  if (fs.existsSync((join(mystTemplate.templatePath, 'node_modules')))) return;
   const toc = tic();
   session.log.info('⤵️  Installing web libraries (can take up to 60 s)');
   await makeExecutable(

--- a/packages/myst-cli/src/build/site/template.ts
+++ b/packages/myst-cli/src/build/site/template.ts
@@ -11,7 +11,10 @@ import { castSession } from '../../session/cache.js';
 const DEFAULT_TEMPLATE = 'book-theme';
 const DEFAULT_INSTALL_COMMAND = 'npm install';
 
-export async function getSiteTemplate(session: ISession, opts?: { template?: string, defaultTemplate?: string }) {
+export async function getSiteTemplate(
+  session: ISession,
+  opts?: { template?: string; defaultTemplate?: string },
+) {
   const cache = castSession(session);
   const state = cache.store.getState();
   if (cache.$siteTemplate) return cache.$siteTemplate;
@@ -31,7 +34,7 @@ export async function getSiteTemplate(session: ISession, opts?: { template?: str
         ruleId: RuleId.validSiteConfig,
       });
     },
-    validateFiles: false
+    validateFiles: false,
   });
   await mystTemplate.ensureTemplateExistsOnPath();
   cache.$siteTemplate = mystTemplate;
@@ -42,7 +45,7 @@ export async function installSiteTemplate(
   session: ISession,
   mystTemplate: MystTemplate,
 ): Promise<void> {
-  if (fs.existsSync((join(mystTemplate.templatePath, 'node_modules')))) return;
+  if (fs.existsSync(join(mystTemplate.templatePath, 'node_modules'))) return;
   const toc = tic();
   session.log.info('⤵️  Installing web libraries (can take up to 60 s)');
   await makeExecutable(

--- a/packages/myst-cli/src/build/site/template.ts
+++ b/packages/myst-cli/src/build/site/template.ts
@@ -34,7 +34,7 @@ export async function getSiteTemplate(
         ruleId: RuleId.validSiteConfig,
       });
     },
-    validateFiles: false,
+    validateFiles: opts?.template ? false : true,
   });
   await mystTemplate.ensureTemplateExistsOnPath();
   cache.$siteTemplate = mystTemplate;

--- a/packages/myst-cli/src/cli/options.ts
+++ b/packages/myst-cli/src/cli/options.ts
@@ -127,6 +127,14 @@ export function makeServerPortOption() {
     .default(undefined);
 }
 
+export function makeTemplateOption() {
+  return new Option(
+    '--template <path-to-template>',
+    'Use this template file, instead of the one specified in the myst.yml manifest'
+  )
+    .default(undefined);
+}
+
 export function makeYesOption() {
   return new Option('-y, --yes', 'Automatically respond yes to prompts').default(false);
 }

--- a/packages/myst-cli/src/cli/options.ts
+++ b/packages/myst-cli/src/cli/options.ts
@@ -130,9 +130,8 @@ export function makeServerPortOption() {
 export function makeTemplateOption() {
   return new Option(
     '--template <path-to-template>',
-    'Use this template file, instead of the one specified in the myst.yml manifest'
-  )
-    .default(undefined);
+    'Use this template file, instead of the one specified in the myst.yml manifest',
+  ).default(undefined);
 }
 
 export function makeYesOption() {

--- a/packages/myst-cli/src/cli/start.ts
+++ b/packages/myst-cli/src/cli/start.ts
@@ -21,4 +21,3 @@ export function makeStartCommand() {
     .addOption(makeMaxSizeWebpOption());
   return command;
 }
-

--- a/packages/myst-cli/src/cli/start.ts
+++ b/packages/myst-cli/src/cli/start.ts
@@ -4,6 +4,7 @@ import {
   makeHeadlessOption,
   makePortOption,
   makeServerPortOption,
+  makeTemplateOption,
   makeExecuteOption,
   makeMaxSizeWebpOption,
 } from './options.js';
@@ -16,6 +17,8 @@ export function makeStartCommand() {
     .addOption(makeHeadlessOption())
     .addOption(makePortOption())
     .addOption(makeServerPortOption())
+    .addOption(makeTemplateOption())
     .addOption(makeMaxSizeWebpOption());
   return command;
 }
+

--- a/packages/myst-templates/src/template.ts
+++ b/packages/myst-templates/src/template.ts
@@ -65,8 +65,15 @@ class MystTemplate {
     if (!fs.existsSync(templateYmlPath)) {
       throw new Error(`The template yml at "${templateYmlPath}" does not exist`);
     }
+
+    interface TemplateYaml {
+      files: string[];
+      [key: string]: any;
+    };
     const content = fs.readFileSync(templateYmlPath).toString();
-    return yaml.load(content);
+    const yamlData : TemplateYaml = yaml.load(content) as TemplateYaml;
+    const { files, ...filteredYaml } = yamlData;
+    return filteredYaml;
   }
 
   getValidatedTemplateYml() {

--- a/packages/myst-templates/src/template.ts
+++ b/packages/myst-templates/src/template.ts
@@ -81,15 +81,11 @@ class MystTemplate {
         errorLogFn: this.errorLogFn,
         warningLogFn: this.warningLogFn,
       };
-      const templateYml = validateTemplateYml(
-        this.session,
-        this.getTemplateYml(),
-        {
-          ...opts,
-          templateDir: this.templatePath,
-          validateFiles: this.validateFiles
-        }
-      );
+      const templateYml = validateTemplateYml(this.session, this.getTemplateYml(), {
+        ...opts,
+        templateDir: this.templatePath,
+        validateFiles: this.validateFiles,
+      });
       if (opts.messages.errors?.length || templateYml === undefined) {
         // Strictly error if template.yml is invalid
         throw new Error(`Cannot use invalid ${TEMPLATE_YML}: ${this.getTemplateYmlPath()}`);

--- a/packages/myst-templates/src/validators.ts
+++ b/packages/myst-templates/src/validators.ts
@@ -511,7 +511,7 @@ export function validateTemplateStyle(input: any, opts: ValidationOptions) {
 export function validateTemplateYml(
   session: ISession,
   input: any,
-  opts: ValidationOptions & { templateDir?: string },
+  opts: ValidationOptions & { templateDir?: string, validateFiles?: boolean },
 ) {
   const inputObj = validateObject(input, opts);
   if (inputObj === undefined) return undefined;
@@ -646,7 +646,7 @@ export function validateTemplateYml(
       },
     );
   }
-  if (defined(value.files)) {
+  if (defined(value.files) && (opts?.validateFiles ?? true)) {
     output.files = validateList(value.files, incrementOptions('files', opts), (val, ind) => {
       const fileOpts = incrementOptions(`files.${ind}`, opts);
       const file = validateString(val, fileOpts);

--- a/packages/myst-templates/src/validators.ts
+++ b/packages/myst-templates/src/validators.ts
@@ -511,7 +511,7 @@ export function validateTemplateStyle(input: any, opts: ValidationOptions) {
 export function validateTemplateYml(
   session: ISession,
   input: any,
-  opts: ValidationOptions & { templateDir?: string, validateFiles?: boolean },
+  opts: ValidationOptions & { templateDir?: string; validateFiles?: boolean },
 ) {
   const inputObj = validateObject(input, opts);
   if (inputObj === undefined) return undefined;


### PR DESCRIPTION
- This command line argument uses the same mechanism as the manifest loader
- The theme manifest currently has a files section that includes build products that are not present when working locally. This commit therefore drops the `files` key from the `template.yml`.
- When determining whether to obtain the manifest locally or download it, we currently check whether `template_dir/node_modules` exists; again, this is not the case when working locally, and merely wanting to point to a different manifest file, so this check was simplified to only check for the presence of the manifest file itself.

Since I do not know the project history, removing `files` and the check for `node_modules` may well violate some known constraint. Happy to be pointed in a better direction!