### PR TITLE
Document how to put content in the right sidebar area

### DIFF
--- a/docs/website-navigation.md
+++ b/docs/website-navigation.md
@@ -157,7 +157,7 @@ site:
     hide_outline: true
 ```
 
-### Make content take up the space in the right margin
+### Make content expand to the right margin
 
 To make content take up the empty space to the right of the content (where the secondary sidebar usually lives), attach the `col-page-right` CSS class (one of the [built-in CSS classes](#built-in-css)) to a page block or element.
 

--- a/docs/website-navigation.md
+++ b/docs/website-navigation.md
@@ -164,7 +164,7 @@ To make content take up the empty space to the right of the content (where the s
 Here's an example of attaching the class directly to an admonition:
 
 ````md
-```{admonition} This admonition will spread to the right!
+```{note} This note will spread to the right!
 :class: col-page-right
 Yes it will!
 ```

--- a/docs/website-navigation.md
+++ b/docs/website-navigation.md
@@ -157,6 +157,21 @@ site:
     hide_outline: true
 ```
 
+### Make content take up the space in the right margin
+
+To make content take up the empty space to the right of the content (where the secondary sidebar usually lives), attach the `col-page-right` CSS class (one of the [built-in CSS classes](#built-in-css)) to a page block or element.
+
+Here's an example of attaching the class directly to an admonition:
+
+````md
+```{admonition} This admonition will spread to the right!
+:class: col-page-right
+Yes it will!
+```
+````
+
+You could also attach it to a [contenet block](./blocks.md).
+
 (navigation:footer)=
 
 ## Footer

--- a/docs/website-navigation.md
+++ b/docs/website-navigation.md
@@ -170,7 +170,7 @@ Yes it will!
 ```
 ````
 
-You could also attach it to a [contenet block](./blocks.md).
+You could also attach the CSS class to a [content block](./blocks.md).
 
 (navigation:footer)=
 

--- a/docs/website-navigation.md
+++ b/docs/website-navigation.md
@@ -170,6 +170,11 @@ Yes it will!
 ```
 ````
 
+```{note} This note will spread to the right!
+:class: col-page-right
+Yes it will!
+```
+
 You could also attach the CSS class to a [content block](./blocks.md).
 
 (navigation:footer)=

--- a/docs/website-style.md
+++ b/docs/website-style.md
@@ -77,6 +77,7 @@ I'm _very stylish_.
 
 You can add CSS classes directly to roles and divs using [Inline Options syntax](./inline-options.md).
 
+(built-in-css)=
 ## Built-in CSS Classes
 
 The HTML themes come with [a grid system of CSS classes](https://jupyter-book.github.io/myst-theme/?path=/docs/components-grid-system--docs), which can be used out-of-the-box to position content.


### PR DESCRIPTION
This adds some light documentation for how you can make content fill to the right sidebar area using the CSS grid classes. It took me a while to figure this one out so I thought it'd be helpful to add.