### PR TITLE
docs: clarify PDF export prerequisites

### DIFF
--- a/docs/quickstart-static-exports.md
+++ b/docs/quickstart-static-exports.md
@@ -103,7 +103,7 @@ Before building PDF exports locally, make sure your environment has the external
 during the export:
 
 - **$\LaTeX$**: install a full $\LaTeX$ distribution before using the default PDF renderer. See
-  [](./creating-pdf-documents.md#install-latex) for setup guidance.
+  [](#install-latex) for setup guidance.
 - **ImageMagick**: install [ImageMagick](https://imagemagick.org/) if your document includes images
   that need conversion for PDF output, such as animated GIFs or rasterized fallbacks for unsupported
   formats. See [](./figures.md) for more on image format handling.

--- a/docs/quickstart-static-exports.md
+++ b/docs/quickstart-static-exports.md
@@ -99,7 +99,14 @@ See [](./creating-word-documents.md) to learn about exporting to `*.docx`, for e
 
 ## Export to PDF with Latex
 
-To export to PDF with $\LaTeX$, first ensure it is installed, see [](./creating-pdf-documents.md) for more information.
+Before building PDF exports locally, make sure your environment has the external tools that MyST calls
+during the export:
+
+- **$\LaTeX$**: install a full $\LaTeX$ distribution before using the default PDF renderer. See
+  [](./creating-pdf-documents.md#install-latex) for setup guidance.
+- **ImageMagick**: install [ImageMagick](https://imagemagick.org/) if your document includes images
+  that need conversion for PDF output, such as animated GIFs or rasterized fallbacks for unsupported
+  formats. See [](./figures.md) for more on image format handling.
 
 First, we need to decide which template to export to, for this, we will use the `myst templates` command, and for example list all the two-column, PDF templates available.
 


### PR DESCRIPTION
Adds the PDF export prerequisites directly to the static exports quickstart, before users run the PDF build steps.

This calls out:
- installing a full LaTeX distribution for the default PDF renderer
- installing ImageMagick when documents include images that need conversion for PDF output
- links to the existing LaTeX install and image-format docs

Fixes #445.

Validation:
- `git diff --check`

Notes:
- `npx --no-install prettier --check docs/quickstart-static-exports.md` could not run in this fresh clone because dependencies are not installed locally (`npx canceled due to missing packages`).
- I did not run the full docs build for the same reason; CI should cover formatting and docs build with the project toolchain.