### PR TITLE
⚠️ Improve error messages for `myst templates download` command

### DIFF
--- a/.changeset/wise-ducks-cough.md
+++ b/.changeset/wise-ducks-cough.md
@@ -1,0 +1,5 @@
+---
+"mystmd": patch
+---
+
+Improve error messages in template handling

--- a/packages/myst-cli/src/cli/build.ts
+++ b/packages/myst-cli/src/cli/build.ts
@@ -42,7 +42,11 @@ export function makeBuildCommand() {
     .addOption(makeDOIBibOption())
     .addOption(makeWatchOption())
     .addOption(makeNamedExportOption('Output file for the export'))
-    .addOption(makeForceOption())
+    .addOption(
+      makeForceOption(
+        'Build outputs for the given format, even if corresponding exports are not defined in file frontmatter',
+      ),
+    )
     .addOption(makeCheckLinksOption())
     .addOption(makeStrictOption())
     .addOption(makeCIOption())

--- a/packages/myst-cli/src/cli/options.ts
+++ b/packages/myst-cli/src/cli/options.ts
@@ -85,11 +85,8 @@ export function makeStrictOption() {
   return new Option('--strict', 'Summarize build warnings and stop on any errors.').default(false);
 }
 
-export function makeForceOption() {
-  return new Option(
-    '--force',
-    'Build outputs for the given format, even if corresponding exports are not defined in file frontmatter',
-  ).default(false);
+export function makeForceOption(description: string) {
+  return new Option('--force', description).default(false);
 }
 
 export function makeCheckLinksOption() {

--- a/packages/mystmd/src/templates.ts
+++ b/packages/mystmd/src/templates.ts
@@ -41,7 +41,7 @@ function getKindFromName(name: string) {
 function getKind(session: ISession, kinds?: TemplateKinds): TemplateKind[] | undefined {
   if (!kinds) return undefined;
   const { pdf, tex, typst, docx, site } = kinds;
-  if (pdf) session.log.warn('PDF templates may use either "tex" or "typst"');
+  if (pdf) session.log.warn('PDF templates may be either "tex" or "typst", including both.');
   const flags = {
     [TemplateKind.tex]: (tex || pdf) ?? false,
     [TemplateKind.typst]: (typst || pdf) ?? false,
@@ -63,8 +63,12 @@ export async function downloadTemplateCLI(
 ) {
   const templateKind = getKindFromName(template);
   const kinds = templateKind ? [templateKind] : getKind(session, opts);
-  if (!kinds || kinds.length > 1) {
-    throw new Error('Cannot lookup a template with more than one kind.');
+  if (!kinds || !kinds.length) {
+    throw new Error('Cannot lookup a template without specifying a kind (e.g. typst).');
+  }
+
+  if (kinds.length > 1) {
+    throw new Error('Cannot lookup a template when more than one kind is specified.');
   }
   const kind = kinds[0] as TemplateKind;
   const { templatePath: defaultTemplatePath, templateUrl } = resolveInputs(session, {

--- a/packages/mystmd/src/templates.ts
+++ b/packages/mystmd/src/templates.ts
@@ -190,7 +190,7 @@ function makeDownloadCLI(program: Command) {
     .addOption(makeTypstOption('Download Typst template'))
     .addOption(makeDocxOption('Download Docx template'))
     .addOption(makeSiteOption('Download Site template'))
-    .addOption(makeForceOption())
+    .addOption(makeForceOption('Overwrite existing downloaded templates'))
     .action(clirun(Session, downloadTemplateCLI, program));
   return command;
 }

--- a/packages/mystmd/src/templates.ts
+++ b/packages/mystmd/src/templates.ts
@@ -63,7 +63,7 @@ export async function downloadTemplateCLI(
 ) {
   const templateKind = getKindFromName(template);
   const kinds = templateKind ? [templateKind] : getKind(session, opts);
-  if (!kinds || !kinds.length) {
+  if (!kinds?.length) {
     throw new Error('Cannot lookup a template without specifying a kind (e.g. typst).');
   }
 


### PR DESCRIPTION
In pursuing #2033, I discovered that the error messages for `myst templates download` were not intuitive.

This PR closes #2033 by rewording the errors to make recovery steps clearer.