### PR TITLE
Only copy thebe JS when necessary

### DIFF
--- a/.changeset/fine-meals-fall.md
+++ b/.changeset/fine-meals-fall.md
@@ -1,0 +1,6 @@
+---
+"myst-cli": patch
+"myst-execute": patch
+---
+
+Only copy thebe JS when necessary

--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -24,6 +24,18 @@ import type { LocalProjectPage } from '../../project/types.js';
 
 const limitConnections = pLimit(5);
 
+/**
+ * Return true if any project in the current site has thebe configured.
+ * `project: jupyter: ...` aliases to `project: thebe`.
+ */
+function siteUsesThebe(session: ISession): boolean {
+  const state = session.store.getState();
+  const siteConfig = selectors.selectCurrentSiteConfig(state);
+  return (siteConfig?.projects ?? []).some(
+    (proj) => !!proj.path && !!selectors.selectLocalProjectConfig(state, proj.path)?.thebe,
+  );
+}
+
 export async function currentSiteRoutes(
   session: ISession,
   host: string,
@@ -199,9 +211,15 @@ export async function buildHtml(session: ISession, opts: StartOptions) {
   );
   await appServer.stop();
 
-  // Copy the files for the template used
+  // Copy files for the template used.
+
+  // Skip thebe JS chunks unless they are required.
   const templateBuildDir = path.join(template.templatePath, 'public');
-  fs.copySync(templateBuildDir, htmlDir);
+  const hasThebe = siteUsesThebe(session);
+  fs.copySync(templateBuildDir, htmlDir, {
+    filter: (src) =>
+      hasThebe || !path.basename(src).match(/^(\d+\.)?(thebe-(core|lite)(\.min)?\.js|thebe-core.*\.css)$/),
+  });
 
   // Copy all of the static assets
   fs.copySync(session.publicPath(), path.join(htmlDir, 'build'));

--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -218,7 +218,8 @@ export async function buildHtml(session: ISession, opts: StartOptions) {
   const hasThebe = siteUsesThebe(session);
   fs.copySync(templateBuildDir, htmlDir, {
     filter: (src) =>
-      hasThebe || !path.basename(src).match(/^(\d+\.)?(thebe-(core|lite)(\.min)?\.js|thebe-core.*\.css)$/),
+      hasThebe ||
+      !path.basename(src).match(/^(\d+\.)?(thebe-(core|lite)(\.min)?\.js|thebe-core.*\.css)$/),
   });
 
   // Copy all of the static assets

--- a/packages/myst-execute/tests/run.spec.ts
+++ b/packages/myst-execute/tests/run.spec.ts
@@ -37,7 +37,9 @@ if (pythonPath === null) {
   throw new Error('python not found in PATH; install it to run myst-execute tests');
 }
 if (spawnSync(pythonPath, ['-c', 'import jupyter_server']).status !== 0) {
-  throw new Error('jupyter_server not found; run `pip install jupyter-server` to run myst-execute tests');
+  throw new Error(
+    'jupyter_server not found; run `pip install jupyter-server` to run myst-execute tests',
+  );
 }
 
 const only = '';


### PR DESCRIPTION
Currently, we copy those ~120 JS files on each build (~3MB!).

This patch checks the `project: thebe: ...` (or `project: jupyter: ...` alias) configuration, and only copies thebe JS if it exists.

/cc @henryiii