### PR TITLE
resolving a site template relies on GH releases and bypasses the API

### DIFF
--- a/packages/myst-templates/src/defaultTemplates.ts
+++ b/packages/myst-templates/src/defaultTemplates.ts
@@ -1,0 +1,11 @@
+/**
+ * Default version of the react/site templates (book-theme, article-theme) that
+ * ships with this CLI release.
+ *
+ * `book-theme.zip` and `article-theme.zip` are assets of the *same*
+ * `myst-theme` GitHub release.
+ *
+ * The release process is in charge of keeping this version up to date with the
+ * latest compatible `myst-theme` release
+ */
+export const DEFAULT_SITE_TEMPLATE_VERSION = '1.3.1';

--- a/packages/myst-templates/src/download.spec.ts
+++ b/packages/myst-templates/src/download.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import memfs from 'memfs';
-import { resolveInputs, resolveSiteTemplateUrl } from './download';
-import { DEFAULT_SITE_TEMPLATE_VERSION } from './defaultTemplates';
+import { resolveInputs, resolveSiteTemplateUrl } from './download.js';
+import { DEFAULT_SITE_TEMPLATE_VERSION } from './defaultTemplates.js';
 import { Session } from './session';
 import { TemplateKind } from 'myst-common';
 

--- a/packages/myst-templates/src/download.spec.ts
+++ b/packages/myst-templates/src/download.spec.ts
@@ -66,7 +66,7 @@ describe('resolveInputs', () => {
       kind: TemplateKind.site,
     });
     expect(templateUrl).toEqual(
-      `${RELEASES}/myst-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
+      `${RELEASES}/myst-to-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
     );
     expect(templatePath).toMatch(/^templates\/site\/[a-f0-9]{64}$/);
   });
