### PR TITLE
📦 Bump turbo repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "latest",
         "rimraf": "^5.0.1",
-        "turbo": "latest",
+        "turbo": "^2.5.4",
         "typescript": "^5.6.2",
         "vitest": "^2.1.2"
       },
@@ -14243,96 +14243,102 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.7.tgz",
-      "integrity": "sha512-xm0MPM28TWx1e6TNC3wokfE5eaDqlfi0G24kmeHupDUZt5Wd0OzHFENEHMPqEaNKJ0I+AMObL6nbSZonZBV2HA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.5.4.tgz",
+      "integrity": "sha512-kc8ZibdRcuWUG1pbYSBFWqmIjynlD8Lp7IB6U3vIzvOv9VG+6Sp8bzyeBWE3Oi8XV5KsQrznyRTBPvrf99E4mA==",
       "dev": true,
-      "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.10.7",
-        "turbo-darwin-arm64": "1.10.7",
-        "turbo-linux-64": "1.10.7",
-        "turbo-linux-arm64": "1.10.7",
-        "turbo-windows-64": "1.10.7",
-        "turbo-windows-arm64": "1.10.7"
+        "turbo-darwin-64": "2.5.4",
+        "turbo-darwin-arm64": "2.5.4",
+        "turbo-linux-64": "2.5.4",
+        "turbo-linux-arm64": "2.5.4",
+        "turbo-windows-64": "2.5.4",
+        "turbo-windows-arm64": "2.5.4"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.7.tgz",
-      "integrity": "sha512-N2MNuhwrl6g7vGuz4y3fFG2aR1oCs0UZ5HKl8KSTn/VC2y2YIuLGedQ3OVbo0TfEvygAlF3QGAAKKtOCmGPNKA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.5.4.tgz",
+      "integrity": "sha512-ah6YnH2dErojhFooxEzmvsoZQTMImaruZhFPfMKPBq8sb+hALRdvBNLqfc8NWlZq576FkfRZ/MSi4SHvVFT9PQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.7.tgz",
-      "integrity": "sha512-WbJkvjU+6qkngp7K4EsswOriO3xrNQag7YEGRtfLoDdMTk4O4QTeU6sfg2dKfDsBpTidTvEDwgIYJhYVGzrz9Q==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.5.4.tgz",
+      "integrity": "sha512-2+Nx6LAyuXw2MdXb7pxqle3MYignLvS7OwtsP9SgtSBaMlnNlxl9BovzqdYAgkUW3AsYiQMJ/wBRb7d+xemM5A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.7.tgz",
-      "integrity": "sha512-x1CF2CDP1pDz/J8/B2T0hnmmOQI2+y11JGIzNP0KtwxDM7rmeg3DDTtDM/9PwGqfPotN9iVGgMiMvBuMFbsLhg==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.5.4.tgz",
+      "integrity": "sha512-5May2kjWbc8w4XxswGAl74GZ5eM4Gr6IiroqdLhXeXyfvWEdm2mFYCSWOzz0/z5cAgqyGidF1jt1qzUR8hTmOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.7.tgz",
-      "integrity": "sha512-JtnBmaBSYbs7peJPkXzXxsRGSGBmBEIb6/kC8RRmyvPAMyqF8wIex0pttsI+9plghREiGPtRWv/lfQEPRlXnNQ==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.5.4.tgz",
+      "integrity": "sha512-/2yqFaS3TbfxV3P5yG2JUI79P7OUQKOUvAnx4MV9Bdz6jqHsHwc9WZPpO4QseQm+NvmgY6ICORnoVPODxGUiJg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.7.tgz",
-      "integrity": "sha512-7A/4CByoHdolWS8dg3DPm99owfu1aY/W0V0+KxFd0o2JQMTQtoBgIMSvZesXaWM57z3OLsietFivDLQPuzE75w==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.5.4.tgz",
+      "integrity": "sha512-EQUO4SmaCDhO6zYohxIjJpOKRN3wlfU7jMAj3CgcyTPvQR/UFLEKAYHqJOnJtymbQmiiM/ihX6c6W6Uq0yC7mA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.7.tgz",
-      "integrity": "sha512-D36K/3b6+hqm9IBAymnuVgyePktwQ+F0lSXr2B9JfAdFPBktSqGmp50JNC7pahxhnuCLj0Vdpe9RqfnJw5zATA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.5.4.tgz",
+      "integrity": "sha512-oQ8RrK1VS8lrxkLriotFq+PiF7iiGgkZtfLKF4DDKsmdbPo0O9R2mQxm7jHLuXraRCuIQDWMIw6dpcr7Iykf4A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "latest",
     "rimraf": "^5.0.1",
-    "turbo": "latest",
+    "turbo": "^2.5.4",
     "typescript": "^5.6.2",
     "vitest": "^2.1.2"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", "api/**", "public/build/**"]


### PR DESCRIPTION
This tiny PR just updates `turbo` from the previous 2-year-old version. This does not impact any of the packages, just the monorepo build, so hopefully it's non-controversial.