### PR TITLE
 Update links to example of landing pages

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -176,11 +176,11 @@ Recall from the [architecture overview](#diagram-app) that `myst-theme` is a Rea
 
 #### Content server
 
-We need some example data to test our theme against, such as [the example landing page](https://github.com/myst-examples/landing-pages). Clone this example content repository and start the content server:
+We need some example data to test our theme against, such as [the example landing page](https://github.com/jupyter-book/example-landing-pages). Clone this example content repository and start the content server:
 
 ```shell
-git clone https://github.com/myst-examples/landing-pages
-cd landing-pages
+git clone https://github.com/jupyter-book/example-landing-pages
+cd example-landing-pages
 myst start --headless
 ```
 
@@ -291,11 +291,13 @@ When we publish a new release to NPM, we also make a release on GitHub and share
 
   See the link above for the release notes on GitHub! Many thanks to the [Jupyter Book team](https://compass.jupyterbook.org/team) for stewarding our development and this release.
   ```
+
 - **Share the release post in Jupyter-adjacent spaces**. Here are a few places that are worth sharing (you can just copy/paste the same text into each):
   - [The MyST Discord](https://discord.mystmd.org/)
   - [The Jupyter Zulip Forum](https://https://jupyter.zulipchat.com)
   - [The Jupyter Discourse](https://discourse.jupyter.org)
   - Social media spaces of your choosing.
+
 ### Packages in the mystmd repository
 
 All packages used to build `mystmd` live in the [https://github.com/jupyter-book/mystmd](https://github.com/jupyter-book/mystmd) repository.

--- a/docs/website-landing-pages.md
+++ b/docs/website-landing-pages.md
@@ -15,7 +15,7 @@ Landing pages are experimental, and the syntax and/or supported block-types are 
 The MyST [book-theme](#template-site-myst-book-theme) template provides out-of-the-box support for high-level landing-page blocks. By adding a small amount of annotation to your landing page, you can increase the approachability of your home page by composing it from visually-appealing blocks.
 
 :::{tip} Landing Page Example
-You can find a full working example at [`myst-examples/landing-pages`](https://github.com/myst-examples/landing-pages).
+You can find a full working example at [`jupyter-book/example-landing-pages`](https://github.com/jupyter-book/example-landing-pages).
 :::
 
 ## Defining a Block


### PR DESCRIPTION
With a recent move from `myst-examples` repositories to the main `jupyter-book` organisation, we need to fix our links in our documentation.

This is tiny: self merging.