### PR TITLE
🤖 Add required label workflow

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,21 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: |
+            enhancement
+            bug
+            documentation
+            maintenance
+            release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,13 @@ jobs:
         with:
           name: python-package-distributions
           path: packages/mystmd-py/dist/
+      - name: Label pull request
+        uses: actions/labeler@v5
+        if: ${{ steps.changesets.outputs.pullRequestNumber }}
+        with:
+          pr-number: ${{ steps.changesets.outputs.pullRequestNumber }}
+          new-labels: release
+
   release-py:
     name: Release Python
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a simple workflow that ensures PRs have a set of particular labels before they can pass:
- enhancement
- bug
- documentation
- maintenance
- release

- [ ] Update Changeset action PRs to have Release label

