### PR TITLE
🔍 Do not treat wiki permalinks as wiki-links for now

### DIFF
--- a/packages/myst-transforms/src/links/plugin.ts
+++ b/packages/myst-transforms/src/links/plugin.ts
@@ -20,7 +20,7 @@ export function formatLinkText(link: Link) {
   if (link.children?.length !== 1 || link.children[0].type !== 'text') return;
   const url = link.children[0].value;
   // Add an exception for wiki transforms links.
-  if (url.length < 20 || url.match(/\s/) || url.startsWith('wiki:')) return;
+  if (url.length < 20 || url.match(/\s/)) return;
   if (url.includes('​')) return;
   // Split the URL into an array to distinguish double slashes from single slashes
   const doubleSlash = url.split('//');
@@ -48,7 +48,10 @@ export function linksTransform(mdast: GenericParent, file: VFile, opts: Options)
     const result = transform?.transform(link, file);
     // The link transform may compare the text
     // Formatting adds no-width spaces to some URLs
-    formatLinkText(link);
+    // Don't format text if transform already does this
+    if (!(transform && transform.formatsText)) {
+      formatLinkText(link);
+    }
     if (!transform || result === undefined) return;
     if (result) {
       delete link.error;

--- a/packages/myst-transforms/src/links/types.ts
+++ b/packages/myst-transforms/src/links/types.ts
@@ -5,6 +5,7 @@ import type { Inventory } from 'intersphinx';
 
 export interface LinkTransformer {
   protocol?: string;
+  formatsText?: boolean;
   test: (uri?: string) => boolean;
   transform: (link: Link, file: VFile) => boolean;
 }

--- a/packages/myst-transforms/src/links/wiki.ts
+++ b/packages/myst-transforms/src/links/wiki.ts
@@ -31,8 +31,11 @@ export class WikiTransformer implements LinkTransformer {
   test(uri?: string): boolean {
     if (!uri) return false;
     if (uri.startsWith('wiki:')) return true;
-    if (uri.match(ANY_WIKIPEDIA_ORG)) return true;
-    if (withoutHttp(uri).startsWith(withoutHttp(this.wikiUrl))) return true;
+    if (uri.match(ANY_WIKIPEDIA_ORG) || withoutHttp(uri).startsWith(withoutHttp(this.wikiUrl))) {
+      // For now, don't match alternative links of the form /w/index.php?oldid=...&title=...
+      // In future, we should support both normalising non-permalinks with ?title=..., and permalinks with oldid=
+      return !uri.match(/\/w\/index\.php(\?[^/]*)?$/);
+    }
     return false;
   }
 


### PR DESCRIPTION
To fix #1954, we need to understand permalinks. I don't have time _right now_ to add support for transforming and understanding permalinks, as this will likely require support in myst-theme too. This PR, instead, just silences any warnings by not touching permalinks and instead treating them as regular old links.