### PR TITLE
🛠️ Increase test timeout

### DIFF
--- a/packages/mystmd/tests/endToEnd.spec.ts
+++ b/packages/mystmd/tests/endToEnd.spec.ts
@@ -39,7 +39,7 @@ function cleanHashes(text: string) {
 }
 
 const only = '';
-const TIMEOUT = 35000; // Long-ish to allow for the execution tests
+const TIMEOUT = 65000; // Long-ish to allow for the execution tests
 describe.concurrent('End-to-end cli export tests', { timeout: TIMEOUT }, () => {
   const cases = loadCases('exports.yml');
   test.each(

--- a/packages/mystmd/tests/exports.yml
+++ b/packages/mystmd/tests/exports.yml
@@ -568,10 +568,10 @@ cases:
     env:
       MYST_TEST_SLEEP_MS: 4000
       MYST_TEST_DELAY_MS: 2000
-    # Used to be 15000, increased due to CI slowness
-    # NOTE that the full test suite has a timeout here too: 
+    # Used to be 15000, then 30000, increased due to CI slowness
+    # NOTE that the full test suite has a timeout here too:
     # mystmd/packages/mystmd/tests/endToEnd.spec.ts
-    timeout: 30000
+    timeout: 60000
     outputs:
       - path: serial-execution/stop-first
       - path: serial-execution/stop-second


### PR DESCRIPTION
Jupyter takes a while, doubling the test timeout as I am seeing this fail in a bunch of places recently.