### PR TITLE
🪄 Improve error handling during cross reference resolution

### DIFF
--- a/.changeset/selfish-news-love.md
+++ b/.changeset/selfish-news-love.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Improve error handling for xref resolution

--- a/packages/myst-cli/src/transforms/crossReferences.ts
+++ b/packages/myst-cli/src/transforms/crossReferences.ts
@@ -39,36 +39,39 @@ async function fetchMystData(
   urlSource: string | undefined,
   vfile: VFile,
 ) {
-  let note: string;
-  if (dataUrl) {
-    const filename = mystDataFilename(dataUrl);
-    const cacheData = loadFromCache(session, filename, { maxAge: XREF_MAX_AGE });
-    if (cacheData) {
-      return JSON.parse(cacheData) as MystData;
-    }
-    try {
-      const resp = await session.fetch(dataUrl);
-      if (resp.ok) {
-        const data = (await resp.json()) as MystData;
-        writeToCache(session, filename, JSON.stringify(data));
-        return data;
-      }
-    } catch {
-      // data is unset
-    }
-    note = 'Could not load data from external project';
-  } else {
-    note = 'Data source URL unavailable';
+  const onError = (note: string): undefined => {
+    fileWarn(
+      vfile,
+      `Unable to resolve link text from external MyST reference: ${urlSource ?? dataUrl ?? ''}`,
+      {
+        ruleId: RuleId.mystLinkValid,
+        note,
+      },
+    );
+  };
+  if (!dataUrl) {
+    return onError('Data source URL unavailable');
   }
-  fileWarn(
-    vfile,
-    `Unable to resolve link text from external MyST reference: ${urlSource ?? dataUrl ?? ''}`,
-    {
-      ruleId: RuleId.mystLinkValid,
-      note,
-    },
-  );
-  return;
+
+  const filename = mystDataFilename(dataUrl);
+  const cacheData = loadFromCache(session, filename, { maxAge: XREF_MAX_AGE });
+  if (cacheData) {
+    return JSON.parse(cacheData) as MystData;
+  }
+  let data: MystData;
+  try {
+    const resp = await session.fetch(dataUrl);
+    if (!resp.ok) {
+      return onError('Could not fetch data from URL');
+    }
+    data = (await resp.json()) as MystData;
+  } catch {
+    return onError('Could not load fetched data');
+    // data is unset
+  }
+
+  writeToCache(session, filename, JSON.stringify(data));
+  return data;
 }
 
 export async function fetchMystLinkData(session: ISession, node: Link, vfile: VFile) {


### PR DESCRIPTION
I created this PR when working on output upgrading a few months ago. It's a simple change to make it easier to determine why xref processing fails.