### PR TITLE
Only trigger documentation update when a release succeeds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,13 @@
 name: Deploy Docs
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Release"]
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      published:
+        description: 'Whether packages were actually published (from changesets)'
+        required: false
+        type: boolean
+        default: false
 concurrency: ${{ github.workflow }}
 permissions:
   contents: write
@@ -13,7 +16,8 @@ jobs:
   release-docs:
     name: Release Documentation
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # Run if: manual dispatch OR called with published=true
+    if: ${{ github.event_name == 'workflow_dispatch' || inputs.published == true }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,3 +107,14 @@ jobs:
     with:
       tag_name: ${{ needs.get-tag.outputs.tag_name }}
     secrets: inherit
+
+  # Update our documentation if we've successfully released
+  deploy-docs:
+    name: Deploy Documentation
+    needs:
+      - release-npm
+    if: ${{ always() && needs.release-npm.result == 'success' }}
+    uses: ./.github/workflows/docs.yml
+    with:
+      published: ${{ needs.release-npm.outputs.published == 'true' }}
+    secrets: inherit


### PR DESCRIPTION
I realized that our documentation was being updated for every commit to `main` because the docs deploy workflow was being called when the release workflow _succeeded_ - that happens regardless of whether an actual release is made. So this updates the workflow to only run on success