### PR TITLE
Document plugin packaging

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -14,40 +14,42 @@ project:
     spec: https://mystmd.org/spec/
     biapol: https://biapol.github.io/blog/
   abbreviations:
-    AST: Abstract Syntax Tree
-    DOI: Digital Object Identifier
-    MyST: Markedly Structured Text
-    CLI: Command Line Interface
-    HTML: Hypertext Markup Language
-    PDF: Portable Document Format
+    # Alphabetical order
     AMS: American Mathematical Society
-    RRID: Research Resource Identifier
-    CSS: Cascading Style Sheet
+    API: Application Programming Interface
+    AST: Abstract Syntax Tree
+    CLI: Command Line Interface
     CRediT: Contributor Roles Taxonomy
-    ROR: Research Organization Registry
-    ISNI: International Standard Name Identifier
-    NISO: National Information Standards Organization
-    YAML: Yet Another Markup Language
-    WASM: WebAssembly
-    REES: Reproducible Execution Environment Specification
-    URL: Uniform Resource Locator
-    XML: Extensible Markup Language
-    PID: Persistent Identifier
+    CSS: Cascading Style Sheet
+    CSV: comma-separated values
+    DOI: Digital Object Identifier
+    ESM: ECMAScript Modules
+    GPU: Graphics Processing Unit
+    HTML: Hypertext Markup Language
     ID: Identifier
+    ISNI: International Standard Name Identifier
     JATS: Journal Article Tag Suite
-    VoR: Version of Record
+    JSON: JavaScript Object Notation
     LTS: Long Term Support
+    MyST: Markedly Structured Text
+    NISO: National Information Standards Organization
+    OA: Open Access
+    PDF: Portable Document Format
+    PID: Persistent Identifier
     POSIX: Portable Operating System Interface
+    REES: Reproducible Execution Environment Specification
+    ROR: Research Organization Registry
+    RRID: Research Resource Identifier
     RST: reStructuredText
     SPDX: Software Package Data Exchange
-    API: Application Programming Interface
-    GPU: Graphics Processing Unit
-    TPU: Tensor Processing Unit
-    JSON: JavaScript Object Notation
     TLA: Three Letter Acronym
-    OA: Open Access
-    CSV: comma-separated values
     TOC: table of contents
+    TPU: Tensor Processing Unit
+    URL: Uniform Resource Locator
+    VoR: Version of Record
+    WASM: WebAssembly
+    YAML: Yet Another Markup Language
+    XML: Extensible Markup Language
   plugins:
     - directives.mjs
     - picsum.mjs
@@ -145,6 +147,7 @@ project:
       file: plugins.md
       children:
         - file: javascript-plugins.md
+        - file: plugins-distribute.md
         - file: executable-plugins.md
     - title: Reference
       children:

