### PR TITLE
📖 Fix typo in frontmatter.md for CC-BY-NC-SA license

### DIFF
--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -605,7 +605,7 @@ If selecting a license from the [SPDX License List](https://spdx.org/licenses/),
 
 * - - `CC-BY-4.0`
     - `CC-BY-SA-4.0`
-    - `CC-BY-N-SA-4.0`
+    - `CC-BY-NC-SA-4.0`
     - `CC0-1.0`
 
   - - `MIT`


### PR DESCRIPTION
One-liner typo fix for the documentation: the correct SPDX license identifier for CC BY-NC-SA 4.0 is `CC-BY-NC-SA-4.0`, not `CC-BY-N-SA-4.0` (missing the `C`). Without the `C`, the license information is not found and the license information on rendered page is undefined.