### PR TITLE
⚠️ Remove docs warning on legacy link syntax

### DIFF
--- a/docs/contribute-docs.md
+++ b/docs/contribute-docs.md
@@ -168,7 +168,7 @@ This is a lightweight way to create flow charts and diagrams.
 3. Confirm that it is a SVG or PNG that was **created with Excalidraw**, and that had **embed scene** checked upon creation.
 4. Drag-and-drop that file into the Excalidraw window. (or, click **hamburger menu** -> **open** and add your file that way).
 5. Make your edits in Excalidraw.
-6. Export the new diagram using the [steps described above](export-excalidraw).
+6. Export the new diagram using the [steps described above](#export-excalidraw).
 7. Replace the old file with the new one and commit it to `git`. If using an SVG, you can also just copy/paste the new SVG text and replace the old SVG text with it.
 
 ## How to enable Pull Request previews on Netlify

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -47,7 +47,7 @@ An overview of the "Rendering and Theming" phase using one or more MyST renderer
 
 The MyST Document engine knows how to parse many kinds of documents into {term}`MyST AST`. This is most-commonly done with markdown files (`.md`) or Jupyter Notebooks (`.ipynb`) written in {term}`MyST Markdown`, a flavor of markdown that was designed for the MyST Document Engine.
 
-However, the MyST Engine knows how to parse other kinds of syntax into MyST AST as well. For example, [for admonition compatibility with GitHub Markdown](admonition-github-compatibility). This is because we see the {term}`MyST AST` as the primary point of _standardization_ for the MyST ecosystem, not the Markdown flavor. Input documents may have many different forms, but once it is parsed into {term}`MyST AST`, the document should have a standardized structure defined by the {term}`MyST Specification`.
+However, the MyST Engine knows how to parse other kinds of syntax into MyST AST as well. For example, [for admonition compatibility with GitHub Markdown](#admonition-github-compatibility). This is because we see the {term}`MyST AST` as the primary point of _standardization_ for the MyST ecosystem, not the Markdown flavor. Input documents may have many different forms, but once it is parsed into {term}`MyST AST`, the document should have a standardized structure defined by the {term}`MyST Specification`.
 
 ## What is the MyST AST and Specification?
 


### PR DESCRIPTION
Removes these warnings:

```
⚠️  overview.md:50 Legacy syntax used for link target, please prepend a '#' to your link url: "admonition-github-compatibility"
   The link target should be of the form `[](#target)`, including the `#` sign.
This may be deprecated in the future.
⚠️  contribute-docs.md:171 Legacy syntax used for link target, please prepend a '#' to your link url: "export-excalidraw"
   The link target should be of the form `[](#target)`, including the `#` sign.
This may be deprecated in the future.
```