### PR TITLE
Pin new tex-to-typst

### DIFF
--- a/.changeset/chubby-nails-look.md
+++ b/.changeset/chubby-nails-look.md
@@ -1,0 +1,7 @@
+---
+'myst-to-typst': patch
+'myst-cli': patch
+'mystmd': patch
+---
+
+Fix \left| and \right| delimeters (rely on upstream fix in tex-to-typst)

--- a/packages/myst-to-typst/package.json
+++ b/packages/myst-to-typst/package.json
@@ -40,7 +40,7 @@
     "myst-common": "^1.9.4",
     "myst-frontmatter": "^1.9.4",
     "myst-spec-ext": "^1.9.4",
-    "tex-to-typst": "^0.0.18",
+    "tex-to-typst": "^0.0.20",
     "unist-util-select": "^4.0.3",
     "vfile-reporter": "^7.0.4"
   }


### PR DESCRIPTION
Fix \left| and \right| delimeters (rely on upstream fix in tex-to-typst)

Closes #2876