### PR TITLE
Ignore ./worktrees dir in linting/formatting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
-*.md
 worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ yalc.lock
 
 # vim swap files
 *.swp
+
+# git worktrees
+worktrees/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:format": "turbo run lint:format",
     "lint:circular": "madge -c packages/*/src/*",
     "test": "turbo run test",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "format": "prettier --write \"**/*.{ts,tsx,md}\" --ignore-pattern 'worktrees'",
     "changeset": "changeset",
     "version": "changeset version && bun install",
     "publish": "bun run clean && bun run build -- --force && changeset publish && git push --follow-tags",
@@ -42,7 +42,7 @@
   },
   "packageManager": "bun@1.3.10",
   "lint-staged": {
-    "*.ts": "eslint --config ./.eslintrc.cjs --fix",
+    "*.ts": "eslint --config ./.eslintrc.cjs --ignore-pattern 'worktrees' --fix",
     "*.{js,jsx,ts,tsx,md,html,css,json}": "prettier --write"
   }
 }


### PR DESCRIPTION
This is a selfish PR, but I (against all advice!) store my worktrees inside my project directories (otherwise it just gets too crazy in `..`). So, requesting if we can ignore `./worktrees`, but totally understood if that's considered too specific/noisy.