### PR TITLE
🐛 mdast lists need to be in paragraphs

### DIFF
--- a/.changeset/smart-feet-jump.md
+++ b/.changeset/smart-feet-jump.md
@@ -1,0 +1,5 @@
+---
+"myst-parser": patch
+---
+
+Transform lists that have non-block content (text, italic, inlineCode, etc.) to ensure they are in paragraphs.

--- a/packages/myst-parser/package.json
+++ b/packages/myst-parser/package.json
@@ -31,7 +31,7 @@
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "lint": "eslint \"src/**/*.ts\" -c .eslintrc.cjs",
+    "lint": "eslint \"src/**/!(*.spec).ts\" -c ./.eslintrc.cjs",
     "lint:format": "prettier --check src/*.ts src/**/*.ts",
     "build:bundle:browser": "esbuild bundle/myst.ts --bundle --outfile=dist/myst.min.js --platform=browser --minify",
     "build:esm": "tsc --project ./src/tsconfig.json",

--- a/packages/myst-parser/src/fromMarkdown.ts
+++ b/packages/myst-parser/src/fromMarkdown.ts
@@ -24,6 +24,7 @@ const UNHIDDEN_TOKENS = new Set([
 export type MdastOptions = {
   handlers?: Record<string, TokenHandlerSpec>;
   hoistSingleImagesOutofParagraphs?: boolean;
+  listItemParagraphs?: boolean;
   nestBlocks?: boolean;
 };
 

--- a/packages/myst-parser/src/tokensToMyst.ts
+++ b/packages/myst-parser/src/tokensToMyst.ts
@@ -8,6 +8,7 @@ import { selectAll } from 'unist-util-select';
 import { u } from 'unist-builder';
 import { MarkdownParseState, withoutTrailingNewline } from './fromMarkdown.js';
 import type { MdastOptions, TokenHandlerSpec } from './fromMarkdown.js';
+import { listItemParagraphsTransform } from './transforms/index.js';
 
 export function computeAmsmathTightness(
   src: string,
@@ -519,6 +520,7 @@ function nestSingleImagesIntoParagraphs(tree: GenericParent) {
 const defaultOptions: MdastOptions = {
   handlers: defaultMdast,
   hoistSingleImagesOutofParagraphs: true,
+  listItemParagraphs: true,
   nestBlocks: true,
 };
 
@@ -570,6 +572,11 @@ export function tokensToMyst(
       }
     }
   });
+
+  if (opts.listItemParagraphs) {
+    // Ensure that listItems that are not paragraphs are wrapped in paragraphs
+    listItemParagraphsTransform(tree);
+  }
 
   // Move crossReference text value to children
   visit(tree, 'crossReference', (node: GenericNode) => {

--- a/packages/myst-parser/src/transforms/index.ts
+++ b/packages/myst-parser/src/transforms/index.ts
@@ -1,0 +1,1 @@
+export { listItemParagraphsTransform } from './listItemParagraphs.js';

--- a/packages/myst-parser/src/transforms/listItemParagraphs.spec.ts
+++ b/packages/myst-parser/src/transforms/listItemParagraphs.spec.ts
@@ -1,0 +1,483 @@
+import { describe, expect, test } from 'vitest';
+import type { GenericParent } from 'myst-common';
+import { listItemParagraphsTransform } from './listItemParagraphs.js';
+
+describe('listItemParagraphsTransform', () => {
+  test('should wrap phrasing content in paragraph when only phrasing content exists', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [
+                { type: 'text', value: 'simple text' },
+                { type: 'inlineCode', value: 'code' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    listItemParagraphsTransform(tree);
+
+    const listItem = tree.children[0].children[0];
+    expect(listItem.children).toHaveLength(1);
+    expect(listItem.children[0]).toEqual({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'simple text' },
+        { type: 'inlineCode', value: 'code' },
+      ],
+    });
+  });
+
+  test('should handle list items with only flow content (no change)', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [
+                {
+                  type: 'blockquote',
+                  children: [{ type: 'text', value: 'quoted content' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const originalTree = JSON.parse(JSON.stringify(tree));
+    listItemParagraphsTransform(tree);
+
+    // Should not change when only flow content (no phrasing content at top level)
+    expect(tree).toEqual(originalTree);
+  });
+
+  test('should wrap phrasing content in paragraph when mixed with flow content', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [
+                { type: 'text', value: 'inline ' },
+                { type: 'inlineCode', value: 'code' },
+                {
+                  type: 'list',
+                  ordered: false,
+                  children: [
+                    {
+                      type: 'listItem',
+                      children: [{ type: 'text', value: 'nested' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    listItemParagraphsTransform(tree);
+
+    const listItem = tree.children[0].children[0];
+    expect(listItem.children).toHaveLength(2);
+    expect(listItem.children[0]).toEqual({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'inline ' },
+        { type: 'inlineCode', value: 'code' },
+      ],
+    });
+    expect(listItem.children[1].type).toBe('list');
+  });
+
+  test('should handle multiple consecutive phrasing content groups', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [
+                { type: 'text', value: 'first group' },
+                { type: 'emphasis', children: [{ type: 'text', value: 'emphasized' }] },
+                {
+                  type: 'list',
+                  ordered: false,
+                  children: [
+                    {
+                      type: 'listItem',
+                      children: [{ type: 'text', value: 'nested' }],
+                    },
+                  ],
+                },
+                { type: 'text', value: 'second group' },
+                { type: 'inlineCode', value: 'more code' },
+                {
+                  type: 'blockquote',
+                  children: [{ type: 'text', value: 'quoted' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    listItemParagraphsTransform(tree);
+
+    const listItem = tree.children[0].children[0];
+    expect(listItem.children).toHaveLength(4);
+
+    // First paragraph with first phrasing group
+    expect(listItem.children[0]).toEqual({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'first group' },
+        { type: 'emphasis', children: [{ type: 'text', value: 'emphasized' }] },
+      ],
+    });
+
+    // Flow content (list) should be unchanged
+    expect(listItem.children[1].type).toBe('list');
+
+    // Second paragraph with second phrasing group
+    expect(listItem.children[2]).toEqual({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'second group' },
+        { type: 'inlineCode', value: 'more code' },
+      ],
+    });
+
+    // Flow content (blockquote) should be unchanged
+    expect(listItem.children[3].type).toBe('blockquote');
+  });
+
+  test('should handle phrasing content at the end of list item', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [
+                {
+                  type: 'list',
+                  ordered: false,
+                  children: [
+                    {
+                      type: 'listItem',
+                      children: [{ type: 'text', value: 'nested' }],
+                    },
+                  ],
+                },
+                { type: 'text', value: 'text at end' },
+                { type: 'inlineCode', value: 'code at end' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    listItemParagraphsTransform(tree);
+
+    const listItem = tree.children[0].children[0];
+    expect(listItem.children).toHaveLength(2);
+
+    // Flow content should be first
+    expect(listItem.children[0].type).toBe('list');
+
+    // Paragraph with phrasing content should be last
+    expect(listItem.children[1]).toEqual({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'text at end' },
+        { type: 'inlineCode', value: 'code at end' },
+      ],
+    });
+  });
+
+  test('should handle empty list items (no change)', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const originalTree = JSON.parse(JSON.stringify(tree));
+    listItemParagraphsTransform(tree);
+
+    expect(tree).toEqual(originalTree);
+  });
+
+  test('should handle list items with no children (no change)', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+            },
+          ],
+        },
+      ],
+    };
+
+    const originalTree = JSON.parse(JSON.stringify(tree));
+    listItemParagraphsTransform(tree);
+
+    expect(tree).toEqual(originalTree);
+  });
+
+  test('should handle complex nested structures', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [
+                { type: 'text', value: 'start ' },
+                { type: 'strong', children: [{ type: 'text', value: 'bold' }] },
+                {
+                  type: 'list',
+                  ordered: true,
+                  children: [
+                    {
+                      type: 'listItem',
+                      children: [{ type: 'text', value: 'nested ordered' }],
+                    },
+                  ],
+                },
+                { type: 'inlineCode', value: 'middle' },
+                {
+                  type: 'blockquote',
+                  children: [{ type: 'text', value: 'quoted content' }],
+                },
+                { type: 'text', value: ' end' },
+                {
+                  type: 'link',
+                  url: 'http://example.com',
+                  children: [{ type: 'text', value: 'link' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    listItemParagraphsTransform(tree);
+
+    const listItem = tree.children[0].children[0];
+    expect(listItem.children).toHaveLength(5);
+
+    // First paragraph with first phrasing group
+    expect(listItem.children[0]).toEqual({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'start ' },
+        { type: 'strong', children: [{ type: 'text', value: 'bold' }] },
+      ],
+    });
+
+    // Flow content (list) should be unchanged
+    expect(listItem.children[1].type).toBe('list');
+
+    // Second paragraph with middle phrasing content
+    expect(listItem.children[2]).toEqual({
+      type: 'paragraph',
+      children: [{ type: 'inlineCode', value: 'middle' }],
+    });
+
+    // Flow content (blockquote) should be unchanged
+    expect(listItem.children[3].type).toBe('blockquote');
+
+    // Third paragraph with final phrasing group
+    expect(listItem.children[4]).toEqual({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: ' end' },
+        { type: 'link', url: 'http://example.com', children: [{ type: 'text', value: 'link' }] },
+      ],
+    });
+  });
+
+  test('should handle all phrasing content types', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [
+                { type: 'text', value: 'text' },
+                { type: 'emphasis', children: [{ type: 'text', value: 'emphasis' }] },
+                { type: 'strong', children: [{ type: 'text', value: 'strong' }] },
+                { type: 'delete', children: [{ type: 'text', value: 'delete' }] },
+                { type: 'inlineCode', value: 'inlineCode' },
+                {
+                  type: 'link',
+                  url: 'http://example.com',
+                  children: [{ type: 'text', value: 'link' }],
+                },
+                { type: 'image', url: 'image.png', alt: 'image' },
+                { type: 'break' },
+                {
+                  type: 'list',
+                  ordered: false,
+                  children: [
+                    {
+                      type: 'listItem',
+                      children: [{ type: 'text', value: 'nested' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    listItemParagraphsTransform(tree);
+
+    const listItem = tree.children[0].children[0];
+    expect(listItem.children).toHaveLength(2);
+
+    // All phrasing content should be wrapped in one paragraph
+    expect(listItem.children[0]).toEqual({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'text' },
+        { type: 'emphasis', children: [{ type: 'text', value: 'emphasis' }] },
+        { type: 'strong', children: [{ type: 'text', value: 'strong' }] },
+        { type: 'delete', children: [{ type: 'text', value: 'delete' }] },
+        { type: 'inlineCode', value: 'inlineCode' },
+        { type: 'link', url: 'http://example.com', children: [{ type: 'text', value: 'link' }] },
+        { type: 'image', url: 'image.png', alt: 'image' },
+        { type: 'break' },
+      ],
+    });
+
+    // Flow content should be unchanged
+    expect(listItem.children[1].type).toBe('list');
+  });
+
+  test('should handle single phrasing content node', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [{ type: 'text', value: 'single text node' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    listItemParagraphsTransform(tree);
+
+    const listItem = tree.children[0].children[0];
+    expect(listItem.children).toHaveLength(1);
+    expect(listItem.children[0]).toEqual({
+      type: 'paragraph',
+      children: [{ type: 'text', value: 'single text node' }],
+    });
+  });
+
+  test('should handle nested list items with phrasing content', () => {
+    const tree: GenericParent = {
+      type: 'root',
+      children: [
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [
+                {
+                  type: 'list',
+                  ordered: true,
+                  children: [
+                    {
+                      type: 'listItem',
+                      children: [
+                        { type: 'text', value: 'nested text' },
+                        { type: 'inlineCode', value: 'nested code' },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    listItemParagraphsTransform(tree);
+
+    // The nested list item should have its phrasing content wrapped in a paragraph
+    const nestedListItem = tree.children[0].children[0].children[0].children[0];
+    expect(nestedListItem.children).toHaveLength(1);
+    expect(nestedListItem.children[0]).toEqual({
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'nested text' },
+        { type: 'inlineCode', value: 'nested code' },
+      ],
+    });
+  });
+});

--- a/packages/myst-parser/src/transforms/listItemParagraphs.ts
+++ b/packages/myst-parser/src/transforms/listItemParagraphs.ts
@@ -1,0 +1,65 @@
+import type { GenericNode, GenericParent } from 'myst-common';
+import { selectAll } from 'unist-util-select';
+
+export function listItemParagraphsTransform(tree: GenericParent) {
+  // Fix mixed content in list items
+  selectAll('listItem', tree).forEach((node: GenericNode) => {
+    if (!node.children || node.children.length === 0) return;
+
+    // Define phrasing content types
+    const phrasingTypes = new Set([
+      'text',
+      'emphasis',
+      'strong',
+      'delete',
+      'link',
+      'image',
+      'break',
+      'subscript',
+      'superscript',
+      'smallcaps',
+      'inlineCode',
+      'inlineMath',
+      'mystRole',
+      'html',
+    ]);
+
+    // Check if this list item has any phrasing content
+    const hasPhrasingContent = node.children.some((child: GenericNode) =>
+      phrasingTypes.has(child.type),
+    );
+
+    if (hasPhrasingContent) {
+      // Group consecutive phrasing content into paragraphs
+      const newChildren: GenericNode[] = [];
+      let currentPhrasingGroup: GenericNode[] = [];
+
+      node.children.forEach((child: GenericNode) => {
+        if (phrasingTypes.has(child.type)) {
+          currentPhrasingGroup.push(child);
+        } else {
+          // If we have accumulated phrasing content, wrap it in a paragraph
+          if (currentPhrasingGroup.length > 0) {
+            newChildren.push({
+              type: 'paragraph',
+              children: currentPhrasingGroup,
+            });
+            currentPhrasingGroup = [];
+          }
+          // Add the flow content as-is
+          newChildren.push(child);
+        }
+      });
+
+      // Don't forget any remaining phrasing content
+      if (currentPhrasingGroup.length > 0) {
+        newChildren.push({
+          type: 'paragraph',
+          children: currentPhrasingGroup,
+        });
+      }
+
+      node.children = newChildren;
+    }
+  });
+}

--- a/packages/myst-parser/src/tsconfig.json
+++ b/packages/myst-parser/src/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig/base.json",
   "compilerOptions": {
-    "outDir": "../dist"
+    "outDir": "../dist",
   },
   "include": ["."],
-  "exclude": ["dist", "build", "node_modules", "src/**/*.spec.ts", "tests"]
+  "exclude": ["dist", "build", "node_modules", "**/*.spec.ts", "tests"],
 }

--- a/packages/myst-parser/tests/commonmark.spec.ts
+++ b/packages/myst-parser/tests/commonmark.spec.ts
@@ -79,6 +79,7 @@ describe('Common Mark Spec with unified', () => {
       },
       mdast: {
         hoistSingleImagesOutofParagraphs: false,
+        listItemParagraphs: false,
       },
       extensions: {
         frontmatter: false, // Frontmatter screws with some tests!

--- a/packages/myst-parser/tests/directives/table.yml
+++ b/packages/myst-parser/tests/directives/table.yml
@@ -62,46 +62,64 @@ cases:
                         - type: tableCell
                           header: true
                           children:
-                            - type: text
-                              value: a
+                            - type: paragraph
+                              children:
+                                - type: text
+                                  value: a
                         - type: tableCell
                           header: true
                           children:
-                            - type: text
-                              value: b
+                            - type: paragraph
+                              children:
+                                - type: text
+                                  value: b
                         - type: tableCell
                           header: true
                           children:
-                            - type: text
-                              value: c
+                            - type: paragraph
+                              children:
+                                - type: text
+                                  value: c
                     - type: tableRow
                       children:
                         - type: tableCell
                           header: true
                           children:
-                            - type: text
-                              value: '1'
+                            - type: paragraph
+                              children:
+                                - type: text
+                                  value: '1'
                         - type: tableCell
                           header: true
                           children:
-                            - type: text
-                              value: '2'
+                            - type: paragraph
+                              children:
+                                - type: text
+                                  value: '2'
                         - type: tableCell
                           header: true
                           children:
-                            - type: text
-                              value: '3'
+                            - type: paragraph
+                              children:
+                                - type: text
+                                  value: '3'
                     - type: tableRow
                       children:
                         - type: tableCell
                           children:
-                            - type: text
-                              value: '4'
+                            - type: paragraph
+                              children:
+                                - type: text
+                                  value: '4'
                         - type: tableCell
                           children:
-                            - type: text
-                              value: '5'
+                            - type: paragraph
+                              children:
+                                - type: text
+                                  value: '5'
                         - type: tableCell
                           children:
-                            - type: text
-                              value: '6'
+                            - type: paragraph
+                              children:
+                                - type: text
+                                  value: '6'

--- a/packages/myst-parser/tests/myst.spec.ts
+++ b/packages/myst-parser/tests/myst.spec.ts
@@ -137,6 +137,7 @@ describe('Testing myst --> mdast conversions', () => {
             mystParse(myst, {
               mdast: {
                 hoistSingleImagesOutofParagraphs: false,
+                listItemParagraphs: false,
                 nestBlocks: false,
               },
               extensions: {

--- a/packages/myst-parser/tests/tasklists.spec.ts
+++ b/packages/myst-parser/tests/tasklists.spec.ts
@@ -12,12 +12,12 @@ describe('Parses GFM Tasklists', () => {
     const task3 = (mdast.children[0] as List).children[2] as ListItem;
     expect(task1.type).toBe('listItem');
     expect(task1.checked).toBe(false);
-    expect((task1.children[0] as any).value).toBe('task 1');
+    expect((task1.children[0] as any).children[0].value).toBe('task 1');
     expect(task2.type).toBe('listItem');
     expect(task2.checked).toBe(true);
-    expect((task2.children[0] as any).value).toBe('task 2');
+    expect((task2.children[0] as any).children[0].value).toBe('task 2');
     expect(task3.type).toBe('listItem');
     expect(task3.checked).toBe(undefined);
-    expect((task3.children[0] as any).value).toBe('not a task');
+    expect((task3.children[0] as any).children[0].value).toBe('not a task');
   });
 });

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -241,7 +241,11 @@ const handlers: Record<string, Handler> = {
   },
   listItem(node, state) {
     state.write('\\item ');
-    state.renderChildren(node, true);
+    if (node.children?.[0]?.type === 'paragraph' && node.children.length === 1) {
+      state.renderChildren(node.children[0], true);
+    } else {
+      state.renderChildren(node, true);
+    }
     state.write('\n');
   },
   thematicBreak(node, state) {

--- a/packages/myst-to-tex/tests/basic.yml
+++ b/packages/myst-to-tex/tests/basic.yml
@@ -461,3 +461,28 @@ cases:
                   value: markdown
     latex: |-
       Some \% other \textit{markdown}
+  - title: list item with and without paragraph
+    description: |
+      The list item should not add space if there is only a single paragraph.
+      This is resilient to a listItem not having a paragraph as the child.
+    mdast:
+      type: root
+      children:
+        - type: list
+          ordered: false
+          children:
+            - type: listItem
+              children:
+                - type: text
+                  value: 'A list item'
+            - type: listItem
+              children:
+                - type: paragraph
+                  children:
+                    - type: text
+                      value: 'A list item in a paragraph'
+    latex: |-
+      \begin{itemize}
+      \item A list item
+      \item A list item in a paragraph
+      \end{itemize}

--- a/packages/myst-to-typst/tests/basic.yml
+++ b/packages/myst-to-typst/tests/basic.yml
@@ -397,3 +397,26 @@ cases:
                   value: markdown
     typst: |-
       Some % other _markdown_
+  - title: list item with and without paragraph
+    description: |
+      The list item should not add space if there is only a single paragraph.
+      This is resilient to a listItem not having a paragraph as the child.
+    mdast:
+      type: root
+      children:
+        - type: list
+          ordered: false
+          children:
+            - type: listItem
+              children:
+                - type: text
+                  value: 'A list item'
+            - type: listItem
+              children:
+                - type: paragraph
+                  children:
+                    - type: text
+                      value: 'A list item in a paragraph'
+    typst: |-
+      - A list item
+      - A list item in a paragraph

--- a/packages/mystmd/tests/indices/outputs/recipes.json
+++ b/packages/mystmd/tests/indices/outputs/recipes.json
@@ -170,12 +170,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "2 boneless, skinless chicken breasts",
-                    "position": {
-                      "start": { "line": 19, "column": 1 },
-                      "end": { "line": 19, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "2 boneless, skinless chicken breasts",
+                        "position": {
+                          "start": { "line": 19, "column": 1 },
+                          "end": { "line": 19, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -188,12 +193,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "1 tablespoon olive oil",
-                    "position": {
-                      "start": { "line": 20, "column": 1 },
-                      "end": { "line": 20, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "1 tablespoon olive oil",
+                        "position": {
+                          "start": { "line": 20, "column": 1 },
+                          "end": { "line": 20, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -206,12 +216,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Salt and pepper to taste",
-                    "position": {
-                      "start": { "line": 21, "column": 1 },
-                      "end": { "line": 21, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Salt and pepper to taste",
+                        "position": {
+                          "start": { "line": 21, "column": 1 },
+                          "end": { "line": 21, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -224,12 +239,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Optional: lemon juice, garlic powder, or your favorite seasoning",
-                    "position": {
-                      "start": { "line": 22, "column": 1 },
-                      "end": { "line": 22, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Optional: lemon juice, garlic powder, or your favorite seasoning",
+                        "position": {
+                          "start": { "line": 22, "column": 1 },
+                          "end": { "line": 22, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               }
@@ -276,12 +296,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Preheat your grill to medium-high heat.",
-                    "position": {
-                      "start": { "line": 26, "column": 1 },
-                      "end": { "line": 26, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Preheat your grill to medium-high heat.",
+                        "position": {
+                          "start": { "line": 26, "column": 1 },
+                          "end": { "line": 26, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -294,12 +319,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Brush the chicken breasts with olive oil and season with salt, pepper, and any optional seasonings.",
-                    "position": {
-                      "start": { "line": 27, "column": 1 },
-                      "end": { "line": 27, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Brush the chicken breasts with olive oil and season with salt, pepper, and any optional seasonings.",
+                        "position": {
+                          "start": { "line": 27, "column": 1 },
+                          "end": { "line": 27, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -312,12 +342,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Grill the chicken for about 6-7 minutes on each side, or until the internal temperature reaches 165°F (75°C).",
-                    "position": {
-                      "start": { "line": 28, "column": 1 },
-                      "end": { "line": 28, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Grill the chicken for about 6-7 minutes on each side, or until the internal temperature reaches 165°F (75°C).",
+                        "position": {
+                          "start": { "line": 28, "column": 1 },
+                          "end": { "line": 28, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -330,12 +365,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Let the chicken rest for a few minutes before serving.",
-                    "position": {
-                      "start": { "line": 29, "column": 1 },
-                      "end": { "line": 29, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Let the chicken rest for a few minutes before serving.",
+                        "position": {
+                          "start": { "line": 29, "column": 1 },
+                          "end": { "line": 29, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               }
@@ -403,12 +443,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "2 eggs",
-                    "position": {
-                      "start": { "line": 35, "column": 1 },
-                      "end": { "line": 35, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "2 eggs",
+                        "position": {
+                          "start": { "line": 35, "column": 1 },
+                          "end": { "line": 35, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -421,12 +466,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "1 tablespoon milk (optional)",
-                    "position": {
-                      "start": { "line": 36, "column": 1 },
-                      "end": { "line": 36, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "1 tablespoon milk (optional)",
+                        "position": {
+                          "start": { "line": 36, "column": 1 },
+                          "end": { "line": 36, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -439,12 +489,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Salt and pepper to taste",
-                    "position": {
-                      "start": { "line": 37, "column": 1 },
-                      "end": { "line": 37, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Salt and pepper to taste",
+                        "position": {
+                          "start": { "line": 37, "column": 1 },
+                          "end": { "line": 37, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -457,12 +512,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "1 teaspoon butter",
-                    "position": {
-                      "start": { "line": 38, "column": 1 },
-                      "end": { "line": 38, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "1 teaspoon butter",
+                        "position": {
+                          "start": { "line": 38, "column": 1 },
+                          "end": { "line": 38, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               }
@@ -509,12 +569,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Crack the eggs into a bowl, add milk (if using), and beat until well combined.",
-                    "position": {
-                      "start": { "line": 42, "column": 1 },
-                      "end": { "line": 42, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Crack the eggs into a bowl, add milk (if using), and beat until well combined.",
+                        "position": {
+                          "start": { "line": 42, "column": 1 },
+                          "end": { "line": 42, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -527,12 +592,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Melt the butter in a non-stick skillet over medium heat.",
-                    "position": {
-                      "start": { "line": 43, "column": 1 },
-                      "end": { "line": 43, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Melt the butter in a non-stick skillet over medium heat.",
+                        "position": {
+                          "start": { "line": 43, "column": 1 },
+                          "end": { "line": 43, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -545,12 +615,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Pour in the eggs and cook, stirring gently, until they are just set.",
-                    "position": {
-                      "start": { "line": 44, "column": 1 },
-                      "end": { "line": 44, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Pour in the eggs and cook, stirring gently, until they are just set.",
+                        "position": {
+                          "start": { "line": 44, "column": 1 },
+                          "end": { "line": 44, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               },
@@ -563,12 +638,17 @@
                 },
                 "children": [
                   {
-                    "type": "text",
-                    "value": "Season with salt and pepper to taste, then serve.",
-                    "position": {
-                      "start": { "line": 45, "column": 1 },
-                      "end": { "line": 45, "column": 1 }
-                    }
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Season with salt and pepper to taste, then serve.",
+                        "position": {
+                          "start": { "line": 45, "column": 1 },
+                          "end": { "line": 45, "column": 1 }
+                        }
+                      }
+                    ]
                   }
                 ]
               }


### PR DESCRIPTION
This transforms listItems after parsing with markdown-it, to ensure that they are mdast compliant. This is important in formatting (e.g. #1948). Without this each inline element of the list item will be on a different line.

Fixes #1957 
