### PR TITLE
🔌 Load plugins earlier, before parsing frontmatter parts

### DIFF
--- a/.changeset/gentle-feet-relax.md
+++ b/.changeset/gentle-feet-relax.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': minor
+'myst-common': patch
+---
+
+Load plugins earlier, before parsing frontmatter parts

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -430,6 +430,7 @@ async function resolveProjectConfigPaths(
         }
       }),
     );
+    await session.loadPlugins(resolvedFields.plugins);
   }
   if (projectConfig.parts) {
     resolvedFields.parts = await loadFrontmatterParts(

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -236,7 +236,6 @@ export async function loadFile(
   extension?: '.md' | '.ipynb' | '.tex' | '.bib' | '.myst.json',
   opts?: LoadFileOptions,
 ): Promise<PreRendererData | undefined> {
-  await session.loadPlugins();
   const toc = tic();
   session.store.dispatch(warnings.actions.clearWarnings({ file }));
   const cache = castSession(session);

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -28,6 +28,7 @@ import type { JupyterServerSettings } from 'myst-execute';
 import { launchJupyterServer } from 'myst-execute';
 import type { RequestInfo, RequestInit } from 'node-fetch';
 import { default as nodeFetch, Headers, Request, Response } from 'node-fetch';
+import type { PluginInfo } from 'myst-config';
 
 // fetch polyfill for node<18
 if (!globalThis.fetch) {
@@ -159,13 +160,8 @@ export class Session implements ISession {
 
   plugins: ValidatedMystPlugin | undefined;
 
-  _pluginPromise: Promise<ValidatedMystPlugin> | undefined;
-
-  async loadPlugins() {
-    // Early return if a promise has already been initiated
-    if (this._pluginPromise) return this._pluginPromise;
-    this._pluginPromise = loadPlugins(this);
-    this.plugins = await this._pluginPromise;
+  async loadPlugins(plugins: PluginInfo[]) {
+    this.plugins = await loadPlugins(this, plugins);
     return this.plugins;
   }
 

--- a/packages/myst-cli/src/session/types.ts
+++ b/packages/myst-cli/src/session/types.ts
@@ -10,6 +10,7 @@ import type { BuildWarning, RootState } from '../store/index.js';
 import type { PreRendererData, RendererData, SingleCitationRenderer } from '../transforms/types.js';
 import type { SessionManager } from '@jupyterlab/services';
 import type MystTemplate from 'myst-templates';
+import type { PluginInfo } from 'myst-config';
 
 export type ISession = {
   API_URL: string;
@@ -26,7 +27,7 @@ export type ISession = {
   publicPath(): string;
   showUpgradeNotice(): void;
   plugins: ValidatedMystPlugin | undefined;
-  loadPlugins(): Promise<MystPlugin>;
+  loadPlugins(plugins: PluginInfo[]): Promise<MystPlugin>;
   getAllWarnings(ruleId: RuleId): (BuildWarning & { file: string })[];
   jupyterSessionManager(): Promise<SessionManager | undefined>;
   dispose(): void;

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -144,7 +144,11 @@ export type MystPlugin = {
   transforms?: TransformSpec[];
 };
 
-export type ValidatedMystPlugin = Required<Pick<MystPlugin, 'directives' | 'roles' | 'transforms'>>;
+export type ValidatedMystPlugin = Required<
+  Pick<MystPlugin, 'directives' | 'roles' | 'transforms'>
+> & {
+  paths: string[];
+};
 
 export enum TargetKind {
   heading = 'heading',


### PR DESCRIPTION
This addresses https://github.com/jupyter-book/mystmd/issues/2071 - Previously, we were processing `parts` files before `plugins` were loaded on the `session`. This ended up caching an empty list of `plugins` which was then never repopulated. Plugins were just silently gone!

@stefanv had a first pass at addressing this here https://github.com/jupyter-book/mystmd/pull/1925 - that PR prevented caching the empty list; however, `plugins` were still not loaded before `parts` processing, so referencing a plugin in a part would fail.

In this PR, I now call `loadPlugins` earlier, while processing project fronmtatter. This happens before any `parts` or other files are processed, so now `plugins` are available during `part` processing and are never cached as an empty list.