### PR TITLE
🧜‍♀️ Create images of mermaid diagrams for static exports

### DIFF
--- a/.changeset/cool-pigs-deny.md
+++ b/.changeset/cool-pigs-deny.md
@@ -1,0 +1,5 @@
+---
+'myst-common': patch
+---
+
+Added `options?: PluginOptions` to `TransformSpec` type. Enables passing configuration options to transform plugins.

--- a/.changeset/orange-rockets-relate.md
+++ b/.changeset/orange-rockets-relate.md
@@ -1,0 +1,8 @@
+---
+'myst-cli': patch
+---
+
+Integrated transform loading from options with proper plugin utilities.
+
+Added mermaid transform import and configuration
+Integrated mermaid transform into Typst build pipeline.

--- a/.changeset/stale-ghosts-drum.md
+++ b/.changeset/stale-ghosts-drum.md
@@ -1,0 +1,5 @@
+---
+'myst-spec-ext': patch
+---
+
+Added `label`, `identifier`, and `html_id` to `Image` type

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -37,3 +37,19 @@ npm install -g @mermaid-js/mermaid-cli
 ```
 
 :::
+
+:::{note .dropdown} For CI Environments
+
+The Mermaid CLI uses Puppeteer which may require special configuration in CI environments. MyST automatically handles this by detecting the `CI` environment variable or you can manually control it:
+
+```bash
+# Automatic detection (recommended for CI)
+CI=true npm run build
+
+# Manual control
+MERMAID_NO_SANDBOX=true npm run build
+```
+
+This automatically creates a Puppeteer configuration file with `--no-sandbox` flag to resolve sandbox issues in Linux CI environments.
+
+:::

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -24,3 +24,16 @@ flowchart LR
 :::{note}
 Both GitHub and JupyterLab ([#101](https://github.com/jupyter/enhancement-proposals/pull/101)) support the translation of a code-block ` ```mermaid ` to a mermaid diagram directly, this can also be used by default in MyST.
 :::
+
+## Rendering for Static Exports
+
+MyST supports static rendering of Mermaid diagrams for static export formats (PDF, Word, LaTeX, Typst). This feature converts Mermaid syntax to base64-encoded SVG or PNG images during the build process, ensuring consistent rendering across all static output formats.
+
+:::{important} Prerequisites
+To use static Mermaid rendering, you need the Mermaid CLI installed:
+
+```bash
+npm install -g @mermaid-js/mermaid-cli
+```
+
+:::

--- a/packages/jtex/tests/download.spec.ts
+++ b/packages/jtex/tests/download.spec.ts
@@ -4,57 +4,53 @@ import { TemplateKind } from 'myst-common';
 import MystTemplate, { downloadTemplate, resolveInputs, Session } from 'myst-templates';
 import { renderTemplate } from '../src';
 
