### PR TITLE
Add kernel startup timeout and retry + choose open port on execute

### DIFF
--- a/.changeset/salty-oranges-teach.md
+++ b/.changeset/salty-oranges-teach.md
@@ -1,0 +1,5 @@
+---
+"myst-execute": patch
+---
+
+Choose a random port on execution

--- a/packages/myst-execute/package.json
+++ b/packages/myst-execute/package.json
@@ -35,6 +35,7 @@
     "@jupyterlab/services": "^7.3.0",
     "@jupyterlab/nbformat": "^3.5.2",
     "chalk": "^5.2.0",
+    "get-port": "^6.1.2",
     "myst-cli-utils": "^2.0.13",
     "myst-common": "^1.9.3",
     "node-fetch": "^3.3.0",

--- a/packages/myst-execute/src/kernel.ts
+++ b/packages/myst-execute/src/kernel.ts
@@ -2,20 +2,30 @@ import type { KernelSpec } from 'myst-frontmatter';
 import type { Kernel, KernelMessage, SessionManager } from '@jupyterlab/services';
 import type { IOutput } from '@jupyterlab/nbformat';
 import type { IExpressionResult } from 'myst-common';
+import type { Logger } from 'myst-cli-utils';
 import type { VFile } from 'vfile';
 import path from 'node:path';
 import assert from 'node:assert';
+import { setTimeout as delay } from 'node:timers/promises';
 
 type ISessionConnection = Awaited<ReturnType<SessionManager['startNew']>>;
 type ISessionConnectionWithKernel = ISessionConnection & {
   kernel: NonNullable<ISessionConnection['kernel']>;
 };
 
