### PR TITLE
📏 Demo tagged `extends`

### DIFF
--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -23,8 +23,240 @@ import { config } from './store/reducers.js';
 import { logMessagesFromVFile } from './utils/logging.js';
 import { addWarningForFile } from './utils/addWarningForFile.js';
 import { resolveToAbsolute } from './utils/resolveToAbsolute.js';
+import { warn } from 'node:console';
 
 const VERSION = 1;
+
+export class TaggedValue {
+  data: object;
+  tag: string;
+  constructor(strategy: string, data: object) {
+    this.data = data;
+    this.tag = strategy;
+  }
+
+  erase() {
+    return this.data;
+  }
+}
+
+function makeTaggedType(tag: string, kind: Exclude<yaml.Type['kind'], null>) {
+  return new yaml.Type(`!${tag}`, {
+    kind,
+
+    resolve: function () {
+      return true;
+    },
+
+    construct: function (data) {
+      return new TaggedValue(tag, data);
+    },
+
+    instanceOf: TaggedValue,
+
+    represent: function (obj: object) {
+      return (obj as TaggedValue).erase();
+    },
+  });
+}
+
+const TAGGED_YAML_SCHEMA = yaml.DEFAULT_SCHEMA.extend([
+  ...['extends', 'joins'].map((tag) => makeTaggedType(tag, 'sequence')),
+  makeTaggedType('replaces', 'mapping'),
+]);
+
+const configParseOpts = {
+  schema: TAGGED_YAML_SCHEMA,
+};
+
+/**
+ * Lazily set a value at a given path in an object.
+ * Paths may contain strings for object keys, or numbers
+ * for array indices.
+ *
+ * @param object the object to modify
+ * @param path a tuple containing path components
+ * @param value the value to set
+ */
+function setValueByPath(object: any, path: (string | number)[], value: any) {
+  if (!path.length) {
+    return;
+  }
+  let dest = object;
+  let prevItem = undefined;
+  let prevDest = undefined;
+  for (const item of path) {
+    // If the destination for this key is unset,
+    // we choose its type and set the value in its parent
+    if (dest === undefined) {
+      if (typeof item === 'number') {
+        prevDest[prevItem!] = dest = [];
+      } else {
+        prevDest[prevItem!] = dest = {};
+      }
+    }
+
+    // Update references
+    prevDest = dest;
+    dest = dest[item];
+    prevItem = item;
+  }
+  // Set the terminal value
+  prevDest[path.at(-1)!] = value;
+}
+
+type TagStructure = {
+  value?: string;
+  children?: { [key: string | number]: TagStructure };
+};
+
+type ParseType = ReturnType<typeof yaml.load>;
+
+/**
+ * Parse YAML into JS types
+ *
+ * YAML may include tags that are recorded and returned
+ *
+ * @param content content to parse into js
+ */
+export function parseYaml(content: string): {
+  content: ParseType;
+  tags: TagStructure;
+} {
+  const tags = {};
+  const cfg = yaml.load(content, configParseOpts);
+
+  // After potentially more merges, realise the config
+  function eraseTags(value: any, path: (string | number)[]): void {
+    if (value instanceof TaggedValue) {
+      const { tag } = value;
+      // Erase the tag type
+      value = value.erase();
+      // Replace config value with erased value
+      setValueByPath(cfg, path, value);
+      // Record tags in node-based scheme of the form
+      // { value: ..., children: [] } or  { value: ..., children: {} }
+      const tagsPath = path.flatMap((item) => ['children', item]);
+      setValueByPath(tags, tagsPath, { value: tag });
+    }
+
+    // Recurse into maps
+    if (isMap(value)) {
+      for (const [childKey, childValue] of Object.entries(value)) {
+        eraseTags(childValue, [...path, childKey]);
+      }
+    }
+    // Recurse into sequences
+    else if (Array.isArray(value)) {
+      value.forEach((elem, i) => {
+        eraseTags(elem, [...path, i]);
+      });
+    }
+  }
+  eraseTags(cfg, []);
+
+  return { content: cfg, tags };
+}
+
+/**
+ * Helper function to determine if YAML-loaded value is a mapping
+ *
+ * @param object value to test
+ */
+function isMap(object: any): object is Record<string, any> {
+  return typeof object === 'object' && !Array.isArray(object);
+}
+
+// Ensure that we have array of non-map to join onto
+function isJoinableArray(obj: any): obj is { id: string }[] {
+  return Array.isArray(obj) && obj.every((p) => isMap(p) && p.id !== undefined);
+}
+/**
+ * Extend one record with another using a particular merging strategy
+ *
+ * @param parent parent object
+ * @param child child object
+ * @param strategy object with tree structure matching tag annotations of document,
+ *                 of the form { value: ..., children: [] } or  { value: ..., children: {} }
+ */
+export function extendConfig(
+  parent: ParseType,
+  child: ParseType,
+  strategy: TagStructure | undefined,
+) {
+  function impl(
+    _parent: ParseType,
+    _child: ParseType,
+    _strategy: TagStructure | undefined,
+    _path: (string | number)[],
+  ): ParseType {
+    function throwError(message: string): never {
+      throw new Error(`${message}: ${_path.join('.')}`);
+    }
+
+    const strategyValue = _strategy?.value;
+
+    // parent: ??, child: sequence
+    if (Array.isArray(_child)) {
+      if (strategyValue === 'extends') {
+        // Ensure we're extending an array
+        if (Array.isArray(_parent)) {
+          return [..._parent, ..._child];
+        } else {
+          throwError('Cannot extend non-array with array');
+        }
+      } else if (strategyValue === 'joins') {
+        // Ensure we have array of map
+        if (!isJoinableArray(_child)) {
+          throwError('Join must be performed from an array of maps containing `id`');
+        }
+
+        if (!isJoinableArray(_parent)) {
+          throwError('Join must be performed onto an array of maps containing `id`');
+        }
+        // Perform join
+        const result = [..._parent];
+        for (let i = 0; i < _child.length; i++) {
+          const childItem = _child.at(i)!;
+
+          // First, are we joining or adding a new member
+          const joinIndex = _parent.findIndex((p) => p.id === childItem.id);
+          if (joinIndex !== -1) {
+            // Perform join and update parent
+            result[joinIndex] = impl(_parent[joinIndex], childItem, _strategy?.children?.[i], [
+              ..._path,
+              i,
+            ]) as any;
+          } else {
+            result.push(childItem);
+          }
+        }
+        return result;
+      } else {
+        // Preserve new value
+        return _child;
+      }
+    }
+    // parent: ??, child: map
+    else if (isMap(_child)) {
+      if (strategyValue === 'replaces' || !isMap(_parent)) {
+        return _child;
+      } else {
+        // Merge from child into parent
+        const result = { ..._parent };
+        for (const [key, value] of Object.entries(_child)) {
+          result[key] = impl(_parent[key], value, _strategy?.children?.[key], [..._path, key]);
+        }
+        return result;
+      }
+    }
+    // parent: ??, child: ??
+    else {
+      return _child;
+    }
+  }
+  return impl(parent, child, strategy, []);
+}
 
 function emptyConfig(): Config {
   return {

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -5,7 +5,6 @@ import { writeFileToFolder } from 'myst-cli-utils';
 import { fileError, fileWarn, RuleId } from 'myst-common';
 import type { Config, ProjectConfig, SiteConfig, SiteProject } from 'myst-config';
 import { validateProjectConfig, validateSiteConfig } from 'myst-config';
-import { fillProjectFrontmatter, fillSiteFrontmatter } from 'myst-frontmatter';
 import type { ValidationOptions } from 'simple-validators';
 import {
   incrementOptions,
@@ -23,7 +22,6 @@ import { config } from './store/reducers.js';
 import { logMessagesFromVFile } from './utils/logging.js';
 import { addWarningForFile } from './utils/addWarningForFile.js';
 import { resolveToAbsolute } from './utils/resolveToAbsolute.js';
-import { warn } from 'node:console';
 
 const VERSION = 1;
 
@@ -119,7 +117,7 @@ type ParseType = ReturnType<typeof yaml.load>;
  *
  * @param content content to parse into js
  */
-export function parseYaml(content: string): {
+export function parseTaggedYaml(content: string): {
   content: ParseType;
   tags: TagStructure;
 } {
@@ -183,7 +181,7 @@ export function extendConfig(
   parent: ParseType,
   child: ParseType,
   strategy: TagStructure | undefined,
-) {
+): ParseType {
   function impl(
     _parent: ParseType,
     _child: ParseType,
@@ -322,13 +320,6 @@ function configValidationOpts(vfile: VFile, property: string, ruleId: RuleId): V
 }
 
 /**
- * Function to add filler keys to base if the keys are not defined in base
- */
-function fillSiteConfig(base: SiteConfig, filler: SiteConfig, opts: ValidationOptions) {
-  return fillSiteFrontmatter(base, filler, opts, Object.keys(filler));
-}
-
-/**
  * Mutate config object to coerce deprecated frontmatter fields to valid schema
  */
 export function handleDeprecatedFields(
@@ -381,7 +372,7 @@ export function handleDeprecatedFields(
  * @returns the validated site and project configs and list of extended config files
  * @throws an error if the config file is malformed or invalid
  */
-async function getValidatedConfigsFromFile(
+async function resolveConfigFile(
   session: ISession,
   file: string,
   projectPath: string,
@@ -393,8 +384,9 @@ async function getValidatedConfigsFromFile(
     vfile.path = file;
   }
   const opts = configValidationOpts(vfile, 'config', RuleId.validConfigStructure);
+  const { content, tags } = parseTaggedYaml(fs.readFileSync(file, { encoding: 'utf-8' }));
   const conf = validateObjectKeys(
-    loadConfigYaml(file),
+    content,
     {
       required: ['version'],
       optional: ['site', 'project', 'extend'],
@@ -416,7 +408,6 @@ async function getValidatedConfigsFromFile(
   handleDeprecatedFields(conf, file, vfile);
   let site: SiteConfig | undefined;
   let project: ProjectConfig | undefined;
-  const projectOpts = configValidationOpts(vfile, 'config.project', RuleId.validProjectConfig);
   let extend: string[] | undefined;
   if (conf.extend) {
     extend = await Promise.all(
@@ -445,7 +436,8 @@ async function getValidatedConfigsFromFile(
           });
           return;
         }
-        const { site: extSite, project: extProject } = await getValidatedConfigsFromFile(
+
+        const { config: extConfig, tags: extTags } = await resolveConfigFile(
           session,
           extFile,
           projectPath,
@@ -453,22 +445,21 @@ async function getValidatedConfigsFromFile(
           stack,
         );
         session.store.dispatch(config.actions.receiveConfigExtension({ file: extFile }));
+        const { site: siteTags, project: projectTags } = extTags.children ?? {};
+
+        const { site: extSite, project: extProject } = extConfig;
         if (extSite) {
-          site = site ? fillSiteConfig(extSite, site, incrementOptions('extend', opts)) : extSite;
+          site = extendConfig(site ?? {}, extSite, siteTags) as any;
         }
         if (extProject) {
-          project = project ? fillProjectFrontmatter(extProject, project, projectOpts) : extProject;
+          project = extendConfig(project ?? {}, extProject, projectTags) as any;
         }
       }),
     );
   }
   const { site: rawSite, project: rawProject } = conf ?? {};
   if (rawProject) {
-    project = fillProjectFrontmatter(
-      await validateProjectConfigAndThrow(session, projectPath, vfile, rawProject),
-      project ?? {},
-      projectOpts,
-    );
+    project = extendConfig(rawProject, project ?? {}, (tags as any).project) as ProjectConfig;
   }
   if (project) {
     session.log.debug(`Loaded project config from ${file}`);
@@ -476,11 +467,7 @@ async function getValidatedConfigsFromFile(
     session.log.debug(`No project config defined in ${file}`);
   }
   if (rawSite) {
-    site = fillSiteConfig(
-      await validateSiteConfigAndThrow(session, projectPath, vfile, rawSite),
-      site ?? {},
-      incrementOptions('extend', opts),
-    );
+    site = extendConfig(rawSite, site ?? {}, (tags as any).project) as SiteConfig;
   }
   if (site) {
     session.log.debug(`Loaded site config from ${file}`);
@@ -488,7 +475,26 @@ async function getValidatedConfigsFromFile(
     session.log.debug(`No site config in ${file}`);
   }
   logMessagesFromVFile(session, vfile);
-  return { site, project, extend };
+  const resolvedConfig = { site, project };
+  return { config: resolvedConfig, tags };
+}
+
+async function getValidatedConfigsFromFile(
+  session: ISession,
+  file: string,
+  projectPath: string,
+  vfile?: VFile,
+) {
+  if (!vfile) {
+    vfile = new VFile();
+    vfile.path = file;
+  }
+  const { config: rawConfig } = await resolveConfigFile(session, file, projectPath, vfile, []);
+  let { site, project } = rawConfig;
+  project = await validateProjectConfigAndThrow(session, projectPath, vfile, project ?? {});
+  site = await validateSiteConfigAndThrow(session, projectPath, vfile, site ?? {});
+
+  return { site, project };
 }
 
 /**
@@ -519,10 +525,10 @@ export async function loadConfig(
       return existingConf.validated;
     }
   }
-  const { extend, ...configs } = await getValidatedConfigsFromFile(session, file, path);
+  const { ...configs } = await getValidatedConfigsFromFile(session, file, path);
   const site = await loadAndResolveConfigParts(session, path, configs.site, file, 'site');
   const project = await loadAndResolveConfigParts(session, path, configs.project, file, 'project');
-  const validated = { ...rawConf, site, project, extend };
+  const validated = { ...rawConf, site, project };
   session.store.dispatch(
     config.actions.receiveRawConfig({
       path,


### PR DESCRIPTION

> [!Note]
> This is not the place for discussion.
> See #1312 

---
This PR shows a demo for using tags in myst.yml. It adds the following understood YAML tags:

- `extends` 
- `replaces` 
- `joins`

When extending configuration files, these rules are applied _before_ the validation step. A choice I made to reflect that this is a schema-agnostic approach and to avoid having to reason about mutations by the validator.

This makes it possible to write the following `myst.yml`:

```yaml
version: 1
extend:
  - authors.yml
project:
  contributors: !joins
    - id: choldgraf
      roles:
        - Conceptualization  
```

Although the implementation performs pairwise merging, it would also be possible to implement an explicit merge step, making it possible for plugins to transform / ignore the tags:
```javascript
function mergeConfigs(rawConfigs: {config: YamlType, tags: TagsType}[]): YamlType;
```

With this PR, it's possible to test this approach and talk about something concrete!