### PR TITLE
🧮 Add a `typst` option in math nodes

### DIFF
--- a/.changeset/breezy-rivers-heal.md
+++ b/.changeset/breezy-rivers-heal.md
@@ -1,0 +1,5 @@
+---
+"myst-parser": patch
+---
+
+Ensure that the options are also on the mystRole.

--- a/.changeset/brown-meals-yell.md
+++ b/.changeset/brown-meals-yell.md
@@ -1,0 +1,9 @@
+---
+"myst-directives": patch
+"myst-spec-ext": patch
+"myst-to-typst": patch
+"myst-parser": patch
+"myst-roles": patch
+---
+
+Add typst as an option to the math nodes.

--- a/docs/math.md
+++ b/docs/math.md
@@ -237,3 +237,31 @@ In the macro in the example above, `\mathbf{d}_\text{pred}\left( #1 \right)`, th
 ```{seealso}
 In the future the information collected in the math macro will expand to include alt text, color, or interaction information (e.g. hover, substitution) to improve accessibility and interactivity.
 ```
+
+
+(typst-math)=
+
+### Typst-specific Math Content
+
+When exporting to Typst format, you can provide Typst-specific math content using the `typst` option. This allows you to use native Typst syntax instead of relying on [`tex-to-typst`](https://github.com/continuous-foundation/tex-to-typst) conversion, which may give incorrect results.
+
+Example with typst argument in a math block:
+
+````{myst}
+```{math}
+:typst: root(3, x)
+\sqrt[3]{x}
+```
+````
+
+When the `typst` option is provided, it will be used directly in Typst output instead of converting the LaTeX content.
+
+For inline math, you can also use the `typst` option with the math role:
+
+```{myst}
+{math typst="typst"}`latex`
+```
+
+:::{important} Improve the Math Conversion
+If your LaTeX math does not convert automatically to typst, please open an [issue here](https://github.com/continuous-foundation/tex-to-typst/issues/new).
+:::

--- a/packages/myst-directives/src/math.ts
+++ b/packages/myst-directives/src/math.ts
@@ -5,6 +5,10 @@ export const mathDirective: DirectiveSpec = {
   name: 'math',
   options: {
     ...commonDirectiveOptions('math'),
+    typst: {
+      type: String,
+      doc: 'Typst-specific math content. If not provided, LaTeX content will be converted to Typst.',
+    },
   },
   body: {
     type: String,
@@ -15,6 +19,9 @@ export const mathDirective: DirectiveSpec = {
     if (data.node.tight) {
       // The default `false` is not written to the AST
       math.tight = data.node.tight;
+    }
+    if (data.options?.typst) {
+      math.typst = data.options.typst as string;
     }
     return [math];
   },

--- a/packages/myst-parser/src/roles.ts
+++ b/packages/myst-parser/src/roles.ts
@@ -44,6 +44,7 @@ export function applyRoles(tree: GenericParent, specs: RoleSpec[], vfile: VFile)
     const { valid: validOptions, options } = parseOptions(name, node, vfile, optionsSpec);
     let validationError = validOptions;
     data.options = options;
+    node.options = options;
 
     // Only look to the direct children
     const bodyNode = node.children?.find((n) => n.type === 'mystRoleBody') as GenericNode;

--- a/packages/myst-parser/tests/directives/math.yml
+++ b/packages/myst-parser/tests/directives/math.yml
@@ -68,3 +68,25 @@ cases:
           children:
             - type: math
               value: 1+2
+  - title: math directive with typst argument
+    markdown: |-
+      ```{math}
+      :label: example
+      :typst: typst
+      x^2 + y^2 = z^2
+      ```
+    mdast:
+      type: root
+      children:
+        - type: mystDirective
+          name: math
+          options:
+            label: example
+            typst: typst
+          value: x^2 + y^2 = z^2
+          children:
+            - type: math
+              identifier: example
+              label: example
+              value: x^2 + y^2 = z^2
+              typst: typst

--- a/packages/myst-parser/tests/roles/basicRole.spec.ts
+++ b/packages/myst-parser/tests/roles/basicRole.spec.ts
@@ -58,6 +58,12 @@ describe('role spec with options', () => {
               type: 'mystRole',
               position: positionFn(1, 1, 1, 61),
               name: 'widget',
+              options: {
+                class: 'something another',
+                label: 'label',
+                max: 5,
+                open: true,
+              },
               value: '_a_',
               children: [
                 {

--- a/packages/myst-parser/tests/roles/math.yml
+++ b/packages/myst-parser/tests/roles/math.yml
@@ -13,3 +13,19 @@ cases:
               children:
                 - type: inlineMath
                   value: 1+2
+  - title: math role with typst option
+    markdown: '{math typst="typst"}`x^2`'
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: mystRole
+              name: math
+              options:
+                typst: typst
+              value: x^2
+              children:
+                - type: inlineMath
+                  value: x^2
+                  typst: typst

--- a/packages/myst-roles/src/math.ts
+++ b/packages/myst-roles/src/math.ts
@@ -3,7 +3,13 @@ import { addCommonRoleOptions, commonRoleOptions } from './utils.js';
 
 export const mathRole: RoleSpec = {
   name: 'math',
-  options: { ...commonRoleOptions('math') },
+  options: {
+    ...commonRoleOptions('math'),
+    typst: {
+      type: String,
+      doc: 'Typst-specific math content. If not provided, LaTeX content will be converted to Typst.',
+    },
+  },
   body: {
     type: String,
     required: true,
@@ -11,6 +17,9 @@ export const mathRole: RoleSpec = {
   run(data: RoleData): GenericNode[] {
     const node: GenericNode = { type: 'inlineMath', value: data.body as string };
     addCommonRoleOptions(data, node);
+    if (data.options?.typst) {
+      node.typst = data.options.typst as string;
+    }
     return [node];
   },
 };

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -73,6 +73,8 @@ export type InlineMath = SpecInlineMath & Target;
 export type Math = SpecMath & {
   kind?: 'subequation';
   tight?: 'before' | 'after' | boolean;
+  /** Typst-specific math content. If not provided, LaTeX content will be converted to Typst. */
+  typst?: string;
 };
 
 export type MathGroup = Target & {

--- a/packages/myst-to-tex/tests/math.spec.ts
+++ b/packages/myst-to-tex/tests/math.spec.ts
@@ -45,4 +45,32 @@ describe('myst-to-tex math', () => {
     const file = pipe.stringify(tree as any);
     expect((file.result as LatexResult).value).toEqual(tex);
   });
+  it('ignores typst value and use LaTeX value', () => {
+    const tree = u('root', [
+      u('math', {
+        value: '\\LaTeX',
+        typst: 'typst',
+      }),
+    ]);
+    const pipe = unified().use(mystToTex);
+    pipe.runSync(tree as any);
+    const file = pipe.stringify(tree as any);
+    expect((file.result as LatexResult).value).toContain('\\LaTeX');
+    expect((file.result as LatexResult).value).not.toContain('typst');
+  });
+  it('ignores typst value for inline math and uses LaTeX value', () => {
+    const tree = u('root', [
+      u('paragraph', [
+        u('inlineMath', {
+          value: '\\LaTeX',
+          typst: 'typst',
+        }),
+      ]),
+    ]);
+    const pipe = unified().use(mystToTex);
+    pipe.runSync(tree as any);
+    const file = pipe.stringify(tree as any);
+    expect((file.result as LatexResult).value).toContain('\\LaTeX');
+    expect((file.result as LatexResult).value).not.toContain('typst');
+  });
 });

--- a/packages/myst-to-typst/src/math.ts
+++ b/packages/myst-to-typst/src/math.ts
@@ -60,7 +60,12 @@ export function resolveRecursiveCommands(plugins: MathPlugins): MathPlugins {
 }
 
 const math: Handler = (node, state) => {
-  const { value, macros } = texToTypst(node.value);
+  // Use typst value if available, otherwise convert LaTeX
+  const mathValue = node.typst || node.value;
+  const { value, macros } = node.typst
+    ? { value: mathValue, macros: undefined } // No conversion needed for typst
+    : texToTypst(node.value); // Convert LaTeX to Typst
+
   macros?.forEach((macro) => {
     state.useMacro(macro);
   });
@@ -80,7 +85,12 @@ const math: Handler = (node, state) => {
 };
 
 const inlineMath: Handler = (node, state) => {
-  const { value, macros } = texToTypst(node.value);
+  // Use typst value if available, otherwise convert LaTeX
+  const mathValue = node.typst || node.value;
+  const { value, macros } = node.typst
+    ? { value: mathValue, macros: undefined } // No conversion needed for typst
+    : texToTypst(node.value); // Convert LaTeX to Typst
+
   macros?.forEach((macro) => {
     state.useMacro(macro);
   });

--- a/packages/myst-to-typst/tests/math.spec.ts
+++ b/packages/myst-to-typst/tests/math.spec.ts
@@ -27,4 +27,48 @@ describe('myst-to-typst math', () => {
       aRecursion: '[ upright(a) ]',
     });
   });
+
+  it('uses typst value when provided', () => {
+    const tree = u('root', [
+      u('math', {
+        value: 'latex',
+        typst: 'typst',
+      }),
+    ]);
+    const pipe = unified().use(mystToTypst);
+    pipe.runSync(tree as any);
+    const file = pipe.stringify(tree as any);
+    expect((file.result as TypstResult).value).toEqual('$ typst $');
+  });
+
+  it('converts LaTeX when typst value not provided', () => {
+    const tree = u('root', [u('math', { value: '\\mathrm{e}' })]);
+    const pipe = unified().use(mystToTypst);
+    pipe.runSync(tree as any);
+    const file = pipe.stringify(tree as any);
+    expect((file.result as TypstResult).value).toEqual('$ upright(e) $');
+  });
+
+  it('uses typst value for inline math when provided', () => {
+    const tree = u('root', [
+      u('paragraph', [
+        u('inlineMath', {
+          value: 'latex',
+          typst: 'typst',
+        }),
+      ]),
+    ]);
+    const pipe = unified().use(mystToTypst);
+    pipe.runSync(tree as any);
+    const file = pipe.stringify(tree as any);
+    expect((file.result as TypstResult).value).toEqual('$typst$');
+  });
+
+  it('converts LaTeX for inline math when typst value not provided', () => {
+    const tree = u('root', [u('paragraph', [u('inlineMath', { value: '\\mathrm{e}' })])]);
+    const pipe = unified().use(mystToTypst);
+    pipe.runSync(tree as any);
+    const file = pipe.stringify(tree as any);
+    expect((file.result as TypstResult).value).toEqual('$upright(e)$');
+  });
 });


### PR DESCRIPTION
This allows for fixing typst math without a release.