### PR TITLE
⚠️ Fix warning about `.*` image extension

### DIFF
--- a/.changeset/chilled-onions-jump.md
+++ b/.changeset/chilled-onions-jump.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Incorrect error about .\* image extension, but only when image is not found

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -536,6 +536,11 @@ export async function transformImageFormats(
   }
   unconvertableImages.forEach((image) => {
     const badExt = path.extname(image.url) || '<no extension>';
+    if (badExt === '.*') {
+      // There is already a warning for the wild card extensions.
+      // See https://github.com/jupyter-book/mystmd/issues/2123
+      return;
+    }
     addWarningForFile(
       session,
       file,


### PR DESCRIPTION
Only when image is not found.

Fixes #2123