### PR TITLE
DOC: Adding upgrade guide link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ TL;DR
 : **Yes**, `mystmd` is compatible with [intersphinx](#intersphinx) even though it is written in JavaScript not Python!
 : Jupyter Book and `mystmd` have **overlap** in the ability to create online books like this one. `mystmd` has some extra capabilities for [cross-references](./cross-references.md), interactivity and [performance](./accessibility-and-performance.md).
 :
-: For an upgrade guide from v1 to v2, please visit this [JupyterBook documentation page](https://next.jupyterbook.org/upgrade/).
+: For more information see this [upgrade guide from Jupyter Book v1 to v2](https://next.jupyterbook.org/upgrade/).
 :::
 
 ## Cite `mystmd`

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,8 @@ TL;DR
 : **Yes**, you can use `mystmd` with your Jupyter Book! `mystmd` can create [scientific PDFs](./creating-pdf-documents.md) and can natively read the [`_toc.yml`](./table-of-contents.md) as well as all of your existing MyST Markdown content and [Jupyter Notebooks](./interactive-notebooks.ipynb).
 : **Yes**, `mystmd` is compatible with [intersphinx](#intersphinx) even though it is written in JavaScript not Python!
 : Jupyter Book and `mystmd` have **overlap** in the ability to create online books like this one. `mystmd` has some extra capabilities for [cross-references](./cross-references.md), interactivity and [performance](./accessibility-and-performance.md).
+:
+: For an upgrade guide from v1 to v2, please visit this [JupyterBook documentation page](https://next.jupyterbook.org/upgrade/).
 :::
 
 ## Cite `mystmd`


### PR DESCRIPTION
I am still having a hard time to find where the upgrade docs is located, and even google is not very useful to find it.