### PR TITLE
🔙 Move execution transform earlier in mdast pipeline

### DIFF
--- a/.changeset/weak-bananas-cover.md
+++ b/.changeset/weak-bananas-cover.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Move kernel execution transform earlier in pipeline

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -182,6 +182,19 @@ export async function transformMdast(
   // This needs to come before basic transformations since it may add labels to blocks
   liftCodeMetadataToBlock(session, vfile, mdast);
 
+  if (execute && !frontmatter.skip_execution) {
+    const cachePath = path.join(session.buildPath(), 'execute');
+    await kernelExecutionTransform(mdast, vfile, {
+      basePath: session.sourcePath(),
+      cache: new LocalDiskCache<(IExpressionResult | IOutput[])[]>(cachePath),
+      sessionFactory: () => session.jupyterSessionManager(),
+      frontmatter: frontmatter,
+      ignoreCache: false,
+      errorIsFatal: false,
+      log: session.log,
+    });
+  }
+
   const pipe = unified()
     .use(reconstructHtmlPlugin) // We need to group and link the HTML first
     .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
@@ -225,18 +238,6 @@ export async function transformMdast(
   // Combine file-specific citation renderers with project renderers from bib files
   const fileCitationRenderer = combineCitationRenderers(cache, ...rendererFiles);
 
-  if (execute && !frontmatter.skip_execution) {
-    const cachePath = path.join(session.buildPath(), 'execute');
-    await kernelExecutionTransform(mdast, vfile, {
-      basePath: session.sourcePath(),
-      cache: new LocalDiskCache<(IExpressionResult | IOutput[])[]>(cachePath),
-      sessionFactory: () => session.jupyterSessionManager(),
-      frontmatter: frontmatter,
-      ignoreCache: false,
-      errorIsFatal: false,
-      log: session.log,
-    });
-  }
   transformRenderInlineExpressions(mdast, vfile);
   await transformOutputsToCache(session, mdast, kind, { minifyMaxCharacters });
   transformFilterOutputStreams(mdast, vfile, frontmatter.settings);


### PR DESCRIPTION
Subsequent PRs that look to introduce Markdown output support from code-cells will want to make use of as much of the AST transform pipeline as possible. This PR moves kernel execution before much of the basic transforms, so that we can later do this. It should not break / change anything.