### PR TITLE
🔐 Improve security for localhost

### DIFF
--- a/.changeset/light-coins-draw.md
+++ b/.changeset/light-coins-draw.md
@@ -1,0 +1,5 @@
+---
+"myst-cli": patch
+---
+
+Ensure host is only for local development and is not exposed on local network.

--- a/packages/myst-cli/src/build/site/logger.ts
+++ b/packages/myst-cli/src/build/site/logger.ts
@@ -2,7 +2,10 @@ import chalk from 'chalk';
 import type { LoggerDE } from 'myst-cli-utils';
 import type { ISession } from '../../session/types.js';
 
-export function createServerLogger(session: ISession, ready: () => void): LoggerDE {
+export function createServerLogger(
+  session: ISession,
+  opts: { host: string; ready: () => void },
+): LoggerDE {
   const logger = {
     debug(data: string) {
       const line = data.trim();
@@ -11,8 +14,8 @@ export function createServerLogger(session: ISession, ready: () => void): Logger
       if (line.includes('started at http://')) {
         const [, ipAndPort] = line.split('http://');
         const port = ipAndPort.split(':')[1].replace(/[^0-9]/g, '');
-        const local = `http://localhost:${port}`;
-        ready();
+        const local = `http://${opts.host}:${port}`;
+        opts.ready();
         session.log.info(
           `\n🔌 Server started on port ${port}!  🥳 🎉\n\n\n\t👉  ${chalk.green(local)}  👈\n\n`,
         );

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -16,10 +16,12 @@ import { buildSite } from './prepare.js';
 import { installSiteTemplate, getSiteTemplate } from './template.js';
 import { watchContent } from './watch.js';
 
+const DEFAULT_HOST = 'localhost';
 const DEFAULT_START_COMMAND = 'npm run start';
 
 type ServerOptions = {
   serverPort?: number;
+  serverHost?: string;
 };
 
 export type StartOptions = ProcessSiteOptions &
@@ -36,6 +38,7 @@ export type StartOptions = ProcessSiteOptions &
  * Creates a content server and a websocket that can reload and log messages to the client.
  */
 export async function startContentServer(session: ISession, opts?: ServerOptions) {
+  const host = opts?.serverHost || DEFAULT_HOST;
   const port = opts?.serverPort ?? (await getPort({ port: portNumbers(3100, 3200) }));
   const app = express();
   app.use(cors());
@@ -43,7 +46,7 @@ export async function startContentServer(session: ISession, opts?: ServerOptions
     res.json({
       version,
       links: {
-        site: `http://localhost:${port}/config.json`,
+        site: `http://${host}:${port}/config.json`,
       },
     });
   });
@@ -53,7 +56,7 @@ export async function startContentServer(session: ISession, opts?: ServerOptions
   app.use('/objects.inv', express.static(join(session.sitePath(), 'objects.inv')));
   app.use('/myst.xref.json', express.static(join(session.sitePath(), 'myst.xref.json')));
   app.use('/myst.search.json', express.static(join(session.sitePath(), 'myst.search.json')));
-  const server = app.listen(port, () => {
+  const server = app.listen(port, host, () => {
     session.log.debug(`Content server listening on port ${port}`);
   });
   const wss = new WebSocketServer({
@@ -93,22 +96,24 @@ export async function startContentServer(session: ISession, opts?: ServerOptions
     server.close();
     wss.close();
   };
-  return { port, reload, log, stop };
+  return { host, port, reload, log, stop };
 }
 
-export function warnOnHostEnvironmentVariable(session: ISession, opts?: StartOptions) {
-  if (process.env.HOST && process.env.HOST !== 'localhost') {
-    if (opts?.keepHost) {
-      session.log.warn(
-        `\nThe HOST environment variable is set to "${process.env.HOST}", this may cause issues for the web server.\n`,
-      );
-    } else {
-      session.log.warn(
-        `\nThe HOST environment variable is set to "${process.env.HOST}", we are overwriting this to "localhost".\nTo keep this value use the \`--keep-host\` flag.\n`,
-      );
-      process.env.HOST = 'localhost';
-    }
+export function warnOnHostEnvironmentVariable(session: ISession, opts?: StartOptions): string {
+  if (!process.env.HOST || process.env.HOST === 'localhost' || process.env.HOST === '127.0.0.1') {
+    return process.env.HOST || DEFAULT_HOST;
   }
+  if (opts?.keepHost) {
+    session.log.warn(
+      `\nThe HOST environment variable is set to "${process.env.HOST}", this may cause issues for the web server.\n`,
+    );
+    return process.env.HOST;
+  }
+  session.log.warn(
+    `\nThe HOST environment variable is set to "${process.env.HOST}", we are overwriting this to "${DEFAULT_HOST}".\nTo keep this value use the \`--keep-host\` flag.\n`,
+  );
+  process.env.HOST = DEFAULT_HOST;
+  return DEFAULT_HOST;
 }
 
 export type AppServer = {
@@ -123,16 +128,16 @@ export async function startServer(
 ): Promise<AppServer | undefined> {
   // Ensure we are on the latest version of the configs
   await session.reload();
-  warnOnHostEnvironmentVariable(session, opts);
+  const host = warnOnHostEnvironmentVariable(session, opts);
   const mystTemplate = await getSiteTemplate(session, opts);
   if (!opts.headless && !opts.template) await installSiteTemplate(session, mystTemplate);
   await buildSite(session, opts);
-  const server = await startContentServer(session, opts);
+  const server = await startContentServer(session, { ...opts, serverHost: host });
   if (!opts.buildStatic) {
     watchContent(session, server.reload, opts);
   }
   if (opts.headless) {
-    const local = chalk.green(`http://localhost:${server.port}`);
+    const local = chalk.green(`http://${host}:${server.port}`);
     session.log.info(
       `\n🔌 Content server started on port ${server.port}!  🥳 🎉\n\n\n\t👉  ${local}  👈\n\n`,
     );
@@ -146,11 +151,12 @@ export async function startServer(
   await new Promise<void>((resolve) => {
     const start = makeExecutable(
       mystTemplate.getValidatedTemplateYml().build?.start ?? DEFAULT_START_COMMAND,
-      createServerLogger(session, resolve),
+      createServerLogger(session, { host, ready: resolve }),
       {
         cwd: mystTemplate.templatePath,
         env: {
           ...process.env,
+          HOST: host,
           CONTENT_CDN_PORT: String(server.port),
           PORT: String(port),
           MODE: opts.buildStatic ? 'static' : 'app',


### PR DESCRIPTION
Pass the host name through correctly to the theme and ensure that the default configuration will only serve on localhost unless a host is specified and passed through explicitly with `--keep-host`.

See also: jupyter-book/myst-theme#646
Fixes #2254