### PR TITLE
Convert pyproject.toml dependencies from approx equal to lower bound

### DIFF
--- a/packages/mystmd-py/pyproject.toml
+++ b/packages/mystmd-py/pyproject.toml
@@ -43,8 +43,8 @@ env-var = "MYSTMD_PACKAGE_VARIANT"
 # Ensure that we only bring in nodeenv for PyPI
 [tool.hatch.build.hooks.selector.variants.pypi]
 dependencies = [
-  "platformdirs~=4.2.2",
-  "nodeenv~=1.9.1"
+  "platformdirs>=4.2.2",
+  "nodeenv>=1.9.1"
 ]
 
 # Conda-forge has no additional dependencies to the `project.dependencies`


### PR DESCRIPTION
This allows them to coexist more easily with other python deps in a single venv

Fixes #2082