### PR TITLE
Add a dedicated authorship and affiliations section

### DIFF
--- a/docs/authorship.md
+++ b/docs/authorship.md
@@ -49,6 +49,63 @@ affiliations:
 
 See [the `authors` frontmatter reference](#frontmatter:authors) for a list of all authorship metadata fields you can use.
 
+### Re-use author information across repositories and projects
+
+By [extending MyST configuration files](#composing-myst-yml) you can store author information in one place and re-use it across many other locations. This allows you to define a source of truth for authorship and affiliations, and reference that over time. For example:
+
+In one file, you'd define all the author affiliations that are relevant to your project:
+
+```{code-block} yaml
+:filename: authors.yml
+version: 1
+project:
+  contributors:
+    - id: person_a
+      name: First Last
+      email: person_a@org_a.org
+      orcid: XXXX-XXXX-XXXX-XXXX
+      github: person_a
+      affiliations:
+        - id: org_a
+        - id: org_b
+    - id: person_b
+      name: First Last
+      email: person_b@org_b.com
+      orcid: XXXX-XXXX-XXXX-XXXX
+      github: person_b
+      affiliations:
+        - id: org_b
+  affiliations:
+    - id: org_a
+      name: Organization A Incorporated
+    - id: org_b
+      name: Org B Inc.
+```
+
+And in each of your project `myst.yml` files, you can extend this authorship file like so to include all the information:
+
+```{code-block} yaml
+:filename: myst.yml
+version: 1
+extends:
+  - ./authors.yml  # OR, the URL of this file if not hosted locally
+project:
+  authors:
+    - person_a
+    - person_b
+```
+
+You could then also reference these authors in your page frontmatter like so:
+
+```{code-block} markdown
+:filename: mypage.md
+---
+authors:
+- person_a
+---
+
+Page content...
+```
 
 (affiliations)=
 

--- a/docs/authorship.md
+++ b/docs/authorship.md
@@ -1,0 +1,141 @@
+# Authorship and attribution
+
+You can bundle information about the authors of each page in a MyST project, as well as metadata about them. For example, their institutional affiliations, funding, etc. These will be treated differently depending on the 
+
+## How to set author information
+
+Author information is set with [MyST frontmatter](./frontmatter.md). You can set this either in **`myst.yml`** (in which case, they will apply to all documents in a MyST project), or in the **page frontmatter** (in which case they'll just apply to that page).
+
+For example, the examples below show frontmatter for authors and [author affiliations](#affiliations) in frontmatter of an `article.md` file, and in `myst.yml`:
+
+::::{tab-set}
+:::{tab-item} article.md
+
+```yaml
+---
+title: My Article
+authors:
+  - name: Marissa Myst
+    affiliation: ubc
+  - name: Miles Mysterson
+    affiliations: ubc; stanford
+---
+
+My article text begins here...
+```
+
+:::
+:::{tab-item} myst.yml
+
+```yaml
+affiliations:
+  - id: ubc
+    institution: University of British Columbia
+    ror: https://ror.org/03rmrcq20
+    isni: 0000 0001 2288 9830
+    department: Department of Earth, Ocean and Atmospheric Sciences
+    address: 2020 – 2207 Main Mall
+    city: Vancouver
+    region: British Columbia
+    country: Canada
+    postal_code: V6T 1Z4
+    phone: 604 822 2449
+  - id: stanford
+    name: ...
+```
+
+:::
+::::
+
+See [the `authors` frontmatter reference](#frontmatter:authors) for a list of all authorship metadata fields you can use.
+
+
+(affiliations)=
+
+## Affiliations
+
+You can create an affiliation directly by adding it to an author.  It can be as simple as a single string.
+
+```yaml
+authors:
+  - name: Marissa Myst
+    affiliation: University of British Columbia
+```
+
+You can also add much more information to any affiliation, such as a ROR, ISNI, or an address. A very complete affiliations list for an author at the University of British Columbia is:
+
+```yaml
+authors:
+  - name: Marissa Myst
+    affiliations:
+      - id: ubc
+        institution: University of British Columbia
+        ror: https://ror.org/03rmrcq20
+        isni: 0000 0001 2288 9830
+        department: Department of Earth, Ocean and Atmospheric Sciences
+        address: 2020 – 2207 Main Mall
+        city: Vancouver
+        region: British Columbia
+        country: Canada
+        postal_code: V6T 1Z4
+        phone: 604 822 2449
+        bluesky: '@eoas.ubc.ca'
+  - name: Miles Mysterson
+    affiliation: ubc
+```
+
+Notice how you can use an `id` to avoid writing this out for every coauthor. Additionally, if the affiliation is a single string and contains a semi-colon `;` it will be treated as a list.
+
+If you use a string that is not recognized as an already defined affiliation in the project or article frontmatter, an affiliation will be created automatically and normalized so that it can be referenced:
+
+::::{tab-set}
+:::{tab-item} Written Frontmatter
+
+```yaml
+authors:
+  - name: Marissa Myst
+    affiliations:
+      - id: ubc
+        institution: University of British Columbia
+        ror: 03rmrcq20
+        department: Earth, Ocean and Atmospheric Sciences
+      - ACME Inc
+  - name: Miles Mysterson
+    affiliation: ubc
+```
+
+:::
+:::{tab-item} Normalized
+
+```yaml
+authors:
+  - name: Marissa Myst
+    affiliations: ['ubc', 'ACME Inc']
+  - name: Miles Mysterson
+    affiliations: ['ubc']
+affiliations:
+  - id: ubc
+    institution: University of British Columbia
+    ror: https://ror.org/03rmrcq20
+    department: Earth, Ocean and Atmospheric Sciences
+  - id: ACME Inc
+    name: ACME Inc
+```
+
+:::
+::::
+
+See [the frontmatter affiliations table](#table-frontmatter-affiliations) for a complete list of the affiliations metadata you can use.
+
+## Add social media links 
+
+You can add social media links to authors and affiliations.
+To do so, use the following fields in an entry for either `author` or the `affiliation`:
+
+![](#table-frontmatter-social-links)
+
+(other-contributors)=
+
+## Reviewers, Editors, Funding Recipients
+
+Other contributors besides authors may be listed elsewhere in the frontmatter. These include `reviewers`, `editors`, and [funding](#frontmatter:funding) award `investigators` and `recipients`. For all of these fields, you may use a full [author object](#frontmatter:authors), or you may use the string `id` from an existing author object defined elsewhere in your frontmatter.

--- a/docs/authorship.md
+++ b/docs/authorship.md
@@ -1,6 +1,6 @@
 # Authorship and attribution
 
-You can bundle information about the authors of each page in a MyST project, as well as metadata about them. For example, their institutional affiliations, funding, etc. These will be treated differently depending on the 
+You can bundle information about the authors of each page in a MyST project, as well as metadata about them. For example, their institutional affiliations, funding, etc. 
 
 ## How to set author information
 

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -59,9 +59,32 @@ project:
   open_access: true
 ```
 
+
+(field-behavior)=
+
+### How project and page frontmatter interact
+
+Frontmatter can be attached to a “page”, meaning a local `.md` or `.ipynb` or a "project". However, some frontmatter fields are available across an entire project, while others are only available for a given page.
+
+The behavior of each frontmatter field is hard-coded within MyST. These are the kinds of scope that a frontmatter field can have:
+
+`page & project`
+: the field is available on both the page & project but they are independent
+
+`page only`
+: the field is only available on pages, and not present on projects and it will be ignored if set there.
+
+`page can override project`
+: the field is available on both page & project but the value of the field on the page will override any set of the project. If the page field is omitted or undefined, the project value will be used. If the page field has a value of `null` (or `[]` in the case of multi-item fields like `authors`), the page will override the project value and clear the field for that page.
+
+`project only`
+: the field is only available on projects, and not present on pages and it will be ignored if set there.
+
++++
+
 (composing-myst-yml)=
 
-## Compose multiple `.yml` files
+### Compose multiple `.yml` files
 
 You may separate your frontmatter into multiple, composable files. This allows you to have a single source of truth for frontmatter to re-use across multiple projects, for example math macros or funding information.
 
@@ -241,26 +264,6 @@ The following table lists the available frontmatter fields, a brief description 
 
 +++
 
-(field-behavior)=
-
-## Field Behavior
-
-Frontmatter can be attached to a “page”, meaning a local `.md` or `.ipynb` or a “project”. However, individual frontmatter fields are not uniformly available at both levels, and behavior of certain fields are different between project and page levels. There are three field behaviors to be aware of:
-
-`page & project`
-: the field is available on both the page & project but they are independent
-
-`page only`
-: the field is only available on pages, and not present on projects and it will be ignored if set there.
-
-`page can override project`
-: the field is available on both page & project but the value of the field on the page will override any set of the project. Note that the page field must be omitted or undefined, for the project value to be used, value of `null` (or `[]` in the case of `authors`) will still override the project value but clear the field for that page.
-
-`project only`
-: the field is only available on projects, and not present on pages and it will be ignored if set there.
-
-+++
-
 (titles)=
 
 ## Titles
@@ -423,6 +426,8 @@ Contributors and affiliations can also have social links and URLs.
 ```{list-table} Social Links for contributors and affiliations.
 :header-rows: 1
 :label: table-frontmatter-social-links
+* - field
+  - description
 * - `url`
   - a string - website or homepage of the author
 * - `bluesky`
@@ -439,123 +444,9 @@ Contributors and affiliations can also have social links and URLs.
   - a GitHub username
 ```
 
-(other-contributors)=
+### Affiliations
 
-### Reviewers, Editors, Funding Recipients
-
-Other contributors besides authors may be listed elsewhere in the frontmatter. These include `reviewers`, `editors`, and [funding](#frontmatter:funding) award `investigators` and `recipients`. For all of these fields, you may use a full [author object](#frontmatter:authors), or you may use the string `id` from an existing author object defined elsewhere in your frontmatter.
-
-(affiliations)=
-
-## Affiliations
-
-You can create an affiliation directly by adding it to an author, and it can be as simple as a single string.
-
-```yaml
-authors:
-  - name: Marissa Myst
-    affiliation: University of British Columbia
-```
-
-You can also add much more information to any affiliation, such as a ROR, ISNI, or an address. A very complete affiliations list for an author at the University of British Columbia is:
-
-```yaml
-authors:
-  - name: Marissa Myst
-    affiliations:
-      - id: ubc
-        institution: University of British Columbia
-        ror: https://ror.org/03rmrcq20
-        isni: 0000 0001 2288 9830
-        department: Department of Earth, Ocean and Atmospheric Sciences
-        address: 2020 – 2207 Main Mall
-        city: Vancouver
-        region: British Columbia
-        country: Canada
-        postal_code: V6T 1Z4
-        phone: 604 822 2449
-        bluesky: '@eoas.ubc.ca'
-  - name: Miles Mysterson
-    affiliation: ubc
-```
-
-Notice how you can use an `id` to avoid writing this out for every coauthor. Additionally, if the affiliation is a single string and contains a semi-colon `;` it will be treated as a list. The affiliations can also be added to your `project` frontmatter in your `myst.yml` and used across any document in the project.
-
-::::{tab-set}
-:::{tab-item} article.md
-
-```yaml
----
-title: My Article
-authors:
-  - name: Marissa Myst
-    affiliation: ubc
-  - name: Miles Mysterson
-    affiliations: ubc; stanford
----
-```
-
-:::
-:::{tab-item} myst.yml
-
-```yaml
-affiliations:
-  - id: ubc
-    institution: University of British Columbia
-    ror: https://ror.org/03rmrcq20
-    isni: 0000 0001 2288 9830
-    department: Department of Earth, Ocean and Atmospheric Sciences
-    address: 2020 – 2207 Main Mall
-    city: Vancouver
-    region: British Columbia
-    country: Canada
-    postal_code: V6T 1Z4
-    phone: 604 822 2449
-  - id: stanford
-    name: ...
-```
-
-:::
-::::
-
-If you use a string that is not recognized as an already defined affiliation in the project or article frontmatter, an affiliation will be created automatically and normalized so that it can be referenced:
-
-::::{tab-set}
-:::{tab-item} Written Frontmatter
-
-```yaml
-authors:
-  - name: Marissa Myst
-    affiliations:
-      - id: ubc
-        institution: University of British Columbia
-        ror: 03rmrcq20
-        department: Earth, Ocean and Atmospheric Sciences
-      - ACME Inc
-  - name: Miles Mysterson
-    affiliation: ubc
-```
-
-:::
-:::{tab-item} Normalized
-
-```yaml
-authors:
-  - name: Marissa Myst
-    affiliations: ['ubc', 'ACME Inc']
-  - name: Miles Mysterson
-    affiliations: ['ubc']
-affiliations:
-  - id: ubc
-    institution: University of British Columbia
-    ror: https://ror.org/03rmrcq20
-    department: Earth, Ocean and Atmospheric Sciences
-  - id: ACME Inc
-    name: ACME Inc
-```
-
-:::
-::::
+Below are all the possible fields for frontmatter affiliations.
 
 ````{list-table} Frontmatter information for affiliations
 :header-rows: 1
@@ -599,6 +490,7 @@ affiliations:
 * - `collaboration`
   - a boolean - Indicate that this affiliation is a collaboration, for example, `"MyST Contributors"` can be both an affiliation and a listed author. This is used in certain templates as well as in [JATS](https://jats.nlm.nih.gov/archiving/tag-library/1.3/element/collab.html).
 ````
+
 
 ## Date
 

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -102,6 +102,7 @@ project:
         - file: glossaries-and-terms.md
         - file: writing-in-latex.md
         - file: table-of-contents.md
+        - file: authorship.md
         - file: inline-options.md
     - title: Executable Content
       children:


### PR DESCRIPTION
This splits out a little bit of the authorship reference documentation into a dedicated "Authorship" section in the user guide. The goal here is to separate out the "reference docs" (which are appropriately listed under `Reference`) and the how-to and conceptual docs (which are hard to find right now because they're embedded in the big reference docs page).

This doesn't change any content, just tries to make a subset of it more modular and discoverable, with cross-references to our reference docs for more complete lists.

It's a complement to #2021 which is focused on adding more social media frontmatter support