--- a/docs/plugins-distribute.md
+++ b/docs/plugins-distribute.md
@@ -1,0 +1,32 @@
+---
+title: Package and distribute plugins
+description: Share your custom plugins so that others can use them.
+---
+
+There is no "official" way to distribute plugins with MyST. However, you can use common workflows in the JavaScript ecosystem to distribute your plugins so that others can use them. This page documents a few approaches that may work.
+
+## Package plugins into a single ESM file 
+
+JavaScript uses the [ECMAScript Modules standard](https://nodejs.org/api/esm.html) for packaging and distributing scripts. Your plugins can be bundled and distributed in the same way.
+
+## Use a builder to build an ESM package
+
+There are several "builders" in the JavaScript ecosystem that make it easy to quickly bundle JavaScript in distributable packages. The resulting artifact can then be shared directly, or published to a package registry like [NPM](https://npmjs.com).
+
+We recommend [using `esbuild`](https://esbuild.github.io/) to accomplish this.
+
+:::{note} Example: Bundle a custom plugin with `esbuild`
+The [`js-plugin` MyST example](https://github.com/myst-examples/js-plugin) demonstrates how to use `esbuild` to bundle a plugin and its dependencies into a single file. It uses GitHub releases to make the file available at a URL. See the [project README](https://github.com/jupyter-book/example-js-plugin?tab=readme-ov-file#myst-js-plugin) for more details.
+:::
+
+:::{note} Example: Share a simple plugin without a build tool
+If your plugin is simple enough, you can directly share it as an ESM bundle rather than needing a builder like `esbuild`. [Here is a an example of a simple plugin](https://github.com/myst-ext/myst-ext-lorem) that generates Lorem Ipsum text. It does not require a separate build tool.
+:::
+
+### Other JavaScript bundlers
+
+There are a few other bundlers in the JavaScript ecosystem, which you may use to package MyST plugins if you prefer. Here are a few known bundler options:
+
+* [tsup](https://github.com/egoist/tsup) - [example plugin](https://github.com/myst-ext/myst-ext-discourse)
+* [ncc](https://github.com/vercel/ncc) - [example plugin](https://github.com/myst-ext/myst-ext-xref-prefix/blob/e975496cafa57e86c88ea71d3abe26a7174b3944/package.json#L20) 
+

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3,9 +3,9 @@ title: Plugins
 description: Plugins provide powerful ways to extend and customize MyST
 ---
 
-Plugins provide powerful ways to extend and customize MyST by adding directives and roles or specific transformations on the AST that can download or augment your articles and documentation. These plugins also support custom rendering and transformation pipelines for various export targets including React, HTML, LaTeX, and Microsoft Word.
+Plugins allow authors to extend and customize MyST to augment your articles and documentation. They also support custom rendering and transformation pipelines for various export targets including React, HTML, LaTeX, and Microsoft Word.
 
-:::{danger} Plugins are incomplete and in Beta
+:::{danger} Plugins are in-progress
 The interfaces and packaging for the plugins may change substantially in the future.\
 **Expect changes!!**
 
@@ -14,7 +14,7 @@ If you are implementing a plugin, please let us know on [GitHub](https://github.
 
 ## Overview of a Plugin
 
-Plugins are executable javascript code that can modify a document source. The supported plugin types are:
+Plugins are executable code that can modify MyST AST as part of a build process. The supported plugin types are:
 
 directives
 : Add or overwrite directives, which provide a "block-level" extension point.
@@ -36,18 +36,28 @@ renderers
 : For example, do something special for node in HTML, React, Microsoft Word, or LaTeX.
 :::
 
-## Building a Plugin
+## Write a Plugin
 
-There are two ways to implement a plugin in MyST: JavaScript plugins, and executable plugins. The easiest way to get started in writing a custom plugin is to build a [JavaScript plugin](./javascript-plugins.md), but writing an executable plugin might be a better choice if you unfamiliar with JavaScript but are confident in a non-JS language e.g. Python.
+There are two ways to implement a plugin in MyST:
 
-:::{card} JavaScript Plugins
-:link: ./javascript-plugins.md
+1. [JavaScript plugins](./javascript-plugins.md) are written in MyST's native language. They are the easiest way to write and share plugins if you have some familiarity with JavaScript.
+2. [Language-agnostic executable plugins](./executable-plugins.md) allow you to write plugins in any language that can be executed. They are a better choice if you are unfamiliar with JavaScript, but are confident in a non-JS language (e.g. Python).
 
-Plugins written in JavaScript with access to helpful AST manipulation routines.
-:::
+## Package and distribute plugins
 
-:::{card} Any Executable Plugins (e.g. Python)
-:link: ./executable-plugins.md
+You can build plugins and share them with others for re-use as JavaScript modules.
+See [](./plugins-distribute.md).
 
-Plugins written in other languages which communicate with MyST over stdin and stdout.
-:::
+## Use plugins in your MyST project
+
+To use a plugin in your MyST project, use the `project.plugins` list in your `myst.yml` configuration. You can link **plugins on local filesystem** or **remote plugins accessible by URL**. Here's an example of each:
+
+```{code} yaml
+:filename: myst.yml
+project:
+  plugins:
+    # Example of a local plugin
+    - local/folder/picsum.mjs
+    # Example of a hosted artifact on github
+    - https://github.com/my-org/plugin-repo/releases/download/latest/myplugin.mjs
+```


### PR DESCRIPTION
This adds some light documentation about packaging and distributing plugins for re-use, including links to several examples shared be @stevejpurves and @agoose77 in https://github.com/orgs/jupyter-book/discussions/2099#discussioncomment-13460945

It also re-orders our abbreviations config so they're alphabetical, because it was kind of a pain to look up whether ESM had already been documented  