@@ -74,24 +74,24 @@ describe('resolveInputs', () => {
     expect(
       resolveInputs(new Session(), { kind: TemplateKind.site, template: 'book-theme@9.9.9' })
         .templateUrl,
-    ).toEqual(`${RELEASES}/myst-react@9.9.9/book-theme.zip`);
+    ).toEqual(`${RELEASES}/myst-to-react@9.9.9/book-theme.zip`);
   });
 });
 
 describe('resolveSiteTemplateUrl', () => {
   it('bare name uses the default org and baked version', () => {
     expect(resolveSiteTemplateUrl('book-theme')).toEqual(
-      `${RELEASES}/myst-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
+      `${RELEASES}/myst-to-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
     );
   });
   it('undefined falls back to the default book-theme', () => {
     expect(resolveSiteTemplateUrl()).toEqual(
-      `${RELEASES}/myst-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
+      `${RELEASES}/myst-to-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
     );
   });
   it('name@version pins the version', () => {
     expect(resolveSiteTemplateUrl('article-theme@1.3.1')).toEqual(
-      `${RELEASES}/myst-react@1.3.1/article-theme.zip`,
+      `${RELEASES}/myst-to-react@1.3.1/article-theme.zip`,
     );
   });
   it('org/name@version overrides the org', () => {
@@ -101,7 +101,7 @@ describe('resolveSiteTemplateUrl', () => {
   });
   it('legacy site/myst/ namespace maps to the default org', () => {
     expect(resolveSiteTemplateUrl('site/myst/book-theme')).toEqual(
-      `${RELEASES}/myst-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
+      `${RELEASES}/myst-to-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
     );
   });
   it('invalid name throws', () => {

--- a/packages/myst-templates/src/download.spec.ts
+++ b/packages/myst-templates/src/download.spec.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import memfs from 'memfs';
-import { resolveInputs } from './download';
+import { resolveInputs, resolveSiteTemplateUrl } from './download';
+import { DEFAULT_SITE_TEMPLATE_VERSION } from './defaultTemplates';
 import { Session } from './session';
 import { TemplateKind } from 'myst-common';
+
+const RELEASES = 'https://github.com/jupyter-book/myst-theme/releases/download';
 
 vi.mock('fs', () => ({ ['default']: memfs.fs }));
 
@@ -57,5 +60,51 @@ describe('resolveInputs', () => {
   });
   it('invalid template errors', async () => {
     expect(() => resolveInputs(new Session(), { template: 'my/public/journal' })).toThrow();
+  });
+  it('site template resolves to a versioned release zip and hashed path', async () => {
+    const { templateUrl, templatePath } = resolveInputs(new Session(), {
+      kind: TemplateKind.site,
+    });
+    expect(templateUrl).toEqual(
+      `${RELEASES}/myst-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
+    );
+    expect(templatePath).toMatch(/^templates\/site\/[a-f0-9]{64}$/);
+  });
+  it('pinned site template uses the requested version', async () => {
+    expect(
+      resolveInputs(new Session(), { kind: TemplateKind.site, template: 'book-theme@9.9.9' })
+        .templateUrl,
+    ).toEqual(`${RELEASES}/myst-react@9.9.9/book-theme.zip`);
+  });
+});
+
+describe('resolveSiteTemplateUrl', () => {
+  it('bare name uses the default org and baked version', () => {
+    expect(resolveSiteTemplateUrl('book-theme')).toEqual(
+      `${RELEASES}/myst-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
+    );
+  });
+  it('undefined falls back to the default book-theme', () => {
+    expect(resolveSiteTemplateUrl()).toEqual(
+      `${RELEASES}/myst-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
+    );
+  });
+  it('name@version pins the version', () => {
+    expect(resolveSiteTemplateUrl('article-theme@1.3.1')).toEqual(
+      `${RELEASES}/myst-react@1.3.1/article-theme.zip`,
+    );
+  });
+  it('org/name@version overrides the org', () => {
+    expect(resolveSiteTemplateUrl('myorga/book-theme@release-name')).toEqual(
+      'https://github.com/myorga/myst-theme/releases/download/release-name/book-theme.zip',
+    );
+  });
+  it('legacy site/myst/ namespace maps to the default org', () => {
+    expect(resolveSiteTemplateUrl('site/myst/book-theme')).toEqual(
+      `${RELEASES}/myst-react@${DEFAULT_SITE_TEMPLATE_VERSION}/book-theme.zip`,
+    );
+  });
+  it('invalid name throws', () => {
+    expect(() => resolveSiteTemplateUrl('a/b/c/d')).toThrow();
   });
 });

--- a/packages/myst-templates/src/download.ts
+++ b/packages/myst-templates/src/download.ts
@@ -68,7 +68,7 @@ function defaultUrl(session: ISession, template: string) {
  */
 const SITE_TEMPLATE_DEFAULT_ORG = 'jupyter-book';
 const SITE_TEMPLATE_REPO = 'myst-theme';
-// not quite sure which name the release name has this prefix or not
+// official releases have this prefix in their name
 const SITE_TEMPLATE_TAG_PREFIX = 'myst-to-react@';
 const DEFAULT_SITE_TEMPLATE = 'book-theme';
 
@@ -101,7 +101,7 @@ export function resolveSiteTemplateUrl(template?: string): string {
   let release = match[3] ? match[3].slice(1) : DEFAULT_SITE_TEMPLATE_VERSION;
   // the official mystmd releases may carry a "myst-react@" prefix
   if (org === SITE_TEMPLATE_DEFAULT_ORG) {
-    release = `${SITE_TEMPLATE_TAG_PREFIX}${release}`
+    release = `${SITE_TEMPLATE_TAG_PREFIX}${release}`;
   }
   return `https://github.com/${org}/${SITE_TEMPLATE_REPO}/releases/download/${release}/${name}.zip`;
 }

--- a/packages/myst-templates/src/download.ts
+++ b/packages/myst-templates/src/download.ts
@@ -69,7 +69,7 @@ function defaultUrl(session: ISession, template: string) {
 const SITE_TEMPLATE_DEFAULT_ORG = 'jupyter-book';
 const SITE_TEMPLATE_REPO = 'myst-theme';
 // not quite sure which name the release name has this prefix or not
-const SITE_TEMPLATE_TAG_PREFIX = 'myst-react@';
+const SITE_TEMPLATE_TAG_PREFIX = 'myst-to-react@';
 const DEFAULT_SITE_TEMPLATE = 'book-theme';
 
 // Matches `[org/]name[@version]`

--- a/packages/myst-templates/src/download.ts
+++ b/packages/myst-templates/src/download.ts
@@ -8,6 +8,7 @@ import { copyFileMaintainPath, isDirectory } from 'myst-cli-utils';
 import { TemplateKind } from 'myst-common';
 import { validateUrl } from 'simple-validators';
 import type { TemplateYmlListResponse, TemplateYmlResponse, ISession } from './types.js';
+import { DEFAULT_SITE_TEMPLATE_VERSION } from './defaultTemplates.js';
 
 export const TEMPLATE_YML = 'template.yml';
 
@@ -60,6 +61,51 @@ function defaultUrl(session: ISession, template: string) {
   return `${templatesUrl(session)}/${template}`;
 }
 
+/**
+ * Site/react templates (book-theme, article-theme) are published as GitHub release assets of the
+ * `myst-theme` repo, e.g.
+ *   https://github.com/jupyter-book/myst-theme/releases/download/myst-react@1.3.1/book-theme.zip
+ */
+const SITE_TEMPLATE_DEFAULT_ORG = 'jupyter-book';
+const SITE_TEMPLATE_REPO = 'myst-theme';
+// not quite sure which name the release name has this prefix or not
+const SITE_TEMPLATE_TAG_PREFIX = 'myst-react@';
+const DEFAULT_SITE_TEMPLATE = 'book-theme';
+
+// Matches `[org/]name[@version]`
+const SITE_TEMPLATE_REGEX = /^([a-zA-Z0-9_-]+\/)?([a-zA-Z0-9_-]+)(@[a-zA-Z0-9._-]+)?$/;
+
+/**
+ * Resolve a site template field to a versioned GitHub release-asset download URL.
+ *
+ * Accepts either
+ *  - `book-theme`
+ *  - `book-theme@1.3.1`
+ *  - `org/book-theme@release`
+ * When no release is given, use DEFAULT_SITE_TEMPLATE_VERSION
+ *
+ * the cache key (a hash of this URL) changes on CLI upgrade and the template is re-fetched.
+ */
+export function resolveSiteTemplateUrl(template?: string): string {
+  const input = template ?? DEFAULT_SITE_TEMPLATE;
+  // the list of themes returns names like site/myst/book-theme
+  const stripped = input.replace(/^site\/myst\//, '');
+  const match = stripped.match(SITE_TEMPLATE_REGEX);
+  if (!match) {
+    throw new Error(
+      `Unable to resolve site template "${input}"; expected a name like "book-theme", "book-theme@1.3.1", or "org/book-theme@1.3.1"`,
+    );
+  }
+  let org = match[1] ? match[1].slice(0, -1) : SITE_TEMPLATE_DEFAULT_ORG;
+  const name = match[2];
+  let release = match[3] ? match[3].slice(1) : DEFAULT_SITE_TEMPLATE_VERSION;
+  // the official mystmd releases may carry a "myst-react@" prefix
+  if (org === SITE_TEMPLATE_DEFAULT_ORG) {
+    release = `${SITE_TEMPLATE_TAG_PREFIX}${release}`
+  }
+  return `https://github.com/${org}/${SITE_TEMPLATE_REPO}/releases/download/${release}/${name}.zip`;
+}
+
 function defaultPath(
   template: string,
   hash: boolean,
@@ -107,6 +153,13 @@ export function resolveInputs(
   // Handle case where template is a download URL
   templateUrl = validateUrl(opts.template, { messages: {}, suppressErrors: true, property: '' });
   if (templateUrl) {
+    templatePath = defaultPath(templateUrl, true, opts);
+    return { templatePath, templateUrl };
+  }
+  // Site/react templates resolve to a versioned GitHub release asset (.zip), bypassing the API.
+  // The version lives in the URL, so the hashed cache path is version-specific and self-invalidates.
+  if (opts.kind === TemplateKind.site) {
+    templateUrl = resolveSiteTemplateUrl(opts.template);
     templatePath = defaultPath(templateUrl, true, opts);
     return { templatePath, templateUrl };
   }


### PR DESCRIPTION
comes with a baked-in version number in defaultTemplates.ts, which needs to be maintained, manually for now, when the CLI gets released

essentially:

```yaml
site:
  # will fetch a release that is baked in the CLI, so should always work
  template: book-theme
  # a specific release
  template: book-theme@1.3.1
  # from a specific orga
  template: flotpython/book-theme@custom
  # or like now
  template: https://any/working/url/to/a.zip
```  
  
in addition, the cache folder is named after the version, so it invalidates when the baked-in version gets bumped

so essentially, it no longer breaks when lagging behind the latest updates

---

for now:
- the new function passes its tests
- I have not been able to test end-to-end yet
- and I have not touched the docs either

waiting for feedback before I go any further

