### PR TITLE
Document deprecated projects config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,11 +156,11 @@ The behavior of each frontmatter field is hard-coded within MyST. These are the 
 
 (multiple-projects-deprecated)=
 
-:::{warning} Combining multiple projects in one site is deprecated
+:::{warning} Multiple projects in one `myst.yml` site has been deprecated
 A MyST site maps one-to-one to a single project.
 
-Historically, the `site.projects` list could combine several projects under one site, each mounted at its own URL slug.
-This is deprecated.
+Historically, the `site.projects` list could combine several projects under one site, each mounted at its own URL slug. This is deprecated due to development complexity, and we encourage composing multiple MyST sites at a higher level (e.g. DNS, file system or through custom web-applications).
+You can combine multiple projects by deploying multiple myst sites next to each other, for example, using GitHub pages or web-based routing. A worked example, which is used in the Jupyter Book documentation deployment can be [found here](https://jupyterbook.org/blog/posts/2026/multi-repo).
 :::
 
 (composing-myst-yml)=

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,6 +154,15 @@ The behavior of each frontmatter field is hard-coded within MyST. These are the 
 
 +++
 
+(multiple-projects-deprecated)=
+
+:::{warning} Combining multiple projects in one site is deprecated
+A MyST site maps one-to-one to a single project.
+
+Historically, the `site.projects` list could combine several projects under one site, each mounted at its own URL slug.
+This is deprecated.
+:::
+
 (composing-myst-yml)=
 
 ## Compose and extend configuration `.yml` files

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -56,23 +56,11 @@ which will serve a static version of the site.
 :::{danger} Static sites should have an `index.html`
 :class: dropdown
 
-Your site should be configured with a single project at the root, this can be done by removing the `site.projects` list so that the site builds at the root url, rather than in a nested folder.
+A static site needs an `index.html` at its root.
+MyST generates one automatically when your site has a single project built at the root URL, which is the default.
 
-If your project is configured to be in a nested folder using a project `slug`, a site index will _not_ be created and your project will be instead accessible at a nested slug.
-
-To fix this, change your `site` configuration to use a flat rather than nested project:
-
-```yaml
-version: 1
-# Your project must be listed in the same myst.yml configuration
-project: ...
-site:
-  title: Site Title
-  # Delete the following `site.projects` configuration:
-  # projects:
-  #   - slug: nested-folder
-  #     path: .
-```
+If a root `index.html` is _not_ generated, your project is being built under a nested URL instead of at the root.
+You're probably using the [deprecated `projects:` configuration](#multiple-projects-deprecated), and should remove it.
 
 :::
 

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -25,6 +25,11 @@ export interface SiteAction {
 }
 
 export type SiteConfig = SiteFrontmatter & {
+  /**
+   * Multiple projects per site is deprecated; a site maps 1:1 to a project.
+   * See https://github.com/jupyter-book/mystmd/issues/1103
+   * TODO: Clean up the `projects` API to clarify that it's only one allowed.
+   */
   projects?: SiteProject[];
   nav?: SiteNavItem[];
   actions?: SiteAction[];
@@ -76,6 +81,11 @@ export type SiteManifest = Omit<SiteFrontmatter, 'parts'> & {
   version: number;
   myst: string;
   id?: string;
+  /**
+   * Multiple projects per site is deprecated; a site maps 1:1 to a project.
+   * See https://github.com/jupyter-book/mystmd/issues/1103
+   * TODO: Clean up the `projects` API to clarify that it's only one allowed.
+   */
   projects?: ManifestProject[];
   nav?: SiteNavItem[];
   actions?: SiteAction[];


### PR DESCRIPTION
Documents that `projects:` is deprecated config even though the codebase still supports it