-describe(
-  'Download Template',
-  () => {
-    it('Download default template', async () => {
-      const session = new Session();
-      const inputs = resolveInputs(session, { buildDir: '_build', kind: TemplateKind.tex });
-      await downloadTemplate(session, {
-        templatePath: inputs.templatePath,
-        templateUrl: inputs.templateUrl as string,
-      });
-      expect(fs.existsSync('_build/templates/tex/myst/plain_latex/template.zip')).toBe(true);
-      expect(fs.existsSync('_build/templates/tex/myst/plain_latex/template.yml')).toBe(true);
-      expect(fs.existsSync('_build/templates/tex/myst/plain_latex/template.tex')).toBe(true);
+describe('Download Template', { timeout: 15000 }, () => {
+  it('Download default template', async () => {
+    const session = new Session();
+    const inputs = resolveInputs(session, { buildDir: '_build', kind: TemplateKind.tex });
+    await downloadTemplate(session, {
+      templatePath: inputs.templatePath,
+      templateUrl: inputs.templateUrl as string,
     });
-    it('Bad template paths to throw', async () => {
-      const jtex = new MystTemplate(new Session(), {
-        template: 'not-there',
-        kind: TemplateKind.tex,
-      });
-      expect(() => jtex.prepare({} as any)).toThrow(/does not exist/);
+    expect(fs.existsSync('_build/templates/tex/myst/plain_latex/template.zip')).toBe(true);
+    expect(fs.existsSync('_build/templates/tex/myst/plain_latex/template.yml')).toBe(true);
+    expect(fs.existsSync('_build/templates/tex/myst/plain_latex/template.tex')).toBe(true);
+  });
+  it('Bad template paths to throw', async () => {
+    const jtex = new MystTemplate(new Session(), {
+      template: 'not-there',
+      kind: TemplateKind.tex,
     });
-    it('Render out the template', async () => {
-      const jtex = new MystTemplate(new Session(), {
-        kind: TemplateKind.tex,
-        template: `${__dirname}/example`,
-      });
-      renderTemplate(jtex, {
-        contentOrPath: `${__dirname}/test.tex`,
-        outputPath: '_build/out/article.tex',
-        frontmatter: {
-          title: 'test',
-          description: 'test',
-          date: new Date(2022, 6, 22).toISOString(),
-          authors: [
-            { name: 'Rowan Cockett', affiliations: ['Curvenote'] },
-            { name: 'Steve Purves', affiliations: ['Curvenote'], orcid: '0000' },
-          ],
-        },
-        options: {
-          keywords: '',
-        },
-        parts: {
-          abstract: 'My abstract!',
-        },
-      });
-      expect(fs.existsSync('_build/out/article.tex')).toBe(true);
-      const content = fs.readFileSync('_build/out/article.tex').toString();
-      expect(content.includes('Volcanic Archipelago')).toBe(true);
-      expect(content.includes('Rowan Cockett')).toBe(true);
-      expect(content.includes('My abstract!')).toBe(true);
+    expect(() => jtex.prepare({} as any)).toThrow(/does not exist/);
+  });
+  it('Render out the template', async () => {
+    const jtex = new MystTemplate(new Session(), {
+      kind: TemplateKind.tex,
+      template: `${__dirname}/example`,
     });
-  },
-  { timeout: 15000 },
-);
+    renderTemplate(jtex, {
+      contentOrPath: `${__dirname}/test.tex`,
+      outputPath: '_build/out/article.tex',
+      frontmatter: {
+        title: 'test',
+        description: 'test',
+        date: new Date(2022, 6, 22).toISOString(),
+        authors: [
+          { name: 'Rowan Cockett', affiliations: ['Curvenote'] },
+          { name: 'Steve Purves', affiliations: ['Curvenote'], orcid: '0000' },
+        ],
+      },
+      options: {
+        keywords: '',
+      },
+      parts: {
+        abstract: 'My abstract!',
+      },
+    });
+    expect(fs.existsSync('_build/out/article.tex')).toBe(true);
+    const content = fs.readFileSync('_build/out/article.tex').toString();
+    expect(content.includes('Volcanic Archipelago')).toBe(true);
+    expect(content.includes('Rowan Cockett')).toBe(true);
+    expect(content.includes('My abstract!')).toBe(true);
+  });
+});

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^7.3.0",
+    "@mermaid-js/mermaid-cli": "^10.9.1",
     "@reduxjs/toolkit": "^2.1.0",
     "adm-zip": "^0.5.10",
     "boxen": "^7.1.1",

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -12,6 +12,7 @@ import {
 import type { RendererDoc } from 'myst-templates';
 import MystTemplate from 'myst-templates';
 import { htmlTransform } from 'myst-transforms';
+import type { TransformSpec } from 'myst-common';
 import { fileError, fileWarn, RuleId, TemplateKind } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import { filterKeys } from 'simple-validators';
@@ -28,6 +29,16 @@ import { cleanOutput } from '../utils/cleanOutput.js';
 import { getFileContent } from '../utils/getFileContent.js';
 import { createFooter } from './footers.js';
 import { createArticleTitle, createReferenceTitle } from './titles.js';
+import { mermaidPlugin } from '../../transforms/mermaid.js';
+
+const mermaidTransform: TransformSpec = {
+  name: 'mermaid',
+  stage: 'document',
+  plugin: mermaidPlugin,
+  options: {
+    format: 'png',
+  },
+};
 
 const DOCX_IMAGE_EXTENSIONS = [ImageExtensions.png, ImageExtensions.jpg, ImageExtensions.jpeg];
 
@@ -98,6 +109,7 @@ export async function runWordExport(
     projectPath,
     imageExtensions: DOCX_IMAGE_EXTENSIONS,
     extraLinkTransformers,
+    transforms: [mermaidTransform],
     preFrontmatters: [
       filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
     ],

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -12,7 +12,6 @@ import {
 import type { RendererDoc } from 'myst-templates';
 import MystTemplate from 'myst-templates';
 import { htmlTransform } from 'myst-transforms';
-import type { TransformSpec } from 'myst-common';
 import { fileError, fileWarn, RuleId, TemplateKind } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import { filterKeys } from 'simple-validators';
@@ -29,16 +28,7 @@ import { cleanOutput } from '../utils/cleanOutput.js';
 import { getFileContent } from '../utils/getFileContent.js';
 import { createFooter } from './footers.js';
 import { createArticleTitle, createReferenceTitle } from './titles.js';
-import { mermaidPlugin } from '../../transforms/mermaid.js';
-
-const mermaidTransform: TransformSpec = {
-  name: 'mermaid',
-  stage: 'document',
-  plugin: mermaidPlugin,
-  options: {
-    format: 'png',
-  },
-};
+import { createMermaidImageMystPlugin } from '../../transforms/mermaid.js';
 
 const DOCX_IMAGE_EXTENSIONS = [ImageExtensions.png, ImageExtensions.jpg, ImageExtensions.jpeg];
 
@@ -109,7 +99,7 @@ export async function runWordExport(
     projectPath,
     imageExtensions: DOCX_IMAGE_EXTENSIONS,
     extraLinkTransformers,
-    transforms: [mermaidTransform],
+    transforms: [createMermaidImageMystPlugin],
     preFrontmatters: [
       filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
     ],

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -14,6 +14,17 @@ import { resolveFrontmatterParts } from '../../utils/resolveFrontmatterParts.js'
 import type { ExportWithOutput, ExportFnOptions } from '../types.js';
 import { cleanOutput } from '../utils/cleanOutput.js';
 import { getFileContent } from '../utils/getFileContent.js';
+import { mermaidPlugin } from '../../transforms/mermaid.js';
+import type { TransformSpec } from 'myst-common';
+
+const mermaidTransform: TransformSpec = {
+  name: 'mermaid',
+  stage: 'document',
+  plugin: mermaidPlugin,
+  options: {
+    format: 'png',
+  },
+};
 
 /**
  * Build a MyST project as JATS XML
@@ -39,6 +50,7 @@ export async function runJatsExport(
       projectPath,
       imageExtensions: KNOWN_IMAGE_EXTENSIONS,
       extraLinkTransformers,
+      transforms: [mermaidTransform],
       preFrontmatters: [
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
       ], // only apply to article, not sub_articles

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -14,17 +14,7 @@ import { resolveFrontmatterParts } from '../../utils/resolveFrontmatterParts.js'
 import type { ExportWithOutput, ExportFnOptions } from '../types.js';
 import { cleanOutput } from '../utils/cleanOutput.js';
 import { getFileContent } from '../utils/getFileContent.js';
-import { mermaidPlugin } from '../../transforms/mermaid.js';
-import type { TransformSpec } from 'myst-common';
-
-const mermaidTransform: TransformSpec = {
-  name: 'mermaid',
-  stage: 'document',
-  plugin: mermaidPlugin,
-  options: {
-    format: 'png',
-  },
-};
+import { createMermaidImageMystPlugin } from '../../transforms/mermaid.js';
 
 /**
  * Build a MyST project as JATS XML
@@ -50,7 +40,7 @@ export async function runJatsExport(
       projectPath,
       imageExtensions: KNOWN_IMAGE_EXTENSIONS,
       extraLinkTransformers,
-      transforms: [mermaidTransform],
+      transforms: [createMermaidImageMystPlugin],
       preFrontmatters: [
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
       ], // only apply to article, not sub_articles

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { TexTemplateImports } from 'jtex';
 import { mergeTexTemplateImports, renderTemplate } from 'jtex';
 import { tic, writeFileToFolder } from 'myst-cli-utils';
-import type { References, GenericParent } from 'myst-common';
+import type { References, GenericParent, TransformSpec } from 'myst-common';
 import { extractPart, RuleId, TemplateKind } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import {
@@ -34,6 +34,16 @@ import { createTempFolder } from '../../utils/createTempFolder.js';
 import { resolveFrontmatterParts } from '../../utils/resolveFrontmatterParts.js';
 import type { ExportWithOutput, ExportResults, ExportFnOptions } from '../types.js';
 import { writeBibtexFromCitationRenderers } from '../utils/bibtex.js';
+import { mermaidPlugin } from '../../transforms/mermaid.js';
+
+const mermaidTransform: TransformSpec = {
+  name: 'mermaid',
+  stage: 'document',
+  plugin: mermaidPlugin,
+  options: {
+    format: 'png',
+  },
+};
 
 export const DEFAULT_BIB_FILENAME = 'main.bib';
 const TEX_IMAGE_EXTENSIONS = [
@@ -140,6 +150,7 @@ export async function localArticleToTexRaw(
       projectPath,
       imageExtensions: TEX_IMAGE_EXTENSIONS,
       extraLinkTransformers,
+      transforms: [mermaidTransform],
       titleDepths: fileArticles.map((article) => article.level),
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
@@ -206,6 +217,7 @@ export async function localArticleToTexTemplated(
       projectPath,
       imageExtensions: TEX_IMAGE_EXTENSIONS,
       extraLinkTransformers,
+      transforms: [mermaidTransform],
       titleDepths: fileArticles.map((article) => article.level),
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { TexTemplateImports } from 'jtex';
 import { mergeTexTemplateImports, renderTemplate } from 'jtex';
 import { tic, writeFileToFolder } from 'myst-cli-utils';
-import type { References, GenericParent, TransformSpec } from 'myst-common';
+import type { References, GenericParent } from 'myst-common';
 import { extractPart, RuleId, TemplateKind } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import {
@@ -34,16 +34,7 @@ import { createTempFolder } from '../../utils/createTempFolder.js';
 import { resolveFrontmatterParts } from '../../utils/resolveFrontmatterParts.js';
 import type { ExportWithOutput, ExportResults, ExportFnOptions } from '../types.js';
 import { writeBibtexFromCitationRenderers } from '../utils/bibtex.js';
-import { mermaidPlugin } from '../../transforms/mermaid.js';
-
-const mermaidTransform: TransformSpec = {
-  name: 'mermaid',
-  stage: 'document',
-  plugin: mermaidPlugin,
-  options: {
-    format: 'png',
-  },
-};
+import { createMermaidImageMystPlugin } from '../../transforms/mermaid.js';
 
 export const DEFAULT_BIB_FILENAME = 'main.bib';
 const TEX_IMAGE_EXTENSIONS = [
@@ -150,7 +141,7 @@ export async function localArticleToTexRaw(
       projectPath,
       imageExtensions: TEX_IMAGE_EXTENSIONS,
       extraLinkTransformers,
-      transforms: [mermaidTransform],
+      transforms: [createMermaidImageMystPlugin],
       titleDepths: fileArticles.map((article) => article.level),
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
@@ -217,7 +208,7 @@ export async function localArticleToTexTemplated(
       projectPath,
       imageExtensions: TEX_IMAGE_EXTENSIONS,
       extraLinkTransformers,
-      transforms: [mermaidTransform],
+      transforms: [createMermaidImageMystPlugin],
       titleDepths: fileArticles.map((article) => article.level),
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),

--- a/packages/myst-cli/src/build/typst.ts
+++ b/packages/myst-cli/src/build/typst.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import which from 'which';
 import { makeExecutable, tic, writeFileToFolder } from 'myst-cli-utils';
-import type { References, GenericParent } from 'myst-common';
+import type { References, GenericParent, TransformSpec } from 'myst-common';
 import { extractPart, RuleId, TemplateKind } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import {
@@ -37,6 +37,16 @@ import version from '../version.js';
 import { cleanOutput } from './utils/cleanOutput.js';
 import type { ExportWithOutput, ExportResults, ExportFnOptions } from './types.js';
 import { writeBibtexFromCitationRenderers } from './utils/bibtex.js';
+import { mermaidPlugin } from '../transforms/mermaid.js';
+
+const mermaidTransform: TransformSpec = {
+  name: 'mermaid',
+  stage: 'document',
+  plugin: mermaidPlugin,
+  options: {
+    format: 'png',
+  },
+};
 
 export const DEFAULT_BIB_FILENAME = 'main.bib';
 const TYPST_IMAGE_EXTENSIONS = [
@@ -158,6 +168,7 @@ export async function localArticleToTypstRaw(
       projectPath,
       imageExtensions: TYPST_IMAGE_EXTENSIONS,
       extraLinkTransformers,
+      transforms: [mermaidTransform],
       titleDepths: fileArticles.map((article) => article.level),
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
@@ -229,6 +240,7 @@ export async function localArticleToTypstTemplated(
       projectPath,
       imageExtensions: TYPST_IMAGE_EXTENSIONS,
       extraLinkTransformers,
+      transforms: [mermaidTransform],
       titleDepths: fileArticles.map((article) => article.level),
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),

--- a/packages/myst-cli/src/build/typst.ts
+++ b/packages/myst-cli/src/build/typst.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import which from 'which';
 import { makeExecutable, tic, writeFileToFolder } from 'myst-cli-utils';
-import type { References, GenericParent, TransformSpec } from 'myst-common';
+import type { References, GenericParent } from 'myst-common';
 import { extractPart, RuleId, TemplateKind } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import {
@@ -37,16 +37,7 @@ import version from '../version.js';
 import { cleanOutput } from './utils/cleanOutput.js';
 import type { ExportWithOutput, ExportResults, ExportFnOptions } from './types.js';
 import { writeBibtexFromCitationRenderers } from './utils/bibtex.js';
-import { mermaidPlugin } from '../transforms/mermaid.js';
-
-const mermaidTransform: TransformSpec = {
-  name: 'mermaid',
-  stage: 'document',
-  plugin: mermaidPlugin,
-  options: {
-    format: 'png',
-  },
-};
+import { createMermaidImageMystPlugin } from '../transforms/mermaid.js';
 
 export const DEFAULT_BIB_FILENAME = 'main.bib';
 const TYPST_IMAGE_EXTENSIONS = [
@@ -168,7 +159,7 @@ export async function localArticleToTypstRaw(
       projectPath,
       imageExtensions: TYPST_IMAGE_EXTENSIONS,
       extraLinkTransformers,
-      transforms: [mermaidTransform],
+      transforms: [createMermaidImageMystPlugin],
       titleDepths: fileArticles.map((article) => article.level),
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),
@@ -240,7 +231,7 @@ export async function localArticleToTypstTemplated(
       projectPath,
       imageExtensions: TYPST_IMAGE_EXTENSIONS,
       extraLinkTransformers,
-      transforms: [mermaidTransform],
+      transforms: [createMermaidImageMystPlugin],
       titleDepths: fileArticles.map((article) => article.level),
       preFrontmatters: fileArticles.map((article) =>
         filterKeys(article, [...PAGE_FRONTMATTER_KEYS, ...Object.keys(FRONTMATTER_ALIASES)]),

--- a/packages/myst-cli/src/build/utils/getFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getFileContent.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+import type { TransformSpec } from 'myst-common';
 import { plural } from 'myst-common';
 import { tic } from 'myst-cli-utils';
 import type { LinkTransformer } from 'myst-transforms';
@@ -19,6 +20,7 @@ export async function getFileContent(
     projectPath,
     imageExtensions,
     extraLinkTransformers,
+    transforms,
     extraTransforms,
     titleDepths,
     preFrontmatters,
@@ -27,6 +29,8 @@ export async function getFileContent(
     projectPath?: string;
     imageExtensions: ImageExtensions[];
     extraLinkTransformers?: LinkTransformer[];
+    transforms?: TransformSpec[];
+    /** @deprecated use transforms instead */
     extraTransforms?: TransformFn[];
     titleDepths?: number | (number | undefined)[];
     preFrontmatters?: Record<string, any> | (Record<string, any> | undefined)[];
@@ -72,6 +76,7 @@ export async function getFileContent(
         minifyMaxCharacters: 0,
         index: project.index,
         titleDepth,
+        transforms,
         extraTransforms,
         execute,
       });

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -1,6 +1,12 @@
 import path from 'node:path';
 import { tic } from 'myst-cli-utils';
-import type { GenericParent, IExpressionResult, PluginUtils, References } from 'myst-common';
+import type {
+  GenericParent,
+  IExpressionResult,
+  PluginUtils,
+  References,
+  TransformSpec,
+} from 'myst-common';
 import { fileError, fileWarn, RuleId, slugToUrl } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import { SourceFileKind } from 'myst-spec-ext';
@@ -112,6 +118,8 @@ export async function transformMdast(
     imageExtensions?: ImageExtensions[];
     watchMode?: boolean;
     execute?: boolean;
+    transforms?: TransformSpec[];
+    /** @deprecated Use `session.plugins?.transforms` instead */
     extraTransforms?: TransformFn[];
     minifyMaxCharacters?: number;
     index?: string;
@@ -125,6 +133,7 @@ export async function transformMdast(
     pageSlug,
     projectSlug,
     imageExtensions,
+    transforms,
     extraTransforms,
     watchMode = false,
     minifyMaxCharacters,
@@ -204,10 +213,15 @@ export async function transformMdast(
     })
     .use(inlineMathSimplificationPlugin, { replaceSymbol: false })
     .use(mathPlugin, { macros: frontmatter.math });
+  // Load transform functions from options (we always run all of them)
+  transforms?.forEach((t) => {
+    pipe.use(t.plugin, t.options, pluginUtils);
+  });
+
   // Load custom transform plugins
   session.plugins?.transforms.forEach((t) => {
     if (t.stage !== 'document') return;
-    pipe.use(t.plugin, undefined, pluginUtils);
+    pipe.use(t.plugin, t.options, pluginUtils);
   });
 
   pipe
@@ -361,7 +375,7 @@ export async function postProcessMdast(
   const pipe = unified();
   session.plugins?.transforms.forEach((t) => {
     if (t.stage !== 'project') return;
-    pipe.use(t.plugin, undefined, pluginUtils);
+    pipe.use(t.plugin, t.options, pluginUtils);
   });
   await pipe.run(mdast, vfile);
 

--- a/packages/myst-cli/src/transforms/index.ts
+++ b/packages/myst-cli/src/transforms/index.ts
@@ -10,4 +10,5 @@ export * from './links.js';
 export * from './mdast.js';
 export * from './outputs.js';
 export * from './inlineExpressions.js';
+export * from './mermaid.js';
 export * from './types.js';

--- a/packages/myst-cli/src/transforms/mermaid.spec.ts
+++ b/packages/myst-cli/src/transforms/mermaid.spec.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { VFile } from 'vfile';
+import type { GenericParent } from 'myst-common';
+import { mermaidTransform, renderMermaidDiagram } from './mermaid.js';
+
+// Real tests that actually execute the Mermaid CLI
+describe('mermaid transform - real CLI tests', () => {
+  describe('renderMermaidDiagram - real CLI execution', () => {
+    it('should render simple flowchart to base64 SVG', async () => {
+      const file = new VFile();
+      const mermaidNode = {
+        type: 'mermaid' as const,
+        value: 'flowchart LR\n  A --> B',
+        identifier: 'test-diagram',
+      };
+
+      const result = await renderMermaidDiagram(file, mermaidNode);
+
+      expect(result.type).toBe('image');
+      if (result.type === 'image') {
+        expect(result.url).toMatch(/^data:image\/svg\+xml;base64,/);
+        expect(result.alt).toBe('Mermaid diagram: flowchart LR');
+        expect(result.title).toBe('Mermaid diagram');
+        expect(result.identifier).toBe('test-diagram');
+
+        // Decode and verify SVG content
+        const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
+        const svgContent = Buffer.from(base64Content, 'base64').toString('utf-8');
+
+        expect(svgContent).toContain('<svg');
+        expect(svgContent).toContain('A');
+        expect(svgContent).toContain('B');
+
+        // console.log('Generated SVG preview:', svgContent.substring(0, 200) + '...');
+      }
+    });
+
+    it('should render complex diagram with decision nodes', async () => {
+      const file = new VFile();
+      const mermaidNode = {
+        type: 'mermaid' as const,
+        value: `graph TD
+  A[Start] --> B{Decision}
+  B -->|Yes| C[OK]
+  B -->|No| D[Cancel]`,
+        identifier: 'complex-diagram',
+      };
+
+      const result = await renderMermaidDiagram(file, mermaidNode);
+
+      expect(result.type).toBe('image');
+      if (result.type === 'image') {
+        const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
+        const svgContent = Buffer.from(base64Content, 'base64').toString('utf-8');
+
+        expect(svgContent).toContain('<svg');
+        expect(svgContent).toContain('Start');
+        expect(svgContent).toContain('Decision');
+        expect(svgContent).toContain('OK');
+        expect(svgContent).toContain('Cancel');
+
+        // console.log('Complex diagram SVG preview:', svgContent.substring(0, 200) + '...');
+      }
+    });
+
+    it('should render sequence diagram', async () => {
+      const file = new VFile();
+      const mermaidNode = {
+        type: 'mermaid' as const,
+        value: `sequenceDiagram
+  participant Alice
+  participant Bob
+  Alice->>John: Hello John, how are you?
+  loop Healthcheck
+    John->>John: Fight against hypochondria
+  end`,
+        identifier: 'sequence-diagram',
+      };
+
+      const result = await renderMermaidDiagram(file, mermaidNode);
+
+      expect(result.type).toBe('image');
+      if (result.type === 'image') {
+        const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
+        const svgContent = Buffer.from(base64Content, 'base64').toString('utf-8');
+
+        expect(svgContent).toContain('<svg');
+        expect(svgContent).toContain('Alice');
+        expect(svgContent).toContain('Bob');
+        expect(svgContent).toContain('John');
+
+        // console.log('Sequence diagram SVG preview:', svgContent.substring(0, 200) + '...');
+      }
+    });
+
+    it('should preserve node metadata in image output', async () => {
+      const file = new VFile();
+      const mermaidNode = {
+        type: 'mermaid' as const,
+        value: 'flowchart LR\n  A --> B',
+        identifier: 'preserved-id',
+        label: 'preserved-label',
+        html_id: 'preserved-html-id',
+      };
+
+      const result = await renderMermaidDiagram(file, mermaidNode);
+
+      expect(result.type).toBe('image');
+      if (result.type === 'image') {
+        expect(result.identifier).toBe('preserved-id');
+        expect(result.label).toBe('preserved-label');
+        expect(result.html_id).toBe('preserved-html-id');
+      }
+    });
+  });
+
+  describe('mermaidTransform - real tree transformation', () => {
+    it('should transform all mermaid nodes in a tree', async () => {
+      const file = new VFile();
+      const tree: GenericParent = {
+        type: 'root',
+        children: [
+          {
+            type: 'mermaid',
+            value: 'flowchart LR\n  A --> B',
+            identifier: 'diagram1',
+          },
+          {
+            type: 'paragraph',
+            children: [{ type: 'text', value: 'Some text' }],
+          },
+          {
+            type: 'mermaid',
+            value: 'graph TD\n  A --> B --> C',
+            identifier: 'diagram2',
+          },
+        ],
+      };
+
+      await mermaidTransform(tree, file);
+
+      expect(tree.children[0].type).toBe('image');
+      if (tree.children[0].type === 'image') {
+        expect(tree.children[0].url).toMatch(/^data:image\/svg\+xml;base64,/);
+        expect(tree.children[0].identifier).toBe('diagram1');
+      }
+
+      expect(tree.children[1].type).toBe('paragraph'); // Should remain unchanged
+
+      expect(tree.children[2].type).toBe('image');
+      if (tree.children[2].type === 'image') {
+        expect(tree.children[2].url).toMatch(/^data:image\/svg\+xml;base64,/);
+        expect(tree.children[2].identifier).toBe('diagram2');
+      }
+    });
+  });
+
+  describe('base64 validation - real SVG content', () => {
+    it('should produce valid base64 data URLs with real SVG content', async () => {
+      const file = new VFile();
+      const mermaidNode = {
+        type: 'mermaid' as const,
+        value: 'flowchart LR\n  A --> B',
+      };
+
+      const result = await renderMermaidDiagram(file, mermaidNode);
+
+      expect(result.type).toBe('image');
+      if (result.type === 'image') {
+        expect(result.url).toMatch(/^data:image\/svg\+xml;base64,/);
+
+        // Verify the base64 content can be decoded
+        const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
+        const decodedSvg = Buffer.from(base64Content, 'base64').toString('utf-8');
+
+        expect(decodedSvg).toContain('<svg');
+        expect(decodedSvg).toContain('xmlns="http://www.w3.org/2000/svg"');
+        expect(decodedSvg).toContain('A');
+        expect(decodedSvg).toContain('B');
+
+        // Log the actual SVG content for inspection
+        // console.log('Real SVG content length:', decodedSvg.length);
+        // console.log('Real SVG preview:', decodedSvg.substring(0, 500) + '...');
+      }
+    });
+  });
+});

--- a/packages/myst-cli/src/transforms/mermaid.spec.ts
+++ b/packages/myst-cli/src/transforms/mermaid.spec.ts
@@ -3,8 +3,8 @@ import { VFile } from 'vfile';
 import type { GenericParent } from 'myst-common';
 import { mermaidTransform, renderMermaidDiagram } from './mermaid.js';
 
-describe('renderMermaidDiagram', { timeout: 15000 }, () => {
-  it('should render simple flowchart to base64 SVG', async () => {
+describe('renderMermaidDiagram', () => {
+  it('should render simple flowchart to base64 SVG', { timeout: 15000 }, async () => {
     const file = new VFile();
     const mermaidNode = {
       type: 'mermaid' as const,
@@ -33,7 +33,7 @@ describe('renderMermaidDiagram', { timeout: 15000 }, () => {
     }
   });
 
-  it('should render complex diagram with decision nodes', async () => {
+  it('should render complex diagram with decision nodes', { timeout: 15000 }, async () => {
     const file = new VFile();
     const mermaidNode = {
       type: 'mermaid' as const,
@@ -61,7 +61,7 @@ describe('renderMermaidDiagram', { timeout: 15000 }, () => {
     }
   });
 
-  it('should render sequence diagram', async () => {
+  it('should render sequence diagram', { timeout: 15000 }, async () => {
     const file = new VFile();
     const mermaidNode = {
       type: 'mermaid' as const,
@@ -91,7 +91,7 @@ describe('renderMermaidDiagram', { timeout: 15000 }, () => {
     }
   });
 
-  it('should preserve node metadata in image output', async () => {
+  it('should preserve node metadata in image output', { timeout: 15000 }, async () => {
     const file = new VFile();
     const mermaidNode = {
       type: 'mermaid' as const,
@@ -113,7 +113,7 @@ describe('renderMermaidDiagram', { timeout: 15000 }, () => {
 });
 
 describe('mermaidTransform - real tree transformation', () => {
-  it('should transform all mermaid nodes in a tree', async () => {
+  it('should transform all mermaid nodes in a tree', { timeout: 15000 }, async () => {
     const file = new VFile();
     const tree: GenericParent = {
       type: 'root',
@@ -154,7 +154,7 @@ describe('mermaidTransform - real tree transformation', () => {
 });
 
 describe('base64 validation - real SVG content', () => {
-  it('should produce valid base64 data URLs with real SVG content', async () => {
+  it('should produce valid base64 data URLs with real SVGs', { timeout: 15000 }, async () => {
     const file = new VFile();
     const mermaidNode = {
       type: 'mermaid' as const,

--- a/packages/myst-cli/src/transforms/mermaid.spec.ts
+++ b/packages/myst-cli/src/transforms/mermaid.spec.ts
@@ -3,185 +3,182 @@ import { VFile } from 'vfile';
 import type { GenericParent } from 'myst-common';
 import { mermaidTransform, renderMermaidDiagram } from './mermaid.js';
 
-// Real tests that actually execute the Mermaid CLI
-describe('mermaid transform - real CLI tests', () => {
-  describe('renderMermaidDiagram - real CLI execution', () => {
-    it('should render simple flowchart to base64 SVG', async () => {
-      const file = new VFile();
-      const mermaidNode = {
-        type: 'mermaid' as const,
-        value: 'flowchart LR\n  A --> B',
-        identifier: 'test-diagram',
-      };
+describe('renderMermaidDiagram', { timeout: 15000 }, () => {
+  it('should render simple flowchart to base64 SVG', async () => {
+    const file = new VFile();
+    const mermaidNode = {
+      type: 'mermaid' as const,
+      value: 'flowchart LR\n  A --> B',
+      identifier: 'test-diagram',
+    };
 
-      const result = await renderMermaidDiagram(file, mermaidNode);
+    const result = await renderMermaidDiagram(file, mermaidNode);
 
-      expect(result.type).toBe('image');
-      if (result.type === 'image') {
-        expect(result.url).toMatch(/^data:image\/svg\+xml;base64,/);
-        expect(result.alt).toBe('Mermaid diagram: flowchart LR');
-        expect(result.title).toBe('Mermaid diagram');
-        expect(result.identifier).toBe('test-diagram');
+    expect(result.type).toBe('image');
+    if (result.type === 'image') {
+      expect(result.url).toMatch(/^data:image\/svg\+xml;base64,/);
+      expect(result.alt).toBe('Mermaid diagram: flowchart LR');
+      expect(result.title).toBe('Mermaid diagram');
+      expect(result.identifier).toBe('test-diagram');
 
-        // Decode and verify SVG content
-        const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
-        const svgContent = Buffer.from(base64Content, 'base64').toString('utf-8');
+      // Decode and verify SVG content
+      const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
+      const svgContent = Buffer.from(base64Content, 'base64').toString('utf-8');
 
-        expect(svgContent).toContain('<svg');
-        expect(svgContent).toContain('A');
-        expect(svgContent).toContain('B');
+      expect(svgContent).toContain('<svg');
+      expect(svgContent).toContain('A');
+      expect(svgContent).toContain('B');
 
-        // console.log('Generated SVG preview:', svgContent.substring(0, 200) + '...');
-      }
-    });
+      // console.log('Generated SVG preview:', svgContent.substring(0, 200) + '...');
+    }
+  });
 
-    it('should render complex diagram with decision nodes', async () => {
-      const file = new VFile();
-      const mermaidNode = {
-        type: 'mermaid' as const,
-        value: `graph TD
+  it('should render complex diagram with decision nodes', async () => {
+    const file = new VFile();
+    const mermaidNode = {
+      type: 'mermaid' as const,
+      value: `graph TD
   A[Start] --> B{Decision}
   B -->|Yes| C[OK]
   B -->|No| D[Cancel]`,
-        identifier: 'complex-diagram',
-      };
+      identifier: 'complex-diagram',
+    };
 
-      const result = await renderMermaidDiagram(file, mermaidNode);
+    const result = await renderMermaidDiagram(file, mermaidNode);
 
-      expect(result.type).toBe('image');
-      if (result.type === 'image') {
-        const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
-        const svgContent = Buffer.from(base64Content, 'base64').toString('utf-8');
+    expect(result.type).toBe('image');
+    if (result.type === 'image') {
+      const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
+      const svgContent = Buffer.from(base64Content, 'base64').toString('utf-8');
 
-        expect(svgContent).toContain('<svg');
-        expect(svgContent).toContain('Start');
-        expect(svgContent).toContain('Decision');
-        expect(svgContent).toContain('OK');
-        expect(svgContent).toContain('Cancel');
+      expect(svgContent).toContain('<svg');
+      expect(svgContent).toContain('Start');
+      expect(svgContent).toContain('Decision');
+      expect(svgContent).toContain('OK');
+      expect(svgContent).toContain('Cancel');
 
-        // console.log('Complex diagram SVG preview:', svgContent.substring(0, 200) + '...');
-      }
-    });
+      // console.log('Complex diagram SVG preview:', svgContent.substring(0, 200) + '...');
+    }
+  });
 
-    it('should render sequence diagram', async () => {
-      const file = new VFile();
-      const mermaidNode = {
-        type: 'mermaid' as const,
-        value: `sequenceDiagram
+  it('should render sequence diagram', async () => {
+    const file = new VFile();
+    const mermaidNode = {
+      type: 'mermaid' as const,
+      value: `sequenceDiagram
   participant Alice
   participant Bob
   Alice->>John: Hello John, how are you?
   loop Healthcheck
     John->>John: Fight against hypochondria
   end`,
-        identifier: 'sequence-diagram',
-      };
+      identifier: 'sequence-diagram',
+    };
 
-      const result = await renderMermaidDiagram(file, mermaidNode);
+    const result = await renderMermaidDiagram(file, mermaidNode);
 
-      expect(result.type).toBe('image');
-      if (result.type === 'image') {
-        const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
-        const svgContent = Buffer.from(base64Content, 'base64').toString('utf-8');
+    expect(result.type).toBe('image');
+    if (result.type === 'image') {
+      const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
+      const svgContent = Buffer.from(base64Content, 'base64').toString('utf-8');
 
-        expect(svgContent).toContain('<svg');
-        expect(svgContent).toContain('Alice');
-        expect(svgContent).toContain('Bob');
-        expect(svgContent).toContain('John');
+      expect(svgContent).toContain('<svg');
+      expect(svgContent).toContain('Alice');
+      expect(svgContent).toContain('Bob');
+      expect(svgContent).toContain('John');
 
-        // console.log('Sequence diagram SVG preview:', svgContent.substring(0, 200) + '...');
-      }
-    });
-
-    it('should preserve node metadata in image output', async () => {
-      const file = new VFile();
-      const mermaidNode = {
-        type: 'mermaid' as const,
-        value: 'flowchart LR\n  A --> B',
-        identifier: 'preserved-id',
-        label: 'preserved-label',
-        html_id: 'preserved-html-id',
-      };
-
-      const result = await renderMermaidDiagram(file, mermaidNode);
-
-      expect(result.type).toBe('image');
-      if (result.type === 'image') {
-        expect(result.identifier).toBe('preserved-id');
-        expect(result.label).toBe('preserved-label');
-        expect(result.html_id).toBe('preserved-html-id');
-      }
-    });
+      // console.log('Sequence diagram SVG preview:', svgContent.substring(0, 200) + '...');
+    }
   });
 
-  describe('mermaidTransform - real tree transformation', () => {
-    it('should transform all mermaid nodes in a tree', async () => {
-      const file = new VFile();
-      const tree: GenericParent = {
-        type: 'root',
-        children: [
-          {
-            type: 'mermaid',
-            value: 'flowchart LR\n  A --> B',
-            identifier: 'diagram1',
-          },
-          {
-            type: 'paragraph',
-            children: [{ type: 'text', value: 'Some text' }],
-          },
-          {
-            type: 'mermaid',
-            value: 'graph TD\n  A --> B --> C',
-            identifier: 'diagram2',
-          },
-        ],
-      };
+  it('should preserve node metadata in image output', async () => {
+    const file = new VFile();
+    const mermaidNode = {
+      type: 'mermaid' as const,
+      value: 'flowchart LR\n  A --> B',
+      identifier: 'preserved-id',
+      label: 'preserved-label',
+      html_id: 'preserved-html-id',
+    };
 
-      await mermaidTransform(tree, file);
+    const result = await renderMermaidDiagram(file, mermaidNode);
 
-      expect(tree.children[0].type).toBe('image');
-      if (tree.children[0].type === 'image') {
-        expect(tree.children[0].url).toMatch(/^data:image\/svg\+xml;base64,/);
-        expect(tree.children[0].identifier).toBe('diagram1');
-      }
-
-      expect(tree.children[1].type).toBe('paragraph'); // Should remain unchanged
-
-      expect(tree.children[2].type).toBe('image');
-      if (tree.children[2].type === 'image') {
-        expect(tree.children[2].url).toMatch(/^data:image\/svg\+xml;base64,/);
-        expect(tree.children[2].identifier).toBe('diagram2');
-      }
-    });
+    expect(result.type).toBe('image');
+    if (result.type === 'image') {
+      expect(result.identifier).toBe('preserved-id');
+      expect(result.label).toBe('preserved-label');
+      expect(result.html_id).toBe('preserved-html-id');
+    }
   });
+});
 
-  describe('base64 validation - real SVG content', () => {
-    it('should produce valid base64 data URLs with real SVG content', async () => {
-      const file = new VFile();
-      const mermaidNode = {
-        type: 'mermaid' as const,
-        value: 'flowchart LR\n  A --> B',
-      };
+describe('mermaidTransform - real tree transformation', () => {
+  it('should transform all mermaid nodes in a tree', async () => {
+    const file = new VFile();
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'mermaid',
+          value: 'flowchart LR\n  A --> B',
+          identifier: 'diagram1',
+        },
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', value: 'Some text' }],
+        },
+        {
+          type: 'mermaid',
+          value: 'graph TD\n  A --> B --> C',
+          identifier: 'diagram2',
+        },
+      ],
+    };
 
-      const result = await renderMermaidDiagram(file, mermaidNode);
+    await mermaidTransform(tree, file);
 
-      expect(result.type).toBe('image');
-      if (result.type === 'image') {
-        expect(result.url).toMatch(/^data:image\/svg\+xml;base64,/);
+    expect(tree.children[0].type).toBe('image');
+    if (tree.children[0].type === 'image') {
+      expect(tree.children[0].url).toMatch(/^data:image\/svg\+xml;base64,/);
+      expect(tree.children[0].identifier).toBe('diagram1');
+    }
 
-        // Verify the base64 content can be decoded
-        const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
-        const decodedSvg = Buffer.from(base64Content, 'base64').toString('utf-8');
+    expect(tree.children[1].type).toBe('paragraph'); // Should remain unchanged
 
-        expect(decodedSvg).toContain('<svg');
-        expect(decodedSvg).toContain('xmlns="http://www.w3.org/2000/svg"');
-        expect(decodedSvg).toContain('A');
-        expect(decodedSvg).toContain('B');
+    expect(tree.children[2].type).toBe('image');
+    if (tree.children[2].type === 'image') {
+      expect(tree.children[2].url).toMatch(/^data:image\/svg\+xml;base64,/);
+      expect(tree.children[2].identifier).toBe('diagram2');
+    }
+  });
+});
 
-        // Log the actual SVG content for inspection
-        // console.log('Real SVG content length:', decodedSvg.length);
-        // console.log('Real SVG preview:', decodedSvg.substring(0, 500) + '...');
-      }
-    });
+describe('base64 validation - real SVG content', () => {
+  it('should produce valid base64 data URLs with real SVG content', async () => {
+    const file = new VFile();
+    const mermaidNode = {
+      type: 'mermaid' as const,
+      value: 'flowchart LR\n  A --> B',
+    };
+
+    const result = await renderMermaidDiagram(file, mermaidNode);
+
+    expect(result.type).toBe('image');
+    if (result.type === 'image') {
+      expect(result.url).toMatch(/^data:image\/svg\+xml;base64,/);
+
+      // Verify the base64 content can be decoded
+      const base64Content = result.url.replace('data:image/svg+xml;base64,', '');
+      const decodedSvg = Buffer.from(base64Content, 'base64').toString('utf-8');
+
+      expect(decodedSvg).toContain('<svg');
+      expect(decodedSvg).toContain('xmlns="http://www.w3.org/2000/svg"');
+      expect(decodedSvg).toContain('A');
+      expect(decodedSvg).toContain('B');
+
+      // Log the actual SVG content for inspection
+      // console.log('Real SVG content length:', decodedSvg.length);
+      // console.log('Real SVG preview:', decodedSvg.substring(0, 500) + '...');
+    }
   });
 });

--- a/packages/myst-cli/src/transforms/mermaid.ts
+++ b/packages/myst-cli/src/transforms/mermaid.ts
@@ -1,0 +1,140 @@
+import type { Plugin } from 'unified';
+import type { VFile } from 'vfile';
+import type { GenericParent } from 'myst-common';
+import type { Image as ImageNode } from 'myst-spec-ext';
+import { selectAll } from 'unist-util-select';
+import { fileError, fileWarn, RuleId } from 'myst-common';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs/promises';
+import path from 'path';
+import crypto from 'crypto';
+import which from 'which';
+import { createTempFolder } from '../utils/createTempFolder.js';
+import pLimit from 'p-limit';
+
+const execAsync = promisify(exec);
+
+// Create a limiter with concurrency limit
+const limitConnections = pLimit(5);
+
+function isMermaidCliAvailable(): boolean {
+  return !!which.sync('mmdc', { nothrow: true });
+}
+
+export type MermaidOptions = {
+  theme?: 'default' | 'forest' | 'dark' | 'neutral';
+  format?: 'png' | 'svg';
+};
+
+interface MermaidNode {
+  type: 'mermaid';
+  value: string;
+  identifier?: string;
+  label?: string;
+  html_id?: string;
+}
+
+async function renderMermaidToBase64(
+  mermaidCode: string,
+  theme = 'default',
+  format: 'png' | 'svg' = 'svg',
+): Promise<string> {
+  // Create unique temporary output file name
+  const hash = crypto.createHash('md5').update(mermaidCode).digest('hex');
+  const tempFolder = createTempFolder();
+  const outputFile = path.join(tempFolder, `mermaid-output-${hash}.${format}`);
+
+  if (!isMermaidCliAvailable()) {
+    throw new Error('Mermaid CLI is not available');
+  }
+
+  try {
+    // Render using Mermaid CLI with stdin input
+    await execAsync(
+      `echo '${mermaidCode.replace(/'/g, "'\"'\"'")}' | mmdc -i - -o "${outputFile}" -t ${theme} -b transparent`,
+    );
+
+    // Read the generated file
+    const fileContent = await fs.readFile(outputFile, format === 'svg' ? 'utf-8' : undefined);
+
+    // Convert to base64
+    const base64Content = Buffer.from(fileContent).toString('base64');
+    const mimeType = format === 'svg' ? 'image/svg+xml' : 'image/png';
+    const dataUrl = `data:${mimeType};base64,${base64Content}`;
+
+    return dataUrl;
+  } finally {
+    // Clean up temporary file
+    try {
+      await fs.rm(tempFolder, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+export async function renderMermaidDiagram(
+  file: VFile,
+  node: MermaidNode,
+  opts?: MermaidOptions,
+): Promise<ImageNode | MermaidNode> {
+  const { value } = node;
+  if (!value) {
+    const message = 'No input for mermaid node';
+    fileWarn(file, message, {
+      node,
+      ruleId: RuleId.directiveArgumentCorrect,
+    });
+    return node;
+  }
+
+  try {
+    const base64Url = await renderMermaidToBase64(value, opts?.theme, opts?.format);
+
+    // Create image node
+    const imageNode: ImageNode = {
+      type: 'image',
+      url: base64Url,
+      alt: `Mermaid diagram: ${value.split('\n')[0]}`,
+      title: 'Mermaid diagram',
+      identifier: node.identifier,
+      label: node.label,
+      html_id: node.html_id,
+    };
+
+    return imageNode;
+  } catch (error) {
+    const message = `Failed to render Mermaid diagram: ${(error as Error).message}`;
+    fileError(file, message, {
+      ruleId: RuleId.imageFormatConverts,
+      node,
+      note: 'To install the Mermaid CLI, run `npm install -g @mermaid-js/mermaid-cli`',
+    });
+    return node;
+  }
+}
+
+export async function mermaidTransform(tree: GenericParent, file: VFile, opts?: MermaidOptions) {
+  const nodes = selectAll('mermaid', tree) as MermaidNode[];
+  await Promise.all(
+    nodes.map(async (node) =>
+      limitConnections(async () => {
+        const result = await renderMermaidDiagram(file, node, opts);
+        // Replace the mermaid node with the image node if successful
+        if (result.type === 'image') {
+          // Delete all keys from the original node and replace with result
+          Object.keys(node).forEach((key) => {
+            delete (node as any)[key];
+          });
+          Object.assign(node, result);
+        }
+      }),
+    ),
+  );
+}
+
+export const mermaidPlugin: Plugin<[MermaidOptions?], GenericParent, GenericParent> =
+  (opts) => async (tree, file) => {
+    await mermaidTransform(tree, file, opts);
+  };

--- a/packages/myst-cli/src/transforms/mermaid.ts
+++ b/packages/myst-cli/src/transforms/mermaid.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
-import type { GenericParent } from 'myst-common';
+import type { GenericParent, TransformSpec } from 'myst-common';
 import type { Image as ImageNode } from 'myst-spec-ext';
 import { selectAll } from 'unist-util-select';
 import { fileError, fileWarn, RuleId } from 'myst-common';
@@ -150,3 +150,12 @@ export const mermaidPlugin: Plugin<[MermaidOptions?], GenericParent, GenericPare
   (opts) => async (tree, file) => {
     await mermaidTransform(tree, file, opts);
   };
+
+export const createMermaidImageMystPlugin: TransformSpec = {
+  name: 'mermaid',
+  stage: 'document',
+  plugin: mermaidPlugin,
+  options: {
+    format: 'png',
+  },
+};

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -130,6 +130,7 @@ export type TransformSpec = {
     GenericParent,
     GenericParent | Promise<GenericParent>
   >;
+  options?: PluginOptions;
 };
 
 /**

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -121,6 +121,9 @@ export type Image = SpecImage & {
   urlOptimized?: string;
   height?: string;
   placeholder?: boolean;
+  label?: string;
+  identifier?: string;
+  html_id?: string;
 };
 
 export type Iframe = Target & {


### PR DESCRIPTION
Fixes #2006

Requires that you have `mmdc` installed, the CLI warns you and I have added some docs. Works with typst, tex, docx and jats.

![Image](https://github.com/user-attachments/assets/ccea9b05-fc83-4945-9bce-31f551f0d245)

![image](https://github.com/user-attachments/assets/e1ba76d9-4283-4cf9-aeb7-c540be108473)

Replaces https://github.com/jupyter-book/mystmd/pull/1452/
