### PR TITLE
Clarify site parts for footers

### DIFF
--- a/docs/document-parts.md
+++ b/docs/document-parts.md
@@ -3,18 +3,18 @@ title: Document Parts
 description: Parts allow you to specify special parts of your document, like abstract, key points, and acknowledgements.
 ---
 
-Document parts allow you to add metadata to your documents with specific components of your page or project, for example, abstract, dedication, or acknowledgments. [Templates](./documents-exports.md) can use this information to put that content in various locations.
+Document *parts* allow you to add content and metadata for specific components of your page or project, including `example`, `abstract`, `dedication`, and `acknowledgment`. [Templates](./documents-exports.md) may use the parts and their metadata, and render such content in various locations.
 
 ## Add document parts
 
 There are several ways you can define parts of a document, each described below:
 
-1. [In page frontmatter](#parts:frontmatter)
+1. [In site configuration](#parts:site)
 2. [In project-level configuration](#parts:project)
-3. [With specific section headings](#parts:implicit)
-4. [With a content block](#parts:blocks)
-5. [With Jupyter Notebook cell tags](#parts:cell-tags)
-6. [In site configuration](#parts:site)
+3. [In page frontmatter](#parts:frontmatter)
+4. [With specific section headings](#parts:implicit)
+5. [With a content block](#parts:blocks)
+6. [With Jupyter Notebook cell tags](#parts:cell-tags)
 
 (parts:frontmatter)=
 
@@ -156,7 +156,7 @@ The advantage of this method is that the content is not rendered in your documen
 
 ## Add parts to your website
 
-[Website themes](./website-templates.md) have their own configuration for parts because they often have extra user interface elements that are not part of a standard "document" structure. These are theme-dependent. For example, the [default myst themes](#default-web-themes) support [a website footer](#navigation:footer).
+[Website themes](./website-templates.md) have additional parts because they render user interface elements that are not part of a standard "document" structure. These are theme-dependent: for example, the [default myst themes](#default-web-themes) support a [`footer` part](#navigation:footer).
 
 Specify the content of a site `part` in the `site.parts` key of the `myst.yml` configuration file:
 

--- a/docs/document-parts.md
+++ b/docs/document-parts.md
@@ -7,14 +7,37 @@ Document *parts* allow you to add content and metadata for specific components o
 
 ## Add document parts
 
-There are several ways you can define parts of a document, each described below:
+Document parts can be used in any export media (`html`, `pdf`, etc).
+There are several ways you can define document parts, each described below:
 
-1. [In site configuration](#parts:site)
-2. [In project-level configuration](#parts:project)
-3. [In page frontmatter](#parts:frontmatter)
+1. [In project-level configuration](#parts:project)
+2. [In page frontmatter](#parts:frontmatter)
+3. [With a content block](#parts:blocks)
 4. [With specific section headings](#parts:implicit)
-5. [With a content block](#parts:blocks)
-6. [With Jupyter Notebook cell tags](#parts:cell-tags)
+5. [With Jupyter Notebook cell tags](#parts:cell-tags)
+
+(parts:project)=
+
+### Parts in `myst.yml` Project configuration
+
+You may also specify `parts` in the project configuration of your `myst.yml` file. These are defined exactly the same as [`parts` defined in page frontmatter](#parts:frontmatter).
+
+```yaml
+version: 1
+project:
+  abstract:  |
+    This is a multi-line
+    abstract, with _markdown_!
+  parts:
+    special_part: |
+      This is another _special_ part!
+```
+
+Project-level `parts` are useful, for example, if you have an abstract, acknowledgments, or other part that applies to your entire project and doesn't make sense attached to an individual page.
+
+```{caution}
+Project-level `parts` are a new feature and may not yet be respected by your chosen MyST template or export format. If the project `part` is not behaving as you expect, try moving it to page frontmatter for now.
+```
 
 (parts:frontmatter)=
 
@@ -40,44 +63,6 @@ abstract: ../abstract.md
 ---
 ```
 
-(parts:project)=
-
-### Parts in `myst.yml` Project configuration
-
-You may also specify `parts` in the project configuration of your `myst.yml` file. These are defined exactly the same as [`parts` defined in page frontmatter](#parts:frontmatter).
-
-```yaml
-version: 1
-project:
-  abstract:  |
-    This is a multi-line
-    abstract, with _markdown_!
-  parts:
-    special_part: |
-      This is another _special_ part!
-```
-
-Project-level `parts` are useful, for example, if you have an abstract, acknowledgments, or other part that applies to your entire project and doesn't make sense attached to an individual page.
-
-```{caution}
-Project-level `parts` are a new feature and may not yet be respected by your chosen MyST template or export format. If the project `part` is not behaving as you expect, try moving it to page frontmatter for now.
-```
-
-(parts:implicit)=
-
-### Parts with specific header titles
-
-If you are rendering your project in other places, it can be helpful to leave these sections directly in the document.
-Complete this using a header as usual:
-
-```
-# Abstract
-
-This is my abstract!
-```
-
-Note that frontmatter parts and explicitly tagged cells/blocks will take precedence over this method. Themes may choose to only pick up a subset of implicit parts, for example, only an `Abstract` and not `Summary` as summary section can be used in other contexts.
-
 (parts:blocks)=
 
 ### Parts with content blocks
@@ -101,16 +86,30 @@ Page content
 
 ```
 
+(parts:implicit)=
+
+### Parts with specific header titles
+
+If you are rendering your project in other places, it can be helpful to leave these sections directly in the document.
+Complete this using a header as usual:
+
+```
+# Abstract
+
+This is my abstract!
+```
+
+Note that frontmatter parts and explicitly tagged cells/blocks will take precedence over this method. Themes may choose to only pick up a subset of implicit parts, for example, only an `Abstract` and not `Summary` as summary section can be used in other contexts.
+
 (parts:cell-tags)=
 
 ### Parts with Jupyter cell tags
 
 When using a Jupyter Notebook, you can add a `tag` to the cell with the part name. If multiple cells share that tag, they will be extracted and merged. 
 
+### Known Document Parts
 
-### Known Frontmatter Parts
-
-The known parts that are recognized as _top-level_ document frontmatter keys are:
+The known parts that are recognized as _top-level_ document parts keys are:
 
 abstract
 : A concise overview of the entire document, highlighting the main objectives, methods, results, and conclusions. It's meant to give readers a quick snapshot of what to expect without having to read the entire document.
@@ -154,7 +153,7 @@ The advantage of this method is that the content is not rendered in your documen
 
 (parts:site)=
 
-## Add parts to your website
+## Add website parts
 
 [Website themes](./website-templates.md) have additional parts because they render user interface elements that are not part of a standard "document" structure. These are theme-dependent: for example, the [default myst themes](#default-web-themes) support a [`footer` part](#navigation:footer).
 
@@ -212,3 +211,6 @@ site:
 
 **If you're extending configuration from a remote source**, make sure that you use absolute URLs if you must refer to an image or other asset in your part content. Relative paths that are defined inside the part content will generally break.
 
+:::{seealso} Referring to parts directly with a URL is coming
+See the [issue tracking this enhancement](https://github.com/jupyter-book/mystmd/issues/2127).
+:::

--- a/docs/document-parts.md
+++ b/docs/document-parts.md
@@ -5,16 +5,20 @@ description: Parts allow you to specify special parts of your document, like abs
 
 Document parts allow you to add metadata to your documents with specific components of your page or project, for example, abstract, dedication, or acknowledgments. [Templates](./documents-exports.md) can use this information to put that content in various locations.
 
-There are three ways that you can define parts of a document, each described below:
+## Add document parts
+
+There are several ways you can define parts of a document, each described below:
 
 1. [In page frontmatter](#parts:frontmatter)
-2. [With specific section headings](#parts:implicit)
-3. [With a content block](#parts:blocks).
-4. [In site configuration](#parts:site)
+2. [In project-level configuration](#parts:project)
+3. [With specific section headings](#parts:implicit)
+4. [With a content block](#parts:blocks)
+5. [With Jupyter Notebook cell tags](#parts:cell-tags)
+6. [In site configuration](#parts:site)
 
 (parts:frontmatter)=
 
-## Parts in Frontmatter
+### Parts in Frontmatter
 
 On any page, you can add a part to your document directly in the frontmatter, for example, the `abstract`:
 
@@ -36,82 +40,9 @@ abstract: ../abstract.md
 ---
 ```
 
-### Known Frontmatter Parts
-
-The known parts that are recognized as _top-level_ document frontmatter keys are:
-
-abstract
-: A concise overview of the entire document, highlighting the main objectives, methods, results, and conclusions. It's meant to give readers a quick snapshot of what to expect without having to read the entire document.
-
-summary
-: Similar to an abstract, but can either be slightly longer and more detailed or used as a plain-language summary, depending on the context. It summarizes the document's content, including the background, purpose, methodology, results, and conclusions.
-: Alias: `plain_language_summary`, `lay_summary`
-
-keypoints
-: A brief list that highlights the main findings, conclusions, or contributions of the document. Key points are often used to quickly convey the core message or most important aspects to the reader.
-
-dedication
-: A short section where the author dedicates the document to someone, often as a gesture of honor or respect.
-
-epigraph
-: A quote or poem that the author includes at the beginning of the document to set a tone or theme, or to hint at the document’s underlying message. It is often relevant to the content but not directly related to it.
-: Alias: `quote`
-
-data_availability
-: A statement or section that details how readers can access the data sets and resources used in the document. This can include links to repositories, conditions for access, and any restrictions on the data. It's crucial for transparency and reproducibility in research documents.
-: Alias: `availability`
-
-acknowledgments
-: A section where the author thanks individuals, organizations, or agencies that contributed to the completion of the document. This can include support in the form of funding, expertise, feedback, or moral support.
-: Alias: `ack`, `acknowledgements`
-
-### Custom Frontmatter Parts
-
-If you have a custom part name for a template, you can nest it under `parts:`, which takes arbitrary keys.
-
-```yaml
----
-title: My document
-parts:
-  special_part: |
-    This is another _special_ part!
----
-```
-
-The advantage of this method is that the content is not rendered in your document.
-
-(parts:implicit)=
-
-## Implicit Parts using a Title
-
-If you are rendering your project in other places, it can be helpful to leave these sections directly in the document.
-Complete this using a header as usual:
-
-```
-# Abstract
-
-This is my abstract!
-```
-
-Note that frontmatter parts and explicitly tagged cells/blocks will take precedence over this method. Themes may choose to only pick up a subset of implicit parts, for example, only an `Abstract` and not `Summary` as summary section can be used in other contexts.
-
-(parts:blocks)=
-
-## In a Jupyter Notebook cells and blocks
-
-When using a Jupyter Notebook, you can add a `tag` to the cell with the part name, if multiple cells share that tag, they will be extracted and merged. This can also be represented in a [block](./blocks.md):
-
-```markdown
-+++ { "part": "abstract" }
-
-This is my abstract block.
-
-+++
-```
-
 (parts:project)=
 
-## Parts in `myst.yml` Project configuration
+### Parts in `myst.yml` Project configuration
 
 You may also specify `parts` in the project configuration of your `myst.yml` file. These are defined exactly the same as [`parts` defined in page frontmatter](#parts:frontmatter).
 
@@ -132,15 +63,60 @@ Project-level `parts` are useful, for example, if you have an abstract, acknowle
 Project-level `parts` are a new feature and may not yet be respected by your chosen MyST template or export format. If the project `part` is not behaving as you expect, try moving it to page frontmatter for now.
 ```
 
+(parts:implicit)=
+
+### Parts with specific header titles
+
+If you are rendering your project in other places, it can be helpful to leave these sections directly in the document.
+Complete this using a header as usual:
+
+```
+# Abstract
+
+This is my abstract!
+```
+
+Note that frontmatter parts and explicitly tagged cells/blocks will take precedence over this method. Themes may choose to only pick up a subset of implicit parts, for example, only an `Abstract` and not `Summary` as summary section can be used in other contexts.
+
+(parts:blocks)=
+
+### Parts with content blocks
+
+You can use [content blocks](./blocks.md) in a page to define a part. This will be parsed differently from the other content on the page for re-use in templates and websites.
+
+The following example shows how to define an _abstract_ part in a content block on a page.
+
+```{code} markdown
+:filename: mypage.md
+
+# Page title
+
++++ { "part": "abstract" }
+
+This is my abstract block.
+
++++
+
+Page content
+
+```
+
+(parts:cell-tags)=
+
+### Parts with Jupyter cell tags
+
+When using a Jupyter Notebook, you can add a `tag` to the cell with the part name. If multiple cells share that tag, they will be extracted and merged. 
+
 (parts:site)=
 
-## Parts in `myst.yml` Site configuration
+## Add parts to your website
 
-You may specify `parts` in the site configuration of your `myst.yml` file. These parts will only be used for MyST site builds, and they must correspond to `parts` declared in your [website theme's template](website-templates.md). For example, see [](#navigation:footer).
+[Website themes](./website-templates.md) have their own configuration for parts because they often have extra user interface elements that are not part of a standard "document" structure. These are theme-dependent. For example, the [default myst themes](#default-web-themes) support [a website footer](#navigation:footer).
 
-You may specify the content of a `part` directly in the configuration file:
+Specify the content of a site `part` in the `site.parts` key of the `myst.yml` configuration file:
 
-```yaml
+```{code} yaml
+:filename: myst.yml
 version: 1
 site:
   template: ...
@@ -190,3 +166,4 @@ site:
 ```
 
 **If you're extending configuration from a remote source**, make sure that you use absolute URLs if you must refer to an image or other asset in your part content. Relative paths that are defined inside the part content will generally break.
+

--- a/docs/document-parts.md
+++ b/docs/document-parts.md
@@ -3,9 +3,14 @@ title: Document Parts
 description: Parts allow you to specify special parts of your document, like abstract, key points, and acknowledgements.
 ---
 
-Document parts allow you to add metadata to your documents with specific components of your page or project, for example, abstract, dedication, or acknowledgments. Many templates put these in specific places.
+Document parts allow you to add metadata to your documents with specific components of your page or project, for example, abstract, dedication, or acknowledgments. [Templates](./documents-exports.md) can use this information to put that content in various locations.
 
-There are three ways that you can define parts of a document: (1) in your page frontmatter; (2) implicitly using a section heading; and (3) on a block using a `part` or `tag` annotation. These are all based on a part name, which is case insensitive.
+There are three ways that you can define parts of a document, each described below:
+
+1. [In page frontmatter](#parts:frontmatter)
+2. [With specific section headings](#parts:implicit)
+3. [With a content block](#parts:blocks).
+4. [In site configuration](#parts:site)
 
 (parts:frontmatter)=
 
@@ -131,7 +136,9 @@ Project-level `parts` are a new feature and may not yet be respected by your cho
 
 ## Parts in `myst.yml` Site configuration
 
-You may specify `parts` in the site configuration of your `myst.yml` file. These parts will only be used for MyST site builds, and they must correspond to `parts` declared in your [website theme's template](website-templates.md).
+You may specify `parts` in the site configuration of your `myst.yml` file. These parts will only be used for MyST site builds, and they must correspond to `parts` declared in your [website theme's template](website-templates.md). For example, see [](#navigation:footer).
+
+You may specify the content of a `part` directly in the configuration file:
 
 ```yaml
 version: 1
@@ -142,3 +149,44 @@ site:
       (c) MyST Markdown
   ...
 ```
+
+Alternatively, you may specify a path to a file that contains the part content:
+
+```{code} yaml
+:filename: myst.yml
+version: 1
+site:
+  template: ...
+  parts:
+    footer: parts/myfooter.md
+  ...
+```
+
+Content in parts will generally be parsed similarly to other MyST content (though some functionality like code execution will not work).
+
+### Share the same part across multiple sites
+
+If you wish to share the same part across multiple sites, use the [`extends:` key to compose multiple configuration files](#composing-myst-yml). This lets you define the part in one location, and re-use it in several others. It is useful if you want to standardize website components like a footer across many websites.
+
+For example, in one file:
+
+```{code} yaml
+:filename: parts.yml
+site:
+  parts:
+    footer: |
+      My nifty footer!
+  ...
+```
+
+And in another:
+
+```{code} yaml
+:filename: myst.yml
+version: 1
+extends: parts.yml
+site:
+  template: ...
+```
+
+**If you're extending configuration from a remote source**, make sure that you use absolute URLs if you must refer to an image or other asset in your part content. Relative paths that are defined inside the part content will generally break.

--- a/docs/document-parts.md
+++ b/docs/document-parts.md
@@ -107,6 +107,51 @@ Page content
 
 When using a Jupyter Notebook, you can add a `tag` to the cell with the part name. If multiple cells share that tag, they will be extracted and merged. 
 
+
+### Known Frontmatter Parts
+
+The known parts that are recognized as _top-level_ document frontmatter keys are:
+
+abstract
+: A concise overview of the entire document, highlighting the main objectives, methods, results, and conclusions. It's meant to give readers a quick snapshot of what to expect without having to read the entire document.
+
+summary
+: Similar to an abstract, but can either be slightly longer and more detailed or used as a plain-language summary, depending on the context. It summarizes the document's content, including the background, purpose, methodology, results, and conclusions.
+: Alias: `plain_language_summary`, `lay_summary`
+
+keypoints
+: A brief list that highlights the main findings, conclusions, or contributions of the document. Key points are often used to quickly convey the core message or most important aspects to the reader.
+
+dedication
+: A short section where the author dedicates the document to someone, often as a gesture of honor or respect.
+
+epigraph
+: A quote or poem that the author includes at the beginning of the document to set a tone or theme, or to hint at the document’s underlying message. It is often relevant to the content but not directly related to it.
+: Alias: `quote`
+
+data_availability
+: A statement or section that details how readers can access the data sets and resources used in the document. This can include links to repositories, conditions for access, and any restrictions on the data. It's crucial for transparency and reproducibility in research documents.
+: Alias: `availability`
+
+acknowledgments
+: A section where the author thanks individuals, organizations, or agencies that contributed to the completion of the document. This can include support in the form of funding, expertise, feedback, or moral support.
+: Alias: `ack`, `acknowledgements`
+
+### Custom Frontmatter Parts
+
+If you have a custom part name for a template, you can nest it under `parts:`, which takes arbitrary keys.
+
+```yaml
+---
+title: My document
+parts:
+  special_part: |
+    This is another _special_ part!
+---
+```
+
+The advantage of this method is that the content is not rendered in your document.
+
 (parts:site)=
 
 ## Add parts to your website

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -104,6 +104,7 @@ project:
         - file: glossaries-and-terms.md
         - file: writing-in-latex.md
         - file: table-of-contents.md
+        - file: document-parts.md
         - file: authorship.md
         - file: inline-options.md
     - title: Executable Content
@@ -159,7 +160,6 @@ project:
         - file: directives.md
         - file: roles.md
         - file: frontmatter.md
-        - file: document-parts.md
         - file: settings.md
         - file: glossary.md
         - file: versions.md

--- a/docs/website-navigation.md
+++ b/docs/website-navigation.md
@@ -198,7 +198,7 @@ You could also attach the CSS class to a [content block](./blocks.md).
 
 ## Footer
 
-You can add a site-wide footer by using [site "parts"](#parts:site).
+Add a site-wide footer by using [site "parts"](#parts:site). 
 Add a footer part to your `myst.yml` like so:
 
 ```{code} yaml
@@ -209,7 +209,10 @@ site:
 ```
 
 The contents of `footer.md` will be rendered at the bottom of each page.
-It will be parsed similarly to other MyST content (though some functionality like code execution will not work).
+
+:::{seealso} More ways to configure footer content
+See [site "parts" configuration](#parts:site) for more ways you can configure site parts to add a footer.
+:::
 
 ### Style your footer
 


### PR DESCRIPTION
This improves our documentation around both site parts, how parts work in general, and cross-links for how to use them to define footers.