### PR TITLE
🎬 More whitelabelling for `myst init`

### DIFF
--- a/.changeset/strange-beans-listen.md
+++ b/.changeset/strange-beans-listen.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Add whitelabelling for myst init

--- a/packages/myst-cli/src/init/gh-actions/index.ts
+++ b/packages/myst-cli/src/init/gh-actions/index.ts
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - name: Install ${readableName()} Markdown
+      - name: Install ${readableName()}
         run: npm install -g ${npmPackageName()}
       - name: Build HTML Assets
         run: ${binaryName()} build --html

--- a/packages/myst-cli/src/init/gh-actions/index.ts
+++ b/packages/myst-cli/src/init/gh-actions/index.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import type { ISession } from 'myst-cli-utils';
 import { writeFileToFolder } from 'myst-cli-utils';
 import { getGithubUrl } from '../../utils/github.js';
+import { binaryName, readableName, npmPackageName } from '../../utils/whiteLabelling.js';
 import { checkFolderIsGit, checkAtGitRoot } from '../../utils/git.js';
 
 function createGithubPagesAction({
@@ -16,10 +17,10 @@ function createGithubPagesAction({
   defaultBranch?: string;
   isGithubIO?: boolean;
 }) {
-  return `# This file was created automatically with \`myst init --gh-pages\` 🪄 💚
+  return `# This file was created automatically with \`${binaryName()} init --gh-pages\` 🪄 💚
 # Ensure your GitHub Pages settings for this repository are set to deploy with **GitHub Actions**.
 
-name: MyST GitHub Pages Deploy
+name: ${readableName()} GitHub Pages Deploy
 on:
   push:
     # Runs on pushes targeting the default branch
@@ -57,10 +58,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - name: Install MyST Markdown
-        run: npm install -g mystmd
+      - name: Install ${readableName()} Markdown
+        run: npm install -g ${npmPackageName()}
       - name: Build HTML Assets
-        run: myst build --html
+        run: ${binaryName()} build --html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -72,7 +73,7 @@ jobs:
 }
 
 function createGithubCurvenoteAction({ defaultBranch = 'main' }: { defaultBranch?: string }) {
-  return `# This file was created automatically with \`myst init --gh-curvenote\` 🪄 💚
+  return `# This file was created automatically with \`${binaryName()} init --gh-curvenote\` 🪄 💚
 
 name: Curvenote Deploy
 on:

--- a/packages/myst-cli/src/utils/whiteLabelling.ts
+++ b/packages/myst-cli/src/utils/whiteLabelling.ts
@@ -11,6 +11,10 @@ export function binaryName(): string {
   return (process.env.MYSTMD_BINARY_NAME ?? 'myst') as string;
 }
 
+export function npmPackageName(): string {
+  return (process.env.MYSTMD_NPM_PACKAGE_NAME ?? 'mystmd') as string;
+}
+
 export function homeURL(): string {
   return (process.env.MYSTMD_HOME_URL ?? 'https://mystmd.org') as string;
 }


### PR DESCRIPTION
I noticed that running `jupyter book init --gh-pages` refers to myst. This PR fixes that under Jupyter Book 2, so that users install the proper package.

This still isn't perfect — the `--curvenote` option uses a Curvenote action, which theoretically doesn't know about Jupyter Book. But I think that's a problem for another day.