### PR TITLE
🩹 Add changeset for `myst-frontmatter`

### DIFF
--- a/.changeset/rotten-needles-cough.md
+++ b/.changeset/rotten-needles-cough.md
@@ -1,0 +1,5 @@
+---
+"myst-frontmatter": patch
+---
+
+Bump frontmatter to reflect change to simple-validators


### PR DESCRIPTION
This ensures that the frontmatter package is re-deployed with a proper version bump in the simple-validators dependency, captured in #2105 and #2021 