### PR TITLE
Automate GitHub Release Creation with Reusable Workflow

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -1,0 +1,76 @@
+name: Publish GitHub Release
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+      release_title:
+        required: false
+        type: string
+        default: ''
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for the release (e.g. v1.2.3)'
+        required: true
+        type: string
+      release_title:
+        description: 'Optional release title (will be ignored, see workflow logic)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      # Get the date of the latest GitHub release
+      - name: Get latest release date
+        id: latest_release
+        run: |
+          latest_release_json=$(gh release list --limit 1 --json publishedAt --jq '.[0]')
+          if [ -z "$latest_release_json" ]; then
+            echo "No previous GitHub release found. Cannot generate release notes."
+            exit 1
+          else
+            date=$(echo "$latest_release_json" | jq -r '.publishedAt')
+            echo "date=$date" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install github-activity
+        run: pip install github-activity
+
+      # Generate release notes since the last release
+      - name: Generate release notes with github-activity
+        run: |
+          github-activity --since "${{ steps.latest_release.outputs.date }}" --repo "$GITHUB_REPOSITORY" > release-notes.md
+
+      # Strip leading 'v' from tag for the release title
+      - name: Prepare release title
+        id: version
+        run: |
+          TAG="${{ github.event.inputs.tag_name || inputs.tag_name }}"
+          VERSION=${TAG#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # Create the GitHub Release
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag_name || inputs.tag_name }}
+          name: mystmd v${{ steps.version.outputs.version }}
+          body_path: release-notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,29 @@ jobs:
           path: dist/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  get-tag:
+    name: Get Tag Name
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.get_tag.outputs.tag_name }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Get tag name from package.json
+        id: get_tag
+        run: |
+          TAG="v$(jq -r .version < packages/mystmd/package.json)"
+          echo "tag_name=$TAG" >> $GITHUB_OUTPUT
+
+  release-github:
+    name: Publish GitHub Release
+    needs:
+      - release-npm
+      - release-py
+      - get-tag
+    if: ${{ needs.release-npm.outputs.published == 'true' }}
+    uses: ./.github/workflows/publish-github-release.yml
+    with:
+      tag_name: ${{ needs.get-tag.outputs.tag_name }}
+    secrets: inherit

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -407,37 +407,37 @@ We describe each below.
 - Next, [make a release on GitHub](#release-github).
 
 (release-github)=
-#### Make a release on GitHub
+#### Automated releases on GitHub
 
-When we publish a new release to NPM, we also make a release on GitHub and share it for our user community. Here's a brief process for what to do:
+After a successful NPM release, our [`release.yml` workflow](https://github.com/jupyter-book/mystmd/blob/main/.github/workflows/publish-github-release.yml) will automatically create a new GitHub Release. The release notes are generated using [`github-activity`](https://github.com/cheukting/github-activity) and include a summary of all merged PRs and commits since the previous release.
 
-- **Confirm a release has been made**. Go to [the Tags page](https://github.com/jupyter-book/mystmd/tags) and look for a tag from the latest release.
-- **Create a release on GitHub**. Go to [the Releases page](https://github.com/jupyter-book/mystmd/releases) and then click **`Draft a new release`**.
-  - The **title** should be the version from the tag. So if the tag was `mystmd@1.3.26`, the title is `v1.3.26`.
-  - Click **Choose a tag** and link it against the tag for the latest release to NPM (the one you discovered in the first step).
-  - Click **Generate release notes** so that GitHub automatically generates a list of the merged PRs and contributors.
-  - Categorize the PRs into `Features`, `Fixes`, `Documentation`, and `Maintenance` as you wish. (this is optional)
-  - For any major changes or new functionality, write a brief description that helps a user understand why it's important and how to learn more. (this is optional)
-  - Write a one or two sentence summary of the big ideas in this release at the top. (this is optional).
-- **Publish the release**. Do this by clicking the **`Publish release`** button at the bottom.
-- **Write a brief post for sharing the release.** This helps others learn about it, and follow the links for more information. Here's a snippet you can copy/paste:
+**Maintainers are encouraged to review the new GitHub Release and edit the description as needed.** For example, you may want to add an executive summary, highlight important changes, or clarify upgrade instructions for users.
 
-  ```md
-  TITLE: 🚀 Release: MySTMD v1.3.26
+You can find the latest releases at: https://github.com/jupyter-book/mystmd/releases
 
-  BODY:
-  The [Jupyter Book project](https://compass.jupyterbook.org) recently made a new release! 👇
+When you've confirmed the release has been made, consider sharing it for others to discover! 
 
-  [MySTMD v1.3.26](https://github.com/jupyter-book/mystmd/releases/tag/mystmd%401.3.26)
+:::{note} Here's an announcement snippet you can copy/paste
+:class: dropdown
+```md
+TITLE: 🚀 Release: MySTMD v1.3.26
 
-  See the link above for the release notes on GitHub! Many thanks to the [Jupyter Book team](https://compass.jupyterbook.org/team) for stewarding our development and this release.
-  ```
+BODY:
+The [Jupyter Book project](https://compass.jupyterbook.org) recently made a new release! 👇
 
-- **Share the release post in Jupyter-adjacent spaces**. Here are a few places that are worth sharing (you can just copy/paste the same text into each):
-  - [The MyST Discord](https://discord.mystmd.org/)
-  - [The Jupyter Zulip Forum](https://https://jupyter.zulipchat.com)
-  - [The Jupyter Discourse](https://discourse.jupyter.org)
-  - Social media spaces of your choosing.
+[MySTMD v1.3.26](https://github.com/jupyter-book/mystmd/releases/tag/mystmd%401.3.26)
+
+See the link above for the release notes on GitHub! Many thanks to the [Jupyter Book team](https://compass.jupyterbook.org/team) for stewarding our development and this release.
+```
+:::
+
+
+**Here are a few Jupyter-adjacent spaces to share with** (you can just copy/paste the same text into each):
+
+- [The MyST Discord](https://discord.mystmd.org/)
+- [The Jupyter Zulip Forum](https://https://jupyter.zulipchat.com)
+- [The Jupyter Discourse](https://discourse.jupyter.org)
+- Social media spaces of your choosing.
 
 (release-myst-theme)=
 ### Make a release of the `myst-theme`


### PR DESCRIPTION
This adds a reusable workflow for publishing GitHub Releases with automatically generated release notes, it runs each time the `release.yml` action completes. It means we won't have to manually create GitHub releases, though we can always edit the release notes ourselves if we want to clean them up.

It defines this in a new action so that we can call it via a workflow_dispatch if we want to - it will let us insert the tag to use as the "start date" for releases.

So the new workflow for releases would be to just merge the changesets PR, wait for the workflow to complete, and a new release should now exist on GitHub.