+// A kernel can start but never finish connecting, which would hang the build
+// forever. Wait for it to be ready, and restart it a few times if it isn't.
+// Healthy kernels connect in about a second, so this timeout is intentionally
+// short to recover quickly.
+const KERNEL_READY_TIMEOUT_MS = 10_000;
+const KERNEL_READY_ATTEMPTS = 3;
+
 export async function createKernelConnection(
   sessionManager: SessionManager,
   basePath: string,
   kernelspec: KernelSpec,
   vfile: VFile,
+  log?: Logger,
 ): Promise<ISessionConnectionWithKernel | undefined> {
   const sessionOpts = {
     type: 'notebook',
@@ -25,11 +35,25 @@ export async function createKernelConnection(
       name: kernelspec.name,
     },
   };
-  const connection = await sessionManager.startNew(sessionOpts);
-  if (connection.kernel === null) {
-    return undefined;
+  for (let attempt = 1; attempt <= KERNEL_READY_ATTEMPTS; attempt += 1) {
+    const connection = await sessionManager.startNew(sessionOpts);
+    if (connection.kernel === null) {
+      return undefined;
+    }
+    const ready = await Promise.race([
+      connection.kernel.info.then(() => true),
+      // ref: false makes sure the timer doesn't keep the process alive if kernel starts
+      delay(KERNEL_READY_TIMEOUT_MS, false, { ref: false }),
+    ]);
+    if (ready) {
+      return connection as any;
+    }
+    log?.warn(
+      `Kernel "${kernelspec.name}" did not become ready (attempt ${attempt}/${KERNEL_READY_ATTEMPTS}); restarting it`,
+    );
+    await connection.shutdown().catch(() => undefined);
   }
-  return connection as any;
+  return undefined;
 }
 
 /**

--- a/packages/myst-execute/src/manager.ts
+++ b/packages/myst-execute/src/manager.ts
@@ -1,7 +1,7 @@
 import type { ServerConnection } from '@jupyterlab/services';
 import which from 'which';
+import getPort from 'get-port';
 import { spawn } from 'node:child_process';
-import { createServer } from 'node:net';
 import * as readline from 'node:readline';
 import type { ISession, Logger } from 'myst-cli-utils';
 import { killProcessTree } from 'myst-cli-utils';
@@ -67,26 +67,6 @@ export async function findExistingJupyterServer(
 }
 
 /**
- * Ask the OS for an unused TCP port. Used so concurrent invocations of
- * jupyter execution don't race on the same default port (8888). This function
- * 1. Opens a server and requests an unused port.
- * 2. Tracks the port number.
- * 3. Closes the server (so that port is released)
- * 4. Returns the port number so we know it's just been made available.
- *
- * We use that port in the Jupyter Server launch, so we are confident it is open.
- */
-function pickUnusedPort(): Promise<number> {
-  return new Promise((resolve) => {
-    // By listening to port 0 it'll assign an open port, which we use later
-    const srv = createServer().listen(0, '127.0.0.1', () => {
-      const { port } = srv.address() as { port: number };
-      srv.close(() => resolve(port));
-    });
-  });
-}
-
-/**
  * Launch a new Jupyter Server whose root directory coincides with the content path
  *
  * @param contentPath path to server contents
@@ -98,7 +78,8 @@ export async function launchJupyterServer(
 ): Promise<JupyterServerSettings> {
   log.info(`🚀 ${chalk.yellowBright('Starting new Jupyter server')}`);
   const pythonPath = which.sync('python');
-  const port = await pickUnusedPort();
+  // Pick an unused port so parallel execution requests don't race on the default port.
+  const port = await getPort();
   const proc = spawn(pythonPath, [
     '-m',
     'jupyter_server',

--- a/packages/myst-execute/src/manager.ts
+++ b/packages/myst-execute/src/manager.ts
@@ -79,7 +79,7 @@ export async function findExistingJupyterServer(
 function pickUnusedPort(): Promise<number> {
   return new Promise((resolve) => {
     // By listening to port 0 it'll assign an open port, which we use later
-    const srv = createServer().listen(0, () => {
+    const srv = createServer().listen(0, '127.0.0.1', () => {
       const { port } = srv.address() as { port: number };
       srv.close(() => resolve(port));
     });

--- a/packages/myst-execute/src/manager.ts
+++ b/packages/myst-execute/src/manager.ts
@@ -1,6 +1,7 @@
 import type { ServerConnection } from '@jupyterlab/services';
 import which from 'which';
 import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
 import * as readline from 'node:readline';
 import type { ISession, Logger } from 'myst-cli-utils';
 import { killProcessTree } from 'myst-cli-utils';
@@ -66,6 +67,26 @@ export async function findExistingJupyterServer(
 }
 
 /**
+ * Ask the OS for an unused TCP port. Used so concurrent invocations of
+ * jupyter execution don't race on the same default port (8888). This function
+ * 1. Opens a server and requests an unused port.
+ * 2. Tracks the port number.
+ * 3. Closes the server (so that port is released)
+ * 4. Returns the port number so we know it's just been made available.
+ * 
+ * We use that port in the Jupyter Server launch, so we are confident it is open.
+ */
+function pickUnusedPort(): Promise<number> {
+  return new Promise((resolve) => {
+    // By listening to port 0 it'll assign an open port, which we use later
+    const srv = createServer().listen(0, () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+/**
  * Launch a new Jupyter Server whose root directory coincides with the content path
  *
  * @param contentPath path to server contents
@@ -77,7 +98,18 @@ export async function launchJupyterServer(
 ): Promise<JupyterServerSettings> {
   log.info(`🚀 ${chalk.yellowBright('Starting new Jupyter server')}`);
   const pythonPath = which.sync('python');
-  const proc = spawn(pythonPath, ['-m', 'jupyter_server', '--ServerApp.root_dir', contentPath]);
+  const port = await pickUnusedPort();
+  const proc = spawn(pythonPath, [
+    '-m',
+    'jupyter_server',
+    '--ServerApp.root_dir',
+    contentPath,
+    `--ServerApp.port=${port}`,
+    // Without this, jupyter silently rebinds to a different port if ours is taken.
+    // We later parse the port from stderr but it returns the *first* instance,
+    // so if the port has changed after a retry, we'll miss it. So fail eagerly instead.
+    '--ServerApp.port_retries=0',
+  ]);
 
   const reader = proc.stderr;
 

--- a/packages/myst-execute/src/manager.ts
+++ b/packages/myst-execute/src/manager.ts
@@ -73,7 +73,7 @@ export async function findExistingJupyterServer(
  * 2. Tracks the port number.
  * 3. Closes the server (so that port is released)
  * 4. Returns the port number so we know it's just been made available.
- * 
+ *
  * We use that port in the Jupyter Server launch, so we are confident it is open.
  */
 function pickUnusedPort(): Promise<number> {

--- a/packages/myst-execute/src/transform.ts
+++ b/packages/myst-execute/src/transform.ts
@@ -144,6 +144,7 @@ export async function kernelExecutionTransform(tree: GenericParent, vfile: VFile
     opts.basePath,
     kernelspec,
     vfile,
+    log,
   );
   if (sessionConnection === undefined) {
     log.error(`Unable to create a new kernel ${kernelspec.name}`);

--- a/packages/myst-execute/tests/run.spec.ts
+++ b/packages/myst-execute/tests/run.spec.ts
@@ -37,7 +37,9 @@ if (pythonPath === null) {
   throw new Error('python not found in PATH; install it to run myst-execute tests');
 }
 if (spawnSync(pythonPath, ['-c', 'import jupyter_server']).status !== 0) {
-  throw new Error('jupyter_server not found; run `pip install jupyter-server` to run myst-execute tests');
+  throw new Error(
+    'jupyter_server not found; run `pip install jupyter-server` to run myst-execute tests',
+  );
 }
 
 const only = '';


### PR DESCRIPTION
This PR aims to clear up two more sources of flakiness around execution.

1. When we have many concurrent kernels being spun up (either in multiple tests run concurrently, or one test with multiple kernels spun up at once), in some cases there seems to be port collisions where a port isn't correctly reported. This PR adds a little function to figure out a port that is open, and then explicitly use that. It should ensure that the execution logic never requests a port that is actually unavailable. I tried to document the rationale in the docstrings so it's clearer why we're doing it this way! 
2. Sometimes, a kernel seems to hang on _startup_ (ie it never starts). Usually startup is < 1 second. This adds a 10 second timeout, and 3 retries, to the "ask for a kernel" step. I think this should remove another class of build hangs. We might be able to shrink the timeout since it seems like the kernel startup was "less than a second, or never" but I didn't know if this would be different on other machines etc

---

- closes #2870 