### PR TITLE
Clarify BASE_URL instructions in GH action for custom domains.

### DIFF
--- a/packages/myst-cli/src/init/gh-actions/index.ts
+++ b/packages/myst-cli/src/init/gh-actions/index.ts
@@ -26,6 +26,12 @@ on:
     branches: [${defaultBranch}]
 env:
   # \`BASE_URL\` determines the website is served from, including CSS & JS assets
+  #
+  # The code below was automatically set when you first ran \`myst init --gh-pages\`,
+  # but the correct values may change if you update where you deploy your site. 
+  # For repositories served from custom domains (e.g. "you.com"), you may need to set
+  # this value to "BASE_URL: ''".
+  #
   # You may need to change this to \`${
     isGithubIO ? 'BASE_URL: /${{ github.event.repository.name }}' : "BASE_URL: ''"
   }\`

--- a/packages/myst-cli/src/init/gh-actions/index.ts
+++ b/packages/myst-cli/src/init/gh-actions/index.ts
@@ -25,8 +25,6 @@ on:
     # Runs on pushes targeting the default branch
     branches: [${defaultBranch}]
 env:
-  # \`BASE_URL\` determines the website is served from, including CSS & JS assets
-  #
   # `BASE_URL` determines, relative to the root of the domain, the URL that your site is served from.
   # E.g., if your site lives at `https://mydomain.org/myproject`, set `BASE_URL=/myproject`.
   # If, instead, your site lives at the root of the domain, at `https://mydomain.org`, set `BASE_URL=''".

--- a/packages/myst-cli/src/init/gh-actions/index.ts
+++ b/packages/myst-cli/src/init/gh-actions/index.ts
@@ -27,10 +27,9 @@ on:
 env:
   # \`BASE_URL\` determines the website is served from, including CSS & JS assets
   #
-  # The code below was automatically set when you first ran \`myst init --gh-pages\`,
-  # but the correct values may change if you update where you deploy your site. 
-  # For repositories served from custom domains (e.g. "you.com"), you may need to set
-  # this value to "BASE_URL: ''".
+  # `BASE_URL` determines, relative to the root of the domain, the URL that your site is served from.
+  # E.g., if your site lives at `https://mydomain.org/myproject`, set `BASE_URL=/myproject`.
+  # If, instead, your site lives at the root of the domain, at `https://mydomain.org`, set `BASE_URL=''".
   #
   # You may need to change this to \`${
     isGithubIO ? 'BASE_URL: /${{ github.event.repository.name }}' : "BASE_URL: ''"

--- a/packages/myst-cli/src/init/gh-actions/index.ts
+++ b/packages/myst-cli/src/init/gh-actions/index.ts
@@ -28,10 +28,6 @@ env:
   # `BASE_URL` determines, relative to the root of the domain, the URL that your site is served from.
   # E.g., if your site lives at `https://mydomain.org/myproject`, set `BASE_URL=/myproject`.
   # If, instead, your site lives at the root of the domain, at `https://mydomain.org`, set `BASE_URL=''".
-  #
-  # You may need to change this to \`${
-    isGithubIO ? 'BASE_URL: /${{ github.event.repository.name }}' : "BASE_URL: ''"
-  }\`
   ${
     isGithubIO
       ? `BASE_URL: '' # Not required for '${username}.github.io' domain. Other repos will need to set this!`


### PR DESCRIPTION
Extends the existing comment to help users who may change deployment options after their original setup, as they may encounter CSS issues.

I just spent an hour tracking this down - while the comment was there as a hint, I wasn't quite sure this was the problem. I just added a slightly more explicit note as my situation may happen again: a user who initially tests as site on `<username>.github.io`  and later decides to move to `theirwebsite.org`, sets everything up correctly for custom domains on GH and their DNS machinery, but gets a borked website with zero CSS.

I'm also happy to add more to the docs if desired, though I didn't quite stumble due to docs issues, it really was this action that threw me for a loop.
