### PR TITLE
Use availableParallelism rather than CPUs

### DIFF
--- a/.changeset/vast-brooms-clap.md
+++ b/.changeset/vast-brooms-clap.md
@@ -1,0 +1,5 @@
+---
+'mystmd': patch
+---
+
+Fix parallelism count

--- a/.changeset/vast-brooms-clap.md
+++ b/.changeset/vast-brooms-clap.md
@@ -2,4 +2,4 @@
 'mystmd': patch
 ---
 
-Fix parallelism count
+Use NodeJS parallelism parallelism feature

--- a/packages/mystmd/src/clirun.ts
+++ b/packages/mystmd/src/clirun.ts
@@ -35,7 +35,7 @@ export function clirun(
     const logger = chalkLogger(opts?.debug ? LogLevel.debug : LogLevel.info, process.cwd());
     // Override default myst.yml if --config option is given.
     const configFiles = opts?.config ? [opts.config] : undefined;
-    const parallelCount = opts?.executeParallel ?? availableParallelism();
+    const parallelCount = opts?.executeParallel ?? Math.max(1, availableParallelism() - 1);
     const executionSemaphore = new Semaphore(parallelCount);
     const session = new sessionClass({ logger, configFiles, executionSemaphore });
     await session.reload();

--- a/packages/mystmd/src/clirun.ts
+++ b/packages/mystmd/src/clirun.ts
@@ -3,7 +3,7 @@ import type { ISession, Session } from 'myst-cli';
 import { checkNodeVersion, getNodeVersion, logVersions } from 'myst-cli';
 import { chalkLogger, LogLevel } from 'myst-cli-utils';
 import { Semaphore } from 'async-mutex';
-import { cpus } from 'node:os';
+import { availableParallelism } from 'node:os';
 
 type SessionOpts = {
   debug?: boolean;
@@ -35,7 +35,7 @@ export function clirun(
     const logger = chalkLogger(opts?.debug ? LogLevel.debug : LogLevel.info, process.cwd());
     // Override default myst.yml if --config option is given.
     const configFiles = opts?.config ? [opts.config] : undefined;
-    const parallelCount = opts?.executeParallel ?? Math.max(1, cpus().length - 1);
+    const parallelCount = opts?.executeParallel ?? availableParallelism();
     const executionSemaphore = new Semaphore(parallelCount);
     const session = new sessionClass({ logger, configFiles, executionSemaphore });
     await session.reload();


### PR DESCRIPTION
I had hoped that this would give physical cores, rather than overcommitting CPUs. On my system, however, it's still reporting threads.

Nevertheless, it's good to use a more appropriate API.