### PR TITLE
Add missing dependencies that are required for proper exports

### DIFF
--- a/.changeset/tangy-mirrors-double.md
+++ b/.changeset/tangy-mirrors-double.md
@@ -1,0 +1,6 @@
+---
+'markdown-it-myst': patch
+'myst-execute': patch
+---
+
+Fix dependencies / types

--- a/packages/markdown-it-myst/package.json
+++ b/packages/markdown-it-myst/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "js-yaml": "^4.1.0",
-    "vfile": "^5.3.7"
+    "vfile": "^5.3.7",
+    "vfile-message": "^3.0.0"
   },
   "devDependencies": {
     "markdown-it-footnote": "^4.0.0"

--- a/packages/markdown-it-myst/src/utils.ts
+++ b/packages/markdown-it-myst/src/utils.ts
@@ -1,7 +1,8 @@
 import type StateCore from 'markdown-it/lib/rules_core/state_core.js';
 import type { VFile } from 'vfile';
+import type { VFileMessage } from 'vfile-message';
 
-export function stateWarn(state: StateCore, message: string) {
+export function stateWarn(state: StateCore, message: string): VFileMessage | undefined {
   const vfile = state.env.vfile as VFile | undefined;
   if (!vfile) return;
   return vfile.message(message);

--- a/packages/myst-execute/src/transform.ts
+++ b/packages/myst-execute/src/transform.ts
@@ -97,10 +97,11 @@ export async function kernelExecutionTransform(tree: GenericParent, vfile: VFile
 
   // Requre kernelspec otherwise Jupyter doesn't know what kernel to use
   if (kernelspec === undefined) {
-    return fileError(
+    fileError(
       vfile,
       `Notebook does not declare the necessary 'kernelspec' frontmatter key required for execution`,
     );
+    return;
   }
 
   // See if we already cached this execution


### PR DESCRIPTION
Newer Bun version(s) complain about this, and it seems reasonable — inference across packages in exports is poorly defined.