### PR TITLE
🐛 List elements with `footnoteReference`s as children

### DIFF
--- a/.changeset/smooth-insects-exercise.md
+++ b/.changeset/smooth-insects-exercise.md
@@ -1,0 +1,5 @@
+---
+"myst-parser": patch
+---
+
+Add footnoteReference to known list elements inline children.

--- a/packages/myst-parser/src/transforms/listItemParagraphs.spec.ts
+++ b/packages/myst-parser/src/transforms/listItemParagraphs.spec.ts
@@ -280,6 +280,7 @@ describe('listItemParagraphsTransform', () => {
               type: 'listItem',
               children: [
                 { type: 'text', value: 'start ' },
+                { type: 'footnoteReference', id: '1' },
                 { type: 'strong', children: [{ type: 'text', value: 'bold' }] },
                 {
                   type: 'list',
@@ -319,6 +320,7 @@ describe('listItemParagraphsTransform', () => {
       type: 'paragraph',
       children: [
         { type: 'text', value: 'start ' },
+        { type: 'footnoteReference', id: '1' },
         { type: 'strong', children: [{ type: 'text', value: 'bold' }] },
       ],
     });

--- a/packages/myst-parser/src/transforms/listItemParagraphs.ts
+++ b/packages/myst-parser/src/transforms/listItemParagraphs.ts
@@ -21,6 +21,9 @@ export function listItemParagraphsTransform(tree: GenericParent) {
       'inlineCode',
       'inlineMath',
       'mystRole',
+      'footnoteReference',
+      'crossReference',
+      'cite',
       'html',
     ]);
 


### PR DESCRIPTION
Before `footnoteReferences` are not treated as inline elements:
<img width="1318" height="224" alt="image" src="https://github.com/user-attachments/assets/8f75791c-6a63-47d5-9256-3145de3e0751" />


After:
<img width="860" height="68" alt="image" src="https://github.com/user-attachments/assets/b32ab7a8-c6b3-4050-b67e-2bf075a69066" />
