### PR TITLE
Add doc for Apache httpd deployment

### DIFF
--- a/docs/deployment-httpd.md
+++ b/docs/deployment-httpd.md
@@ -1,0 +1,27 @@
+---
+title: Deploy on an Apache web server (httpd)
+short_title: httpd
+description: Deploy your MyST site on Apache httpd
+---
+
+Once you have built a static version of your MyST project via `myst build --html`, it can be served on an [Apache web server (httpd)](https://httpd.apache.org) instance.
+
+For example, let's assume your web server's base URL is `http://www.example.com`, it uses `/var/www/html` as its `DocumentRoot`, and that your MyST project's `_build` directory is `/var/www/html/my_MyST_project/_build`.
+
+The URL for your static MyST project would therefore be `http://www.example.com/my_MyST_project/_build`.
+
+:::{warning} Enable automatic `.html` file suffixes
+`myst build --html` will produce HTML-formatted files that have `.html` as their suffix for `.md` and (if you choose to `execute` Jupyter notebooks) `.ipynb` files that you list in your project's [table of contents](table-of-contents.md).
+
+However, the links that are generated will not have `.html` as part of their HREFs. You will need to add a directive in your Apache httpd configuration file to make these links work properly.
+
+For example, assuming your httpd configuration file lives in `/etc/httpd/conf/httpd.conf`, add the following stanza, and then reload/restart your Apache web server:
+
+```
+<Directory "/var/www/html/my_Myst_project/_build">
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME}.html -f
+    RewriteRule ^([^\.]+)$ $1.html [L]
+</Directory>
+
+

--- a/docs/deployment-httpd.md
+++ b/docs/deployment-httpd.md
@@ -8,11 +8,13 @@ Once you have built a static version of your MyST project via `myst build --html
 
 For example, let's assume your web server's base URL is `http://www.example.com`, it uses `/var/www/html` as its `DocumentRoot`. If you copy the `_build/html/` directory to `/var/www/html/my-project`, then the URL would be: `http://www.example.com/my-project`:
 
+```shell
 cp -r _build/html /var/www/html/my-project
+```
 
 The URL for your static MyST project would then be `http://www.example.com/`.
 
-:::{warning} Enable automatic `.html` file suffixes
+::::{warning} Enable automatic `.html` file suffixes
 `myst build --html` will produce HTML-formatted files that have `.html` as their suffix for `.md` and (if you choose to `execute` Jupyter notebooks) `.ipynb` files that you list in your project's [table of contents](table-of-contents.md).
 
 However, the links that are generated will not have `.html` as part of their HREFs. You will need to enable the [MultiViews](https://httpd.apache.org/docs/2.4/content-negotiation.html#multiviews) option in your Apache httpd configuration file to make these links work properly.
@@ -24,13 +26,12 @@ For example, assuming your httpd configuration file lives in `/etc/httpd/conf/ht
     Options MultiViews
 </Directory>
 ```
-::::{tip} 
+:::{tip} 
 You may also need to add the line: 
 
 ```
 LoadModule negotiation_module modules/mod_negotiation.so
 ```
 to your `httpd` configuration. In RHEL-like Linux distributions, this line is already included in the `httpd` RPM package, in `/etc/httpd/conf.modules.d/00-base.conf`.
-::::
 :::
-
+::::

--- a/docs/deployment-httpd.md
+++ b/docs/deployment-httpd.md
@@ -19,7 +19,7 @@ For example, assuming your httpd configuration file lives in `/etc/httpd/conf/ht
 
 ```
 <Directory "/var/www/html/my_Myst_project/_build">
-    Options Multiviews
+    Options MultiViews
 </Directory>
 ```
 ::::{tip} 

--- a/docs/deployment-httpd.md
+++ b/docs/deployment-httpd.md
@@ -12,8 +12,6 @@ For example, let's assume your web server's base URL is `http://www.example.com`
 cp -r _build/html /var/www/html/my-project
 ```
 
-The URL for your static MyST project would then be `http://www.example.com/`.
-
 ::::{warning} Enable automatic `.html` file suffixes
 `myst build --html` will produce HTML-formatted files that have `.html` as their suffix for `.md` and (if you choose to `execute` Jupyter notebooks) `.ipynb` files that you list in your project's [table of contents](table-of-contents.md).
 

--- a/docs/deployment-httpd.md
+++ b/docs/deployment-httpd.md
@@ -6,9 +6,9 @@ description: Deploy your MyST site on Apache httpd
 
 Once you have built a static version of your MyST project via `myst build --html`, it can be served on an [Apache web server (httpd)](https://httpd.apache.org) instance.
 
-For example, let's assume your web server's base URL is `http://www.example.com`, it uses `/var/www/html` as its `DocumentRoot`, and that your MyST project's `_build` directory is `/var/www/html/my_MyST_project/_build`.
+For example, let's assume your web server's base URL is `http://www.example.com`, it uses `/var/www/html` as its `DocumentRoot`. You should copy the contents of your `_build/html/` directory into the `/var/www/html/` directory.
 
-The URL for your static MyST project would therefore be `http://www.example.com/my_MyST_project/_build`.
+The URL for your static MyST project would then be `http://www.example.com/`.
 
 :::{warning} Enable automatic `.html` file suffixes
 `myst build --html` will produce HTML-formatted files that have `.html` as their suffix for `.md` and (if you choose to `execute` Jupyter notebooks) `.ipynb` files that you list in your project's [table of contents](table-of-contents.md).
@@ -18,7 +18,7 @@ However, the links that are generated will not have `.html` as part of their HRE
 For example, assuming your httpd configuration file lives in `/etc/httpd/conf/httpd.conf`, add the following stanza, and then reload/restart your Apache web server:
 
 ```
-<Directory "/var/www/html/my_Myst_project/_build">
+<Directory "/var/www/html/">
     Options MultiViews
 </Directory>
 ```

--- a/docs/deployment-httpd.md
+++ b/docs/deployment-httpd.md
@@ -6,7 +6,7 @@ description: Deploy your MyST site on Apache httpd
 
 Once you have built a static version of your MyST project via `myst build --html`, it can be served on an [Apache web server (httpd)](https://httpd.apache.org) instance.
 
-For example, let's assume your web server's base URL is `http://www.example.com`, it uses `/var/www/html` as its `DocumentRoot`. If you copy the `_build/html/` directory to `/var/www/html/my-project`, then the URL would be: `http://www.example.com/my-project`:
+For example, let's assume your web server's base URL is `http://www.example.com`, it uses `/var/www/html` as its `DocumentRoot`. If you copy the `_build/html/` directory to `/var/www/html/my-project`, then the URL would be `http://www.example.com/my-project`:
 
 ```shell
 cp -r _build/html /var/www/html/my-project

--- a/docs/deployment-httpd.md
+++ b/docs/deployment-httpd.md
@@ -6,11 +6,13 @@ description: Deploy your MyST site on Apache httpd
 
 Once you have built a static version of your MyST project via `myst build --html`, it can be served on an [Apache web server (httpd)](https://httpd.apache.org) instance.
 
-For example, let's assume your web server's base URL is `http://www.example.com`, it uses `/var/www/html` as its `DocumentRoot`. If you copy the `_build/html/` directory to `/var/www/html/my-project`, then the URL would be `http://www.example.com/my-project`:
+For example, let's assume your web server's base URL is `http://www.example.com` and it uses `/var/www/html` as its `DocumentRoot`. If you copy the `_build/html/` directory to `/var/www/html/my-project` using
 
 ```shell
 cp -r _build/html /var/www/html/my-project
 ```
+
+then the resulting URL would be `http://www.example.com/my-project`.
 
 ::::{warning} Enable automatic `.html` file suffixes
 `myst build --html` will produce HTML-formatted files that have `.html` as their suffix for `.md` and (if you choose to `execute` Jupyter notebooks) `.ipynb` files that you list in your project's [table of contents](table-of-contents.md).

--- a/docs/deployment-httpd.md
+++ b/docs/deployment-httpd.md
@@ -6,7 +6,9 @@ description: Deploy your MyST site on Apache httpd
 
 Once you have built a static version of your MyST project via `myst build --html`, it can be served on an [Apache web server (httpd)](https://httpd.apache.org) instance.
 
-For example, let's assume your web server's base URL is `http://www.example.com`, it uses `/var/www/html` as its `DocumentRoot`. You should copy the contents of your `_build/html/` directory into the `/var/www/html/` directory.
+For example, let's assume your web server's base URL is `http://www.example.com`, it uses `/var/www/html` as its `DocumentRoot`. If you copy the `_build/html/` directory to `/var/www/html/my-project`, then the URL would be: `http://www.example.com/my-project`:
+
+cp -r _build/html /var/www/html/my-project
 
 The URL for your static MyST project would then be `http://www.example.com/`.
 

--- a/docs/deployment-httpd.md
+++ b/docs/deployment-httpd.md
@@ -23,5 +23,6 @@ For example, assuming your httpd configuration file lives in `/etc/httpd/conf/ht
     RewriteCond %{REQUEST_FILENAME}.html -f
     RewriteRule ^([^\.]+)$ $1.html [L]
 </Directory>
-
+```
+:::
 

--- a/docs/deployment-httpd.md
+++ b/docs/deployment-httpd.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy on an Apache web server (httpd)
-short_title: httpd
+short_title: Apache httpd
 description: Deploy your MyST site on Apache httpd
 ---
 
@@ -13,16 +13,22 @@ The URL for your static MyST project would therefore be `http://www.example.com/
 :::{warning} Enable automatic `.html` file suffixes
 `myst build --html` will produce HTML-formatted files that have `.html` as their suffix for `.md` and (if you choose to `execute` Jupyter notebooks) `.ipynb` files that you list in your project's [table of contents](table-of-contents.md).
 
-However, the links that are generated will not have `.html` as part of their HREFs. You will need to add a directive in your Apache httpd configuration file to make these links work properly.
+However, the links that are generated will not have `.html` as part of their HREFs. You will need to enable the [MultiViews](https://httpd.apache.org/docs/2.4/content-negotiation.html#multiviews) option in your Apache httpd configuration file to make these links work properly.
 
 For example, assuming your httpd configuration file lives in `/etc/httpd/conf/httpd.conf`, add the following stanza, and then reload/restart your Apache web server:
 
 ```
 <Directory "/var/www/html/my_Myst_project/_build">
-    RewriteEngine On
-    RewriteCond %{REQUEST_FILENAME}.html -f
-    RewriteRule ^([^\.]+)$ $1.html [L]
+    Options Multiviews
 </Directory>
 ```
+::::{tip} 
+You may also need to add the line: 
+
+```
+LoadModule negotiation_module modules/mod_negotiation.so
+```
+to your `httpd` configuration. In RHEL-like Linux distributions, this line is already included in the `httpd` RPM package, in `/etc/httpd/conf.modules.d/00-base.conf`.
+::::
 :::
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -120,6 +120,11 @@ Deploy as a static site to GitHub pages using an action.
 Deploy to Netlify as static HTML, and pull-request previews.
 :::
 
+:::{card} Apache HTTPD
+:link: ./deployment-httpd.md
+Deploy on a web server that runs [Apache httpd](https://httpd.apache.org).
+:::
+
 % TODO: ReadTheDocs
 
 ## Application Websites

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -131,6 +131,7 @@ project:
             - file: deployment-github-pages.md
             - file: deployment-curvenote.md
             - file: deployment-netlify.md
+            - file: deployment-httpd.md
         - file: website-landing-pages.md
 
         # - file: publishing.md


### PR DESCRIPTION
Adds documentation for static web page deployment on Apache httpd, as discussed in #2086 .