### PR TITLE
🏷️ Add autolabeler rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,7 @@ release:
 documentation:
   - head-branch: '^docs\\b'
   - changed-files:
-      - any-docs-files: 'docs/*'
+      - any-glob-to-any-file: 'docs/*'
 maintenance:
   - head-branch: '^maint\\b'
 enhancement:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,16 @@
 release:
   - head-branch: '^changeset-release/main$'
+documentation:
+  - head-branch: '^docs\\b'
+  - changed-files:
+      - any-docs-files: 'docs/*'
+maintenance:
+  - head-branch: '^maint\\b'
+enhancement:
+  - head-branch:
+      - '^enh\\b'
+      - '^feat\\b'
+bug:
+  - head-branch:
+      - '^fix\\b'
+      - '^bug\\b'

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,6 +1,6 @@
 name: Apply Pull Request Labels
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, unlabeled, synchronize, reopened]
 jobs:
   auto-label:
@@ -8,8 +8,8 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
-      issues: write
     steps:
+      # As this is a pull_request_target, we'll get `main` here
       - name: Checkout contents
         uses: actions/checkout@v4
       - name: Add labels

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -10,5 +10,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - name: Labeler
+      - name: Checkout contents
+        uses: actions/checkout@v4
+      - name: Add labels
         uses: actions/labeler@v6.0.1

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,14 @@
+name: Apply Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened]
+jobs:
+  require-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    steps:
+      - name: Labeler
+        uses: actions/labeler@v6.0.1

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize, reopened]
 jobs:
-  require-label:
+  auto-label:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Checkout contents
         uses: actions/checkout@v4
       - name: Add labels
-        uses: actions/labeler@v6.0.1
+        uses: actions/labeler@v6

--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -1,4 +1,4 @@
-name: Pull Request Labels
+name: Enforce Pull Request Labels
 on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize, reopened]
@@ -21,16 +21,3 @@ jobs:
             documentation
             maintenance
             release
-  label-release:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'opened' && github.head_ref == 'changeset-release/main'
-    permissions:
-      pull-requests: write
-      contents: read
-      issues: write
-    steps:
-      # WARNING: this is a pull_request_target workflow
-      #          DO NOT checkout the repo
-      - name: Label release pull request
-        # .github/labeler.yml defines configuration
-        uses: actions/labeler@v5


### PR DESCRIPTION
Enforcing label requirements is a good way to ensure that our release notes are easy to generate. Although it is not directly harmful to contributors that the current workflow requires contributors with permissions to assign these labels, we could make this easier!

This PR fixes #2325 by adding labels according to the path and/or branch name.