### PR TITLE
🔄 Change default LaTeX template to `plain_latex`

### DIFF
--- a/.changeset/thin-owls-begin.md
+++ b/.changeset/thin-owls-begin.md
@@ -1,0 +1,5 @@
+---
+"myst-templates": patch
+---
+
+Change default LaTeX template

--- a/packages/jtex/tests/download.spec.ts
+++ b/packages/jtex/tests/download.spec.ts
@@ -14,9 +14,9 @@ describe(
         templatePath: inputs.templatePath,
         templateUrl: inputs.templateUrl as string,
       });
-      expect(fs.existsSync('_build/templates/tex/myst/curvenote/template.zip')).toBe(true);
-      expect(fs.existsSync('_build/templates/tex/myst/curvenote/template.yml')).toBe(true);
-      expect(fs.existsSync('_build/templates/tex/myst/curvenote/template.tex')).toBe(true);
+      expect(fs.existsSync('_build/templates/tex/myst/plain_latex/template.zip')).toBe(true);
+      expect(fs.existsSync('_build/templates/tex/myst/plain_latex/template.yml')).toBe(true);
+      expect(fs.existsSync('_build/templates/tex/myst/plain_latex/template.tex')).toBe(true);
     });
     it('Bad template paths to throw', async () => {
       const jtex = new MystTemplate(new Session(), {

--- a/packages/myst-templates/src/download.spec.ts
+++ b/packages/myst-templates/src/download.spec.ts
@@ -10,8 +10,8 @@ describe('resolveInputs', () => {
   beforeEach(() => memfs.vol.reset());
   it('default path and url fill correctly', async () => {
     expect(resolveInputs(new Session(), { kind: TemplateKind.tex })).toEqual({
-      templatePath: 'templates/tex/myst/curvenote',
-      templateUrl: 'https://api.mystmd.org/templates/tex/myst/curvenote',
+      templatePath: 'templates/tex/myst/plain_latex',
+      templateUrl: 'https://api.mystmd.org/templates/tex/myst/plain_latex',
     });
   });
   it('template as path to template file exists', async () => {

--- a/packages/myst-templates/src/download.ts
+++ b/packages/myst-templates/src/download.ts
@@ -19,7 +19,7 @@ export const KIND_TO_EXT: Record<TemplateKind, string | undefined> = {
 };
 
 const DEFAULT_TEMPLATES = {
-  tex: 'tex/myst/curvenote',
+  tex: 'tex/myst/plain_latex',
   typst: 'typst/myst/lapreprint-typst',
   docx: 'docx/myst/default',
   site: 'site/myst/book-theme',

--- a/packages/mystmd/tests/indices/outputs/index.tex
+++ b/packages/mystmd/tests/indices/outputs/index.tex
@@ -1,7 +1,9 @@
 \documentclass{article}
-\PassOptionsToPackage{short, nodayofweek}{datetime}
-
-\input{curvenote.def}
+\usepackage{hyperref}
+\usepackage{datetime}
+\usepackage{graphicx}
+\usepackage{natbib}
+\bibliographystyle{abbrvnat}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%  imports  %%%%%%%%%%%%%%%%%%%
@@ -13,26 +15,22 @@
 
 % colors for hyperlinks
 \hypersetup{colorlinks=true, allcolors=blue}
-\hypersetup{
-pdftitle={\@title},
-pdfsubject={},
-pdfauthor={\@author},
-pdfkeywords={},
-addtopdfcreator={Written in Curvenote}
+
+\newcommand{\logo}{
+  \href{https://curvenote.com}{\includegraphics[width=2cm]{curvenote.png}}
 }
 
-\usepackage{curvenote}
-
 \title{Chicken Thesis}
+
+\author{Franklin Koch}
 
 \newdate{articleDate}{20}{7}{2024}
 \date{\displaydate{articleDate}}
 
-\author{\bfseries Franklin Koch\mdseries\\Curvenote\\}
-
 \begin{document}
-
 \maketitle
+\begin{center}\logo\end{center}
+
 
 \include{index-index}
 
@@ -41,6 +39,8 @@ addtopdfcreator={Written in Curvenote}
 \include{index-recipes}
 
 \include{index-joke}
+
+
 
 
 \end{document}

--- a/packages/mystmd/tests/math-macros/outputs/index.tex
+++ b/packages/mystmd/tests/math-macros/outputs/index.tex
@@ -1,9 +1,13 @@
 \documentclass{article}
-\PassOptionsToPackage{short, nodayofweek}{datetime}
-
-\input{curvenote.def}
+\usepackage{hyperref}
+\usepackage{datetime}
+\usepackage{graphicx}
+\usepackage{natbib}
+\bibliographystyle{abbrvnat}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%  imports  %%%%%%%%%%%%%%%%%%%
+\usepackage{amsmath}
 %%%%%%%%%%%%%%%%%  math commands  %%%%%%%%%%%%%%%%
 \newcommand{\three}{d}
 \newcommand{\one}{x}
@@ -15,27 +19,22 @@
 
 % colors for hyperlinks
 \hypersetup{colorlinks=true, allcolors=blue}
-\hypersetup{
-pdftitle={\@title},
-pdfsubject={},
-pdfauthor={\@author},
-pdfkeywords={},
-addtopdfcreator={Written in Curvenote}
+
+\newcommand{\logo}{
+  \href{https://curvenote.com}{\includegraphics[width=2cm]{curvenote.png}}
 }
 
-\usepackage{curvenote}
-
 \title{Testing Math Plugins}
+
+\author{}
 
 \newdate{articleDate}{1}{1}{2024}
 \date{\displaydate{articleDate}}
 
-\author{}
-
 \begin{document}
-
 \maketitle
-\keywords{}
+\begin{center}\logo\end{center}
+
 
 \section{No plugins}
 
@@ -76,4 +75,6 @@ Double recurse
 \begin{equation}
 \seven
 \end{equation}
+
+
 \end{document}


### PR DESCRIPTION
Closes #1714 by changing the default template, as suggested in https://github.com/jupyter-book/mystmd/issues/1714#issuecomment-2767357252

We could also make a MyST-ified version of the Curvenote template, but I think this is a simple enough start.