### PR TITLE
⏱️ Remove time unit from timing message

### DIFF
--- a/.changeset/famous-mayflies-camp.md
+++ b/.changeset/famous-mayflies-camp.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Remove time unit from heartbeat message

--- a/packages/myst-cli/src/transforms/crossReferences.ts
+++ b/packages/myst-cli/src/transforms/crossReferences.ts
@@ -164,7 +164,7 @@ export async function transformMystXRefs(
   const denominator = number === nodes.length ? '' : `/${nodes.length}`;
   session.log.info(
     toc(
-      `🪄 Updated link text for ${plural(`%s${denominator} external MyST reference(s)`, number)} in %s seconds`,
+      `🪄 Updated link text for ${plural(`%s${denominator} external MyST reference(s)`, number)} in %s`,
     ),
   );
 }


### PR DESCRIPTION
With this PR,
```
🪄 Updated link text for 1 external MyST reference in 151 ms seconds
```
is now
```
🪄 Updated link text for 1 external MyST reference in 142 ms
```
