### PR TITLE
📖 Document JupyterHub PDF export tools

### DIFF
--- a/docs/figures.md
+++ b/docs/figures.md
@@ -183,7 +183,7 @@ For animated images, `.gif`, the first frame is extracted for static exports.
 :class: dropdown
 The image transforms and optimizations requires you to have the following packages installed:
 
-- [imagemagik](https://imagemagick.org/) for conversion between raster formats
+- [ImageMagick](https://imagemagick.org/) for conversion between raster formats
 - [inkscape](https://inkscape.org/) for conversion between some vector formats
 - [webp](https://developers.google.com/speed/webp) for image optimizations
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -105,14 +105,7 @@ $ mamba install -c conda-forge texlive-core latexmk imagemagick
 
 `imagemagick` is optional, but recommended if your documents include images that need conversion for PDF output.
 
+For Debian or Ubuntu based systems, the equivalent packages commonly include `texlive-xetex`, `texlive-fonts-recommended`, `texlive-plain-generic`, `latexmk`, and `imagemagick`.
+
 ::::
 :::::
-
-If you maintain a shared JupyterHub or other managed environment, install the PDF export tools into the user environment rather than expecting users to add them one-by-one. A minimal environment for MyST PDF exports should include:
-
-- `mystmd`
-- a working $\LaTeX$ distribution, such as `texlive-core` from `conda-forge`
-- `latexmk`
-- `imagemagick` for image conversion when documents include formats that need conversion for PDF output
-
-For Debian or Ubuntu based images, the equivalent system packages commonly include `texlive-xetex`, `texlive-fonts-recommended`, `texlive-plain-generic`, `latexmk`, and `imagemagick`.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -97,11 +97,22 @@ mamba 1.5.8
 conda 24.7.1
 ```
 
-🛠 Install `texlive-core` and `latexmk` from `conda-forge`:
+🛠 Install `texlive-core`, `latexmk`, and `imagemagick` from `conda-forge`:
 
 ```shell
-$ mamba install -c conda-forge texlive-core latexmk
+$ mamba install -c conda-forge texlive-core latexmk imagemagick
 ```
+
+`imagemagick` is optional, but recommended if your documents include images that need conversion for PDF output.
 
 ::::
 :::::
+
+If you maintain a shared JupyterHub or other managed environment, install the PDF export tools into the user environment rather than expecting users to add them one-by-one. A minimal environment for MyST PDF exports should include:
+
+- `mystmd`
+- a working $\LaTeX$ distribution, such as `texlive-core` from `conda-forge`
+- `latexmk`
+- `imagemagick` for image conversion when documents include formats that need conversion for PDF output
+
+For Debian or Ubuntu based images, the equivalent system packages commonly include `texlive-xetex`, `texlive-fonts-recommended`, `texlive-plain-generic`, `latexmk`, and `imagemagick`.


### PR DESCRIPTION
## Summary
- include `imagemagick` in the conda-forge PDF export dependency install
- add a short note for shared JupyterHub / managed environments with minimal PDF export tools
- fix the ImageMagick spelling/link text in the figures dependency note

Fixes #237.

## Checks
- `npm exec --yes prettier@latest -- --check docs/installing.md docs/figures.md`
- `git diff --check`
