### PR TITLE
:left_right_arrow: Add `alternatives` directive and AST node

### DIFF
--- a/docs/alternative-content.md
+++ b/docs/alternative-content.md
@@ -1,0 +1,26 @@
+---
+title: Alternatives
+description: Specify alternative representations for videos and animated graphics.
+---
+
+The MyST Document Engine supports multiple kinds of export targets, such as PDF via Typst, and web deployments. Each of these has its own preferred set of image formats that it can display, and certain content may not be supported by one or more exporters (such as HTML). 
+
+Authors can use the {myst:directive}`alternatives` directive to define several representations of the same conceptual entity in order to allow different exports to choose their preferred representation:
+
+````{myst}
+:::{alternatives}
+![](https://gifdb.com/images/high/earth-spinning-and-rotating-zxmey0cjachu1buc.gif)
+![](http://pngimg.com/uploads/earth/earth_PNG39.png)
+:::
+````
+
+In the above example, exporters (such as the PDF exporter) that do not understand GIF images will choose the PNG representation instead. Meanwhile, exporters that support GIF images _may_ choose the GIF _if_ it is preferred over the PNG format (which it usually is). The decision about which content to render lies with the exporter, not the MyST engine.
+
+For now, the `alternatives` directive only supports the following content:
+1. Images
+2. Videos
+3. Anywidgets
+
+:::{note}
+In future, we expect to open this up to more complex types such as figures with different images and captions.
+:::

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -83,6 +83,7 @@ project:
         - file: glossaries-and-terms.md
         - file: writing-in-latex.md
         - file: inline-options.md
+        - file: alternative-content.md
     - title: Executable Content
       children:
         - file: execute-notebooks.md

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -30,6 +30,7 @@ import {
   checkLinkTextTransform,
   indexIdentifierPlugin,
   buildTocTransform,
+  validateAlternativesPlugin,
 } from 'myst-transforms';
 import { unified } from 'unified';
 import { select, selectAll } from 'unist-util-select';
@@ -210,7 +211,8 @@ export async function transformMdast(
       firstDepth: (titleDepth ?? 1) + (frontmatter.content_includes_title ? 0 : 1),
     })
     .use(inlineMathSimplificationPlugin, { replaceSymbol: false })
-    .use(mathPlugin, { macros: frontmatter.math });
+    .use(mathPlugin, { macros: frontmatter.math })
+    .use(validateAlternativesPlugin);
   // Load custom transform plugins
   session.plugins?.transforms.forEach((t) => {
     if (t.stage !== 'document') return;

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -169,20 +169,40 @@ export function transformImagesWithoutExt(
     const wildcardRegex = /\.\*$/;
     const imagePath = path.join(path.dirname(file), image.url).replace(wildcardRegex, '');
     if (!fs.existsSync(imagePath)) {
-      const sortedExtensions = [
+      const sortedExtensions = new Set([
         // Valid extensions
         ...(opts?.imageExtensions ?? []),
         // Convertible extensions
         ...Object.keys(conversionFnLookup),
         // All known extensions
         ...KNOWN_IMAGE_EXTENSIONS,
-      ];
-      const extension = sortedExtensions.find((ext) => fs.existsSync(imagePath + ext));
-      if (extension) {
-        const replacement = image.url.replace(wildcardRegex, '') + extension;
-        session.log.debug(`Resolving ${image.url} to ${replacement}`);
-        image.url = replacement;
-        image.urlSource = image.url;
+      ]);
+      const extensions = Array.from(sortedExtensions.values()).filter((ext) =>
+        fs.existsSync(imagePath + ext),
+      );
+      if (extensions.length) {
+        const resolvedUrls = [];
+        for (const ext of extensions) {
+          const resolved = image.url.replace(wildcardRegex, '') + ext;
+          resolvedUrls.push(resolved);
+          session.log.debug(`Resolving ${image.url} to ${resolved}`);
+        }
+
+        const alternatives = {
+          type: 'alternatives',
+          children: resolvedUrls.map((url) => ({
+            type: 'image',
+            urlSource: url,
+            url,
+          })),
+        };
+
+        // Clear the current object
+        Object.keys(image).forEach((k) => {
+          delete image[k];
+        });
+        // Replace with the import
+        Object.assign(image, alternatives);
       }
     }
   });

--- a/packages/myst-common/src/ruleids.ts
+++ b/packages/myst-common/src/ruleids.ts
@@ -102,6 +102,7 @@ export enum RuleId {
   pluginLoads = 'plugin-loads',
   // Container rules
   containerChildrenValid = 'container-children-valid',
+  alternativesChildrenValid = 'alternatives-children-valid',
   // File rules
   mystJsonValid = 'myst-json-valid',
   // Execution
@@ -222,6 +223,7 @@ export const RULE_ID_DESCRIPTIONS: Record<RuleId, string> = {
   [RuleId.pluginLoads]: 'Plugin loads and executes without errors',
   // Container rules
   [RuleId.containerChildrenValid]: 'Container has valid child elements',
+  [RuleId.alternativesChildrenValid]: 'Container has valid child elements',
   // File rules
   [RuleId.mystJsonValid]: 'MyST JSON file is valid',
   [RuleId.codeCellExecutes]: 'Code cell executes without errors',

--- a/packages/myst-directives/src/alternatives.ts
+++ b/packages/myst-directives/src/alternatives.ts
@@ -1,26 +1,21 @@
 import type { Alternatives } from 'myst-spec-ext';
 import { addCommonDirectiveOptions, commonDirectiveOptions } from './utils.js';
 import { type DirectiveSpec, type DirectiveData, type GenericNode } from 'myst-common';
-import { selectAll } from 'unist-util-select';
+
+const nodeType = 'alternatives';
 
 export const alternativesDirective: DirectiveSpec = {
-  name: 'alternatives',
+  name: nodeType,
   doc: 'Alternatives group together a selection of similar representations of some content. For example, a video and still image for static exports.',
-  options: commonDirectiveOptions('alternative'),
+  options: commonDirectiveOptions(nodeType),
   body: {
     type: 'myst',
     doc: 'The body of the alternative. If there is no title and the body starts with bold text or a heading, that content will be used as the alternative title.',
   },
   run(data: DirectiveData): GenericNode[] {
-    const root = {
-      type: 'root',
-      children: (data.body as GenericNode[]) ?? [],
-    };
-    const children = selectAll('image,anywidget', root);
-
     const alternative: Alternatives = {
-      type: 'alternatives',
-      children: children,
+      type: nodeType,
+      children: (data.body as GenericNode[]) ?? [],
     };
     addCommonDirectiveOptions(data, alternative);
     return [alternative];

--- a/packages/myst-directives/src/alternatives.ts
+++ b/packages/myst-directives/src/alternatives.ts
@@ -1,7 +1,7 @@
 import type { Alternatives } from 'myst-spec-ext';
 import { addCommonDirectiveOptions, commonDirectiveOptions } from './utils.js';
-import { type DirectiveSpec, type DirectiveData, type GenericNode, fileError } from 'myst-common';
-import type { VFile } from 'vfile';
+import { type DirectiveSpec, type DirectiveData, type GenericNode } from 'myst-common';
+import { selectAll } from 'unist-util-select';
 
 export const alternativesDirective: DirectiveSpec = {
   name: 'alternatives',
@@ -11,26 +11,16 @@ export const alternativesDirective: DirectiveSpec = {
     type: 'myst',
     doc: 'The body of the alternative. If there is no title and the body starts with bold text or a heading, that content will be used as the alternative title.',
   },
-  run(data: DirectiveData, vfile: VFile): GenericNode[] {
-    let rawChildren: GenericNode[] = (data.body as GenericNode[]) ?? [];
-
-    // Multiple images are presented as paragraph of images.
-    // We could also walk down the tree, but this is only temporary and a 
-    // reasonable assumption
-    if (rawChildren.length === 1 && rawChildren[0].type === 'paragraph') {
-      rawChildren = rawChildren[0].children as any[];
-    }
-    const children = rawChildren.filter((n) => n.type === 'image' || n.type === 'anywidget');
-
-    if (children.length !== rawChildren.length) {
-      console.dir(children);
-      console.dir(rawChildren);
-      fileError(vfile, `alternatives can only contain images or anywidgets`);
-    }
+  run(data: DirectiveData): GenericNode[] {
+    const root = {
+      type: 'root',
+      children: (data.body as GenericNode[]) ?? [],
+    };
+    const children = selectAll('image,anywidget', root);
 
     const alternative: Alternatives = {
       type: 'alternatives',
-      children: children as any[],
+      children: children,
     };
     addCommonDirectiveOptions(data, alternative);
     return [alternative];

--- a/packages/myst-directives/src/alternatives.ts
+++ b/packages/myst-directives/src/alternatives.ts
@@ -12,10 +12,19 @@ export const alternativesDirective: DirectiveSpec = {
     doc: 'The body of the alternative. If there is no title and the body starts with bold text or a heading, that content will be used as the alternative title.',
   },
   run(data: DirectiveData, vfile: VFile): GenericNode[] {
-    const rawChildren: GenericNode[] = (data.body as GenericNode[]) ?? [];
+    let rawChildren: GenericNode[] = (data.body as GenericNode[]) ?? [];
+
+    // Multiple images are presented as paragraph of images.
+    // We could also walk down the tree, but this is only temporary and a 
+    // reasonable assumption
+    if (rawChildren.length === 1 && rawChildren[0].type === 'paragraph') {
+      rawChildren = rawChildren[0].children as any[];
+    }
     const children = rawChildren.filter((n) => n.type === 'image' || n.type === 'anywidget');
 
     if (children.length !== rawChildren.length) {
+      console.dir(children);
+      console.dir(rawChildren);
       fileError(vfile, `alternatives can only contain images or anywidgets`);
     }
 

--- a/packages/myst-directives/src/alternatives.ts
+++ b/packages/myst-directives/src/alternatives.ts
@@ -1,0 +1,29 @@
+import type { Alternatives } from 'myst-spec-ext';
+import { addCommonDirectiveOptions, commonDirectiveOptions } from './utils.js';
+import { type DirectiveSpec, type DirectiveData, type GenericNode, fileError } from 'myst-common';
+import type { VFile } from 'vfile';
+
+export const alternativesDirective: DirectiveSpec = {
+  name: 'alternatives',
+  doc: 'Alternatives group together a selection of similar representations of some content. For example, a video and still image for static exports.',
+  options: commonDirectiveOptions('alternative'),
+  body: {
+    type: 'myst',
+    doc: 'The body of the alternative. If there is no title and the body starts with bold text or a heading, that content will be used as the alternative title.',
+  },
+  run(data: DirectiveData, vfile: VFile): GenericNode[] {
+    const rawChildren: GenericNode[] = (data.body as GenericNode[]) ?? [];
+    const children = rawChildren.filter((n) => n.type === 'image' || n.type === 'anywidget');
+
+    if (children.length !== rawChildren.length) {
+      fileError(vfile, `alternatives can only contain images or anywidgets`);
+    }
+
+    const alternative: Alternatives = {
+      type: 'alternatives',
+      children: children as any[],
+    };
+    addCommonDirectiveOptions(data, alternative);
+    return [alternative];
+  },
+};

--- a/packages/myst-directives/src/index.ts
+++ b/packages/myst-directives/src/index.ts
@@ -1,3 +1,4 @@
+import { alternativesDirective } from './alternatives.js';
 import { admonitionDirective } from './admonition.js';
 import { bibliographyDirective } from './bibliography.js';
 import { codeDirective, codeCellDirective } from './code.js';
@@ -22,6 +23,7 @@ import { tocDirective } from './toc.js';
 import { widgetDirective } from './anywidget.js';
 
 export const defaultDirectives = [
+  alternativesDirective,
   admonitionDirective,
   bibliographyDirective,
   csvTableDirective,

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -68,6 +68,11 @@ export type AlgorithmLine = Parent & {
   enumerator?: string;
 };
 
+export type Alternatives = Parent & {
+  type: 'alternatives';
+  class?: Image['class'];
+};
+
 export type InlineMath = SpecInlineMath &
   Target & {
     /** Typst-specific math content. If not provided, LaTeX content will be converted to Typst. */

--- a/packages/myst-transforms/src/alternatives.ts
+++ b/packages/myst-transforms/src/alternatives.ts
@@ -1,0 +1,28 @@
+import type { Plugin } from 'unified';
+import type { Alternatives } from 'myst-spec-ext';
+import type { VFile } from 'vfile';
+import { selectAll, matches } from 'unist-util-select';
+import type { GenericParent } from 'myst-common';
+import { RuleId, fileError } from 'myst-common';
+
+/**
+ * Validate alternatives
+ */
+export function validateAlternativesTransform(tree: GenericParent, vfile: VFile) {
+  const alternatives = selectAll('alternatives', tree) as Alternatives[];
+  alternatives.forEach((node) => {
+    for (const child of node.children) {
+      if (!matches('image,anywidget', child)) {
+        fileError(vfile, 'alternatives has unsupported child', {
+          node,
+          ruleId: RuleId.containerChildrenValid,
+        });
+      }
+    }
+  });
+}
+
+export const validateAlternativesPlugin: Plugin<[], GenericParent, GenericParent> =
+  () => (tree, vfile) => {
+    validateAlternativesTransform(tree, vfile);
+  };

--- a/packages/myst-transforms/src/index.ts
+++ b/packages/myst-transforms/src/index.ts
@@ -1,3 +1,4 @@
+export { validateAlternativesPlugin, validateAlternativesTransform } from './alternatives.js';
 export {
   admonitionHeadersPlugin,
   admonitionHeadersTransform,


### PR DESCRIPTION
This PR adds an `alternatives` node, initially scoped to Images and Anywidgets. Whilst the concept of "preferred representation" is well defined with MIME types, it's trivial enough to generalise to other node types such as HTML and anywidgets. To begin with, we only add anywidgets, because HTML is transformed into AST by default.

<img width="466" height="530" alt="example-alt" src="https://github.com/user-attachments/assets/1b2bb334-f4b7-4d5b-b403-2d6dd144cb9e" />

Once a user has authored an alternation, e.g.
```markdown
:::{alternatives}
![](foo.png)
![](bar.svg)
:::
```

The exporter must choose which to ultimately render. 

See https://hackmd.io/jDApA05kQFO76R3g0VOPDA for a detailed long-term plan.

## To Do
- [ ] Add renderers for `alternatives` in built-in MyST exporters.
- [ ] Add renderers for `alternatives` in MyST Theme.

## Motivation

- We want to parse outputs from code cells. 
- Each output can have multiple representations (MIME types)
- Each exporter has its own preference for MIME types
- We need a way to represent this choice in the AST

## Out of scope
This PR does not update the AST built from `![](foo.*)` wildcard syntax. This _should_ be changed in future, once this mechanism is more well established.

This PR does not go beyond images and anywidgets. In the HackMD linked above, I set out a view that we should support more complicated alternations like:
```markdown
::::{alternatives}

:::{figure} globe.png
A static image of the world.
:::

:::{figure} spinning-globe.gif
A GIF of the world.
:::

::::
```

But I want to add that later as an extension of this mechanism. See https://agoose77.github.io/demo-myst-alternatives/ for a demonstration of this using MyST Theme components.