### PR TITLE
🐛 Fix missing references in `docx` export

### DIFF
--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -67,6 +67,7 @@ function defaultWordRenderer(
     serializer.render(createReferenceTitle());
     const referencesRoot = htmlTransform({ type: 'root', children: referencesDocStates as any });
     serializer.renderChildren(referencesRoot);
+    serializer.closeBlock();
   }
   selectAll('footnoteDefinition', mdast).forEach((footnote) => {
     serializer.render(footnote);


### PR DESCRIPTION
Fixes issue #1467.

Test case: [01-paper.md](https://github.com/user-attachments/files/19551220/01-paper.md)

Without fix:
![without_fix](https://github.com/user-attachments/assets/f9c70458-ef12-4ac4-879c-1e6d7590e7ae)

With fix:
![with_fix](https://github.com/user-attachments/assets/1f116192-756f-4063-b68e-bc1ae1e7de66)
