### PR TITLE
👨🏻‍🔧 fix check link transform for cards

### DIFF
--- a/.changeset/long-fishes-change.md
+++ b/.changeset/long-fishes-change.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+This makes a fix to the checkLinkTransform, that processes `card` nodes in addition to `links`. Card nodes can have optional `url` properties, which when undefined cause a fatal error.

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -206,8 +206,8 @@ export async function checkLinksTransform(
           addWarningForFile(
             session,
             file,
-            `Linkable node (${link.type}) is missing a URL`,
-            'error',
+            `A linkable node (${link.type}) is missing a URL, skipping...`,
+            'warn',
             {
               position,
               ruleId: RuleId.linkResolves,

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -202,6 +202,19 @@ export async function checkLinksTransform(
     linkNodes.map(async (link) =>
       limitOutgoingConnections(async () => {
         const { position, url } = link;
+        if (!url) {
+          addWarningForFile(
+            session,
+            file,
+            `Linkable node (${link.type}) is missing a URL`,
+            'error',
+            {
+              position,
+              ruleId: RuleId.linkResolves,
+            },
+          );
+          return '';
+        }
         const check = await checkLink(session, url);
         if (check.ok || check.skipped) return url as string;
         const status = check.status ? ` (${check.status}, ${check.statusText})` : '';

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -201,18 +201,9 @@ export async function checkLinksTransform(
   const linkResults = await Promise.all(
     linkNodes.map(async (link) =>
       limitOutgoingConnections(async () => {
-        const { position, url } = link;
-        if (!url) {
-          addWarningForFile(
-            session,
-            file,
-            `A linkable node (${link.type}) is missing a URL, skipping...`,
-            'warn',
-            {
-              position,
-              ruleId: RuleId.linkResolves,
-            },
-          );
+        const { position, url, type } = link;
+        // Allow cards to have undefined URLs
+        if (type === 'card' && !url) {
           return '';
         }
         const check = await checkLink(session, url);


### PR DESCRIPTION
This makes a fix to the checkLinkTransform, that processes `card` nodes in addition to `links`. Card nodes can have optional `url` properties, which when undefined cause a fatal error.

Reproduce using:

```markdown
# testing cards with no links

:::{card}

some content

:::

:::{card}
:link: https://curvenote.com

some content linked

:::
```

and running `myst build --check-links`, the first card will cause the build failure.

