### PR TITLE
feat: users can specify static files to include in their sites

### DIFF
--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -24,12 +24,18 @@ export interface SiteAction {
   static?: boolean;
 }
 
+export interface StaticAsset {
+  url: string;
+  filename: string;
+}
+
 export type SiteConfig = SiteFrontmatter & {
   projects?: SiteProject[];
   nav?: SiteNavItem[];
   actions?: SiteAction[];
   domains?: string[];
   template?: string;
+  static?: StaticAsset[];
 };
 
 export type SiteExport = {
@@ -83,4 +89,5 @@ export type SiteManifest = Omit<SiteFrontmatter, 'parts'> & {
   favicon?: string;
   template?: string;
   parts?: FrontmatterParts;
+  static?: StaticAsset[];
 };

--- a/packages/myst-config/src/site/validators.ts
+++ b/packages/myst-config/src/site/validators.ts
@@ -17,10 +17,18 @@ import {
   SITE_FRONTMATTER_KEYS,
   validateSiteFrontmatterKeys,
 } from 'myst-frontmatter';
-import type { SiteAction, SiteConfig, SiteNavItem, SiteProject } from './types.js';
+import type { SiteAction, SiteConfig, SiteNavItem, SiteProject, StaticAsset } from './types.js';
 
 export const SITE_CONFIG_KEYS = {
-  optional: [...SITE_FRONTMATTER_KEYS, 'projects', 'nav', 'actions', 'domains', 'template'],
+  optional: [
+    ...SITE_FRONTMATTER_KEYS,
+    'projects',
+    'nav',
+    'actions',
+    'domains',
+    'template',
+    'static',
+  ],
   alias: FRONTMATTER_ALIASES,
 };
 
@@ -104,6 +112,16 @@ export function validateSiteAction(input: any, opts: ValidationOptions) {
   return output;
 }
 
+export function validateStaticAsset(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { required: ['url', 'filename'] }, opts);
+  if (value === undefined) return undefined;
+  const filename = validateString(value.filename, incrementOptions('filename', opts));
+  const url = validateString(value.url, incrementOptions('url', opts));
+  if (!filename || !url) return undefined;
+  const output: StaticAsset = { filename, url };
+  return output;
+}
+
 export function validateSiteConfigKeys(
   value: Record<string, any>,
   opts: ValidationOptions,
@@ -131,6 +149,11 @@ export function validateSiteConfigKeys(
         return validateSiteAction(action, incrementOptions(`actions.${index}`, opts));
       },
     );
+  }
+  if (defined(value.static)) {
+    output.static = validateList(value.static, incrementOptions('static', opts), (asset, index) => {
+      return validateStaticAsset(asset, incrementOptions(`static.${index}`, opts));
+    });
   }
   if (defined(value.domains)) {
     const domains = validateList(


### PR DESCRIPTION
Using a new field in in the site config, users can specify static files that are copied as-is to the build output folder and served by the content server.

Closes #1921 

TODO:

- [ ] Specify folders in addition to single files
- [ ] Move the content to a dedicated subdirectory (perhaps `_build/site/static` to match the `myst-theme` route?)
- [ ] Copy to the URL that the user specifies (relative to the `static` folder) rather than keeping the same structure as the filesystem
- [ ] See if a new handler needs to be added in the content server for that folder
- [ ] Documentation
- [ ] Tests