### PR TITLE
🔎 Set `HOST` environment variable to `127.0.0.1` on ReadTheDocs CI

### DIFF
--- a/.changeset/honest-jeans-enjoy.md
+++ b/.changeset/honest-jeans-enjoy.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Set the HOST environment variable to 127.0.0.1 on ReadTheDocs CI

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -100,6 +100,13 @@ export async function startContentServer(session: ISession, opts?: ServerOptions
 }
 
 export function warnOnHostEnvironmentVariable(session: ISession, opts?: StartOptions): string {
+  // Check if we're running in ReadTheDocs environment
+  if (process.env.READTHEDOCS === 'True') {
+    session.log.info('Detected ReadTheDocs environment, setting HOST to 127.0.0.1');
+    process.env.HOST = '127.0.0.1';
+    return '127.0.0.1';
+  }
+
   if (!process.env.HOST || process.env.HOST === 'localhost' || process.env.HOST === '127.0.0.1') {
     return process.env.HOST || DEFAULT_HOST;
   }


### PR DESCRIPTION
Fixes #2304