### PR TITLE
:camel: Enable alternate YAML build config

### DIFF
--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -32,6 +32,7 @@ type FormatBuildOpts = {
   all?: boolean;
   force?: boolean;
   output?: string;
+  config?: string;
 };
 
 export type BuildOpts = FormatBuildOpts & CollectionOptions & RunExportOptions & StartOptions;
@@ -220,6 +221,12 @@ function extToKind(ext: string): string {
 
 export async function build(session: ISession, files: string[], opts: BuildOpts) {
   const { site, all, watch, writeDOIBib } = opts;
+
+  // Override default myst.yml if --config option is given.
+  if (opts.config !== undefined) {
+    session.configFiles[0] = opts.config;
+  }
+
   const performSiteBuild = all || (files.length === 0 && exportSite(session, opts)) || writeDOIBib;
   const exportOptionsList = await collectAllBuildExportOptions(session, files, opts);
   // TODO: generalize and pull this out!

--- a/packages/myst-cli/src/cli/build.ts
+++ b/packages/myst-cli/src/cli/build.ts
@@ -20,6 +20,7 @@ import {
   makeMaxSizeWebpOption,
   makeDOIBibOption,
   makeCffOption,
+  makeConfigOption,
 } from './options.js';
 import { readableName } from '../utils/whiteLabelling.js';
 
@@ -50,6 +51,7 @@ export function makeBuildCommand() {
     .addOption(makeCheckLinksOption())
     .addOption(makeStrictOption())
     .addOption(makeCIOption())
-    .addOption(makeMaxSizeWebpOption());
+    .addOption(makeMaxSizeWebpOption())
+    .addOption(makeConfigOption());
   return command;
 }

--- a/packages/myst-cli/src/cli/options.ts
+++ b/packages/myst-cli/src/cli/options.ts
@@ -175,3 +175,11 @@ export function makeTemplatesOption() {
     'Delete the _build/templates folder where downloaded templates are saved',
   ).default(false);
 }
+
+export function makeConfigOption() {
+  return new Option(
+    '--config <config-file>',
+    'Use this YAML config file, instead of the default myst.yml',
+  ).default(undefined);
+}
+

--- a/packages/myst-cli/src/config.spec.ts
+++ b/packages/myst-cli/src/config.spec.ts
@@ -1,9 +1,4 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest';
-import memfs from 'memfs';
-import { Session } from '../session';
-import { projectFromPath } from './fromPath';
-import { pagesFromSphinxTOC, projectFromSphinxTOC } from './fromTOC';
-import { tocFromProject } from './toTOC';
+import { describe, expect, it } from 'vitest';
 import { handleDeprecatedFields } from './config';
 import { VFile } from 'vfile';
 


### PR DESCRIPTION
Add `--config` option to the `myst build` command to override the default `myst.yml` config file.

Closes https://github.com/jupyter-book/mystmd/issues/1817