### PR TITLE
➡️ Indentation of log message in `crossReference`

### DIFF
--- a/.changeset/violet-ants-try.md
+++ b/.changeset/violet-ants-try.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Fix indentation of log message

--- a/packages/myst-cli/src/transforms/crossReferences.ts
+++ b/packages/myst-cli/src/transforms/crossReferences.ts
@@ -164,7 +164,7 @@ export async function transformMystXRefs(
   const denominator = number === nodes.length ? '' : `/${nodes.length}`;
   session.log.info(
     toc(
-      `🪄  Updated link text for ${plural(`%s${denominator} external MyST reference(s)`, number)} in %s seconds`,
+      `🪄 Updated link text for ${plural(`%s${denominator} external MyST reference(s)`, number)} in %s seconds`,
     ),
   );
 }


### PR DESCRIPTION
In this log message, "Updated link text" has an additional space of indentation. I don't _think_ this is intentional.

```
📖 Built content/index.md in 63 ms.
🪄  Updated link text for 1 external MyST reference in 4.42 ms seconds
```