### PR TITLE
Add footnote about links to md files not in ToC

### DIFF
--- a/docs/cross-references.md
+++ b/docs/cross-references.md
@@ -56,7 +56,7 @@ Cross-referencing content is accomplished with markdown link syntax (`[text](#ta
     : If you override the text in the link, that will be used.
   - [**bold _reference_**](#targeting-headers)
 * - `[](./citations.md)`
-    : Link to documents using relative links from the markdown.
+    : Link to documents using relative links from the markdown[^3].
   - [](./citations.md)
 * - `[](./myst.yml)`
     : Link to static files that will be included in your built website. Similar to the [{download}](#download-role) role.
@@ -65,6 +65,8 @@ Cross-referencing content is accomplished with markdown link syntax (`[text](#ta
     : External hover-references to MyST or Sphinx projects. See [](./external-references.md).
   - [Admonition](xref:spec#admonition)
 ```
+
+[^3]: To link to a page, that file must be included in the project's [table of contents](./table-of-contents.md). If it isn't, then the document will be presented as a static file.
 
 % TODO: absolute links
 
@@ -194,9 +196,9 @@ See [](#my-math-label) for an equation!
 
 ### Header Targets
 
-To add labels to a header use `(my-section)=` before the header, these can then be used in markdown links and {myst:role}`ref` roles. This is helpful if you want to quickly insert links to other parts of your book. Referencing a heading will show the heading and the subsequent two pieces of content[^3], unless a header is encountered.
+To add labels to a header use `(my-section)=` before the header, these can then be used in markdown links and {myst:role}`ref` roles. This is helpful if you want to quickly insert links to other parts of your book. Referencing a heading will show the heading and the subsequent two pieces of content[^4], unless a header is encountered.
 
-[^3]: The content could be a single paragraph, a figure, table or list. It can also be fully interactive content, with cross-references to other content, allowing you to nest and follow references easily!
+[^4]: The content could be a single paragraph, a figure, table or list. It can also be fully interactive content, with cross-references to other content, allowing you to nest and follow references easily!
 
 ```{myst}
 (my-section)=


### PR DESCRIPTION
This PR adds a footnote to the cross-references page.

Cross-references to relative markdown files (like, `[document](./document.md)`) will serve static files if those files are not included in the ToC. This might be confusing for users manually curating their ToC. The footnote points out this behaviour.