### PR TITLE
Preserve heading levels for Part source files

### DIFF
--- a/.changeset/tidy-melons-cheer.md
+++ b/.changeset/tidy-melons-cheer.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Preserve heading levels in frontmatter part files

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -200,7 +200,11 @@ export async function transformMdast(
     .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
     .use(basicTransformationsPlugin, {
       parser: (content: string) => parseMyst(session, content, file),
-      firstDepth: (titleDepth ?? 1) + (frontmatter.content_includes_title ? 0 : 1),
+      // Parts should preserve their original heading levels for structural sections like appendices
+      firstDepth:
+        kind === SourceFileKind.Part
+          ? undefined
+          : (titleDepth ?? 1) + (frontmatter.content_includes_title ? 0 : 1),
     })
     .use(inlineMathSimplificationPlugin, { replaceSymbol: false })
     .use(mathPlugin, { macros: frontmatter.math });

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -215,7 +215,11 @@ export async function transformMdast(
     .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
     .use(basicTransformationsPlugin, {
       parser: (content: string) => parseMyst(session, content, file),
-      firstDepth: (titleDepth ?? 1) + (frontmatter.content_includes_title ? 0 : 1),
+      // Parts should preserve their original heading levels for structural sections like appendices
+      firstDepth:
+        kind === SourceFileKind.Part
+          ? undefined
+          : (titleDepth ?? 1) + (frontmatter.content_includes_title ? 0 : 1),
     })
     .use(inlineMathSimplificationPlugin, { replaceSymbol: false })
     .use(mathPlugin, { macros: frontmatter.math });


### PR DESCRIPTION
Updated the mdast transformation to retain original heading levels for files of kind 'Part', ensuring structural sections like appendices are not altered. Other file kinds continue to adjust heading depth based on title and frontmatter.