### PR TITLE
Document site options config w page frontmatter

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -25,7 +25,7 @@ site:
     analytics_google: UA-XXXXX # Measurement ID or Tracking ID
 ```
 
-If using page frontmatter, omit the `options:` key, see [](#site-options-page).
+![](#page-site-options-note)
 
 See [Google Analytics docs](https://developers.google.com/analytics/devguides/collection/gtagjs) for more information on how to find this Measurement ID.
 
@@ -40,7 +40,7 @@ site:
     analytics_plausible: mystmd.org # Domain(s) to track
 ```
 
-If using page frontmatter, omit the `options:` key, see [](#site-options-page).
+![](#page-site-options-note)
 
 See [Plausible docs](https://plausible.io/docs/plausible-script) for more information on how to find the domain. Note, you only copy in the contents of: `data-domain="COPY_THIS"`, which can be a comma-separated list for multiple domains.
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -12,6 +12,7 @@ However, we offer support for two analytics tracking systems:
 2. [Plausible](https://plausible.io/), which is privacy-friendly alternative to Google.
 
 These are set using template specific options in your site configuration using either an `analytics_google` or an `analytics_plausible` key.
+See [](#site-options) for more on site options and how to set them.
 
 ## Google Analytics
 
@@ -23,6 +24,8 @@ site:
   options:
     analytics_google: UA-XXXXX # Measurement ID or Tracking ID
 ```
+
+If using page frontmatter, omit the `options:` key, see [](#site-options-page).
 
 See [Google Analytics docs](https://developers.google.com/analytics/devguides/collection/gtagjs) for more information on how to find this Measurement ID.
 
@@ -36,6 +39,8 @@ site:
   options:
     analytics_plausible: mystmd.org # Domain(s) to track
 ```
+
+If using page frontmatter, omit the `options:` key, see [](#site-options-page).
 
 See [Plausible docs](https://plausible.io/docs/plausible-script) for more information on how to find the domain. Note, you only copy in the contents of: `data-domain="COPY_THIS"`, which can be a comma-separated list for multiple domains.
 

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -69,7 +69,7 @@ site:
     numbered_references: true
 ```
 
-If using page frontmatter, omit the `options:` key, see [](#site-options-page).
+![](#page-site-options-note)
 
 ### Writing DOIs to BibTeX
 

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -69,6 +69,8 @@ site:
     numbered_references: true
 ```
 
+If using page frontmatter, omit the `options:` key, see [](#site-options-page).
+
 ### Writing DOIs to BibTeX
 
 If you encounter problems fetching DOIs from `https://doi.org`, for example the downloaded citation does not include all the data you expect or requests to `https://doi.org` are failing on an automated continuous integration platform, you may write your DOI citations to file using the MyST command:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,8 @@ See [](#field-behavior) below about how these two sources of settings interact.
 
 See also [](frontmatter.md) for a list of supported frontmatter settings.
 
+See [](#site-options) for theme settings like analytics, logos, and navigation toggles, which are set under `site.options` in your `myst.yml`.
+
 ## Page-level frontmatter
 
 ### In a MyST markdown file

--- a/docs/website-navigation.md
+++ b/docs/website-navigation.md
@@ -136,7 +136,7 @@ site:
     hide_toc: true
 ```
 
-If using page frontmatter, omit the `options:` key, see [](#site-options-page).
+![](#page-site-options-note)
 
 ### Edit the primary sidebar footer
 
@@ -194,7 +194,7 @@ site:
     hide_outline: true
 ```
 
-If using page frontmatter, omit the `options:` key, see [](#site-options-page).
+![](#page-site-options-note)
 
 ### Make content expand to the right margin
 

--- a/docs/website-navigation.md
+++ b/docs/website-navigation.md
@@ -136,6 +136,8 @@ site:
     hide_toc: true
 ```
 
+If using page frontmatter, omit the `options:` key, see [](#site-options-page).
+
 ### Edit the primary sidebar footer
 
 The "Made with MyST" branding at the bottom of the primary sidebar can be customized by providing a markdown file, e.g. `primary-sidebar-footer.md`, and adding the path to the `site.parts.toc_footer` configuration to your `myst.yml`:
@@ -191,6 +193,8 @@ site:
   options:
     hide_outline: true
 ```
+
+If using page frontmatter, omit the `options:` key, see [](#site-options-page).
 
 ### Make content expand to the right margin
 

--- a/docs/website-style.md
+++ b/docs/website-style.md
@@ -25,7 +25,7 @@ site:
     style: ./my-style.css
 ```
 
-If using page frontmatter, omit the `options:` key, see [](#site-options-page).
+![](#page-site-options-note)
 
 For example, the style-sheet could contain styling for `em` elements nested below a particular `text-gradient` class:
 

--- a/docs/website-style.md
+++ b/docs/website-style.md
@@ -25,6 +25,8 @@ site:
     style: ./my-style.css
 ```
 
+If using page frontmatter, omit the `options:` key, see [](#site-options-page).
+
 For example, the style-sheet could contain styling for `em` elements nested below a particular `text-gradient` class:
 
 :::{literalinclude} public/style.css

--- a/docs/website-templates.md
+++ b/docs/website-templates.md
@@ -123,7 +123,9 @@ If both `getting-started.md` and `getting-started/index.md` exist, the sibling f
 ### Page Options
 
 Any option from `site.options` can be overridden per-page in the frontmatter under the `site` key.
-Note that the nesting is different: options are placed directly under `site:` in page frontmatter, not under `site.options:`.
+
+(page-site-options-note)=
+When setting an option from a page, omit the `options:` key - put it directly under `site:`, not `site.options:`. See [](#site-options-page).
 
 ```{code-block} yaml
 :filename: my-page.md

--- a/docs/website-templates.md
+++ b/docs/website-templates.md
@@ -118,6 +118,8 @@ getting-started/
 If both `getting-started.md` and `getting-started/index.md` exist, the sibling file takes the slug `getting-started` first, and the folder's index file gets a deduplicated slug like `getting-started-1`.
 :::
 
+(site-options-page)=
+
 ### Page Options
 
 Any option from `site.options` can be overridden per-page in the frontmatter under the `site` key.


### PR DESCRIPTION
This clarifies how site options are specified when using page frontmatter, and adds a bunch of cross-references so this information is easier to find.

---

- closes #2869 (I think, assuming this is the problem!)