### PR TITLE
Give notebook cells stable deep-link anchors

### DIFF
--- a/.changeset/easy-bikes-divide.md
+++ b/.changeset/easy-bikes-divide.md
@@ -1,0 +1,7 @@
+---
+'myst-transforms': patch
+'myst-to-html': patch
+'myst-cli': patch
+---
+
+Support cell IDs from Jupyter Notebooks

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mystmd",

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -33,9 +33,7 @@ function blockParent(cell: ICell, children: GenericNode[]) {
   const kind = cell.cell_type === CELL_TYPES.code ? NotebookCell.code : NotebookCell.content;
   const data = JSON.parse(JSON.stringify(cell.metadata));
   // Stash the nbformat cell `id` so it can be promoted to a durable anchor
-  // downstream (see blockMetadataTransform). This is read verbatim from the
-  // .ipynb JSON, so its presence signals a trusted, file-persisted id: markdown
-  // notebooks never reach this reader, and ids mystmd fabricates live elsewhere.
+  // downstream
   const cellId = (cell as { id?: unknown }).id;
   if (typeof cellId === 'string' && cellId.length > 0) {
     data._jupyterCellId = cellId;

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -31,7 +31,16 @@ import type { PageFrontmatter } from 'myst-frontmatter';
 
 function blockParent(cell: ICell, children: GenericNode[]) {
   const kind = cell.cell_type === CELL_TYPES.code ? NotebookCell.code : NotebookCell.content;
-  return { type: 'block', kind, data: JSON.parse(JSON.stringify(cell.metadata)), children };
+  const data = JSON.parse(JSON.stringify(cell.metadata));
+  // Stash the nbformat cell `id` so it can be promoted to a durable anchor
+  // downstream (see blockMetadataTransform). This is read verbatim from the
+  // .ipynb JSON, so its presence signals a trusted, file-persisted id: markdown
+  // notebooks never reach this reader, and ids mystmd fabricates live elsewhere.
+  const cellId = (cell as { id?: unknown }).id;
+  if (typeof cellId === 'string' && cellId.length > 0) {
+    data._jupyterCellId = cellId;
+  }
+  return { type: 'block', kind, data, children };
 }
 
 /**

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -1,4 +1,4 @@
-import { NotebookCell, RuleId, fileWarn } from 'myst-common';
+import { NotebookCell, RuleId, fileWarn, normalizeLabel } from 'myst-common';
 import type { GenericNode, GenericParent } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import { nanoid } from 'nanoid';
@@ -16,7 +16,7 @@ import { logMessagesFromVFile } from '../utils/logging.js';
 import type { ISession } from '../session/types.js';
 import { BASE64_HEADER_SPLIT } from '../transforms/images.js';
 import { parseMyst } from './myst.js';
-import type { Code, InlineExpression } from 'myst-spec';
+import type { Code, InlineExpression, Block } from 'myst-spec';
 import { findExpression, metadataSection } from '../transforms/inlineExpressions.js';
 import type { IUserExpressionMetadata } from '../transforms/inlineExpressions.js';
 import { frontmatterValidationOpts } from '../frontmatter.js';
@@ -29,9 +29,31 @@ import {
 } from 'myst-frontmatter';
 import type { PageFrontmatter } from 'myst-frontmatter';
 
+type LabeledBlock = Block &
+  Partial<{
+    identifier: string;
+    html_id: string;
+  }>;
+
 function blockParent(cell: ICell, children: GenericNode[]) {
   const kind = cell.cell_type === CELL_TYPES.code ? NotebookCell.code : NotebookCell.content;
-  return { type: 'block', kind, data: JSON.parse(JSON.stringify(cell.metadata)), children };
+  const block: LabeledBlock = {
+    type: 'block',
+    kind,
+    data: JSON.parse(JSON.stringify(cell.metadata)),
+    children: children as any,
+  };
+  const cellId = (cell as { id?: unknown }).id;
+  if (typeof cellId === 'string' && cellId.length > 0) {
+    // Provenance-gated fallback: promote a real .ipynb cell id to a durable
+    // anchor. An author-supplied label always wins (handled above). The
+    // html_id is kept verbatim so a copied deep link equals the nbformat cell
+    // id; the identifier is normalized so `[](#<id>)` resolves like a label.
+    const normalized = normalizeLabel(cellId)!;
+    block.identifier = normalized.identifier;
+    block.html_id = cellId;
+  }
+  return block;
 }
 
 /**

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -31,14 +31,7 @@ import type { PageFrontmatter } from 'myst-frontmatter';
 
 function blockParent(cell: ICell, children: GenericNode[]) {
   const kind = cell.cell_type === CELL_TYPES.code ? NotebookCell.code : NotebookCell.content;
-  const data = JSON.parse(JSON.stringify(cell.metadata));
-  // Stash the nbformat cell `id` so it can be promoted to a durable anchor
-  // downstream
-  const cellId = (cell as { id?: unknown }).id;
-  if (typeof cellId === 'string' && cellId.length > 0) {
-    data._jupyterCellId = cellId;
-  }
-  return { type: 'block', kind, data, children };
+  return { type: 'block', kind, data: JSON.parse(JSON.stringify(cell.metadata)), children };
 }
 
 /**

--- a/packages/myst-to-html/src/schema.ts
+++ b/packages/myst-to-html/src/schema.ts
@@ -106,7 +106,12 @@ const mystDirective: Handler = (h, node) => {
 };
 
 const block: Handler = (h, node) =>
-  h(node, 'div', { class: 'block', 'data-block': node.meta }, all(h, node));
+  h(
+    node,
+    'div',
+    { id: node.html_id || node.identifier || undefined, class: 'block', 'data-block': node.meta },
+    all(h, node),
+  );
 
 const comment: Handler = (h, node) => u('comment', node.value);
 

--- a/packages/myst-transforms/src/blocks.spec.ts
+++ b/packages/myst-transforms/src/blocks.spec.ts
@@ -149,6 +149,71 @@ describe('Test blockMetadataTransform', () => {
   });
 });
 
+describe('Test blockMetadataTransform notebook cell ids', () => {
+  test('a code cell gets a stable anchor equal to its nbformat id', async () => {
+    const mdast = u('root', [
+      u('block', { kind: 'notebook-code', data: { _jupyterCellId: '9bd1512c-9ca1-4695' } }, [
+        u('code', 'points'),
+        u('outputs', [u('output', 'a'), u('output', 'b')]),
+      ]),
+    ]) as any;
+    blockMetadataTransform(mdast, new VFile());
+    const block = mdast.children[0];
+    // html_id is verbatim so a copied deep link equals the nbformat cell id
+    expect(block.html_id).toBe('9bd1512c-9ca1-4695');
+    // identifier is normalized so [](#id) resolves like a label
+    expect(block.identifier).toBe('9bd1512c-9ca1-4695');
+    // not registered as a named "label"; internal stash is removed
+    expect(block.label).toBeUndefined();
+    expect(block.data).toBeUndefined();
+    // multi-output: anchor the cell only — no per-output ids fabricated
+    const outputs = block.children[1];
+    expect(outputs.identifier).toBeUndefined();
+    expect(outputs.children.every((o: any) => o.identifier === undefined)).toBe(true);
+    expect(block.children[0].identifier).toBeUndefined();
+  });
+  test('the anchor is unchanged across two runs of the same source', async () => {
+    const build = () => {
+      const mdast = u('root', [
+        u('block', { kind: 'notebook-code', data: { _jupyterCellId: 'abc-123' } }, [
+          u('code', 'x = 1'),
+        ]),
+      ]) as any;
+      blockMetadataTransform(mdast, new VFile());
+      return mdast.children[0].html_id;
+    };
+    expect(build()).toBe('abc-123');
+    expect(build()).toBe(build());
+  });
+  test('an unlabeled markdown cell without an id gets no anchor', async () => {
+    const mdast = u('root', [
+      u('block', { kind: 'notebook-content', data: {} }, [u('paragraph', [u('text', 'hello')])]),
+    ]) as any;
+    blockMetadataTransform(mdast, new VFile());
+    const block = mdast.children[0];
+    expect(block.identifier).toBeUndefined();
+    expect(block.html_id).toBeUndefined();
+  });
+  test('an author label wins over the auto cell id', async () => {
+    const mdast = u('root', [
+      u(
+        'block',
+        { kind: 'notebook-code', data: { label: 'My_Label', _jupyterCellId: 'abc-123' } },
+        [u('code', 'x = 1'), u('outputs', [u('output', 'a')])],
+      ),
+    ]) as any;
+    blockMetadataTransform(mdast, new VFile());
+    const block = mdast.children[0];
+    expect(block.identifier).toBe('my_label');
+    expect(block.label).toBe('My_Label');
+    expect(block.html_id).toBe('my-label');
+    // explicit labels keep propagating to input/outputs (unchanged behavior)
+    expect(block.children[0].identifier).toBe('my_label-code');
+    expect(block.children[1].identifier).toBe('my_label-outputs');
+    expect(block.children[1].children[0].identifier).toBe('my_label-outputs-0');
+  });
+});
+
 describe('Test blockToFigureTransform', () => {
   test('block metadata is propagated to new figure', async () => {
     const mdast = u('root', [

--- a/packages/myst-transforms/src/blocks.spec.ts
+++ b/packages/myst-transforms/src/blocks.spec.ts
@@ -152,10 +152,16 @@ describe('Test blockMetadataTransform', () => {
 describe('Test blockMetadataTransform notebook cell ids', () => {
   test('a code cell gets a stable anchor equal to its nbformat id', async () => {
     const mdast = u('root', [
-      u('block', { kind: 'notebook-code', data: { _jupyterCellId: '9bd1512c-9ca1-4695' } }, [
-        u('code', 'points'),
-        u('outputs', [u('output', 'a'), u('output', 'b')]),
-      ]),
+      u(
+        'block',
+        {
+          kind: 'notebook-code',
+          data: {},
+          identifier: '9bd1512c-9ca1-4695',
+          html_id: '9bd1512c-9ca1-4695',
+        },
+        [u('code', 'points'), u('outputs', [u('output', 'a'), u('output', 'b')])],
+      ),
     ]) as any;
     blockMetadataTransform(mdast, new VFile());
     const block = mdast.children[0];
@@ -175,7 +181,7 @@ describe('Test blockMetadataTransform notebook cell ids', () => {
   test('the anchor is unchanged across two runs of the same source', async () => {
     const build = () => {
       const mdast = u('root', [
-        u('block', { kind: 'notebook-code', data: { _jupyterCellId: 'abc-123' } }, [
+        u('block', { kind: 'notebook-code', data: {}, identifier: 'abc-123', html_id: 'abc-123' }, [
           u('code', 'x = 1'),
         ]),
       ]) as any;
@@ -198,7 +204,12 @@ describe('Test blockMetadataTransform notebook cell ids', () => {
     const mdast = u('root', [
       u(
         'block',
-        { kind: 'notebook-code', data: { label: 'My_Label', _jupyterCellId: 'abc-123' } },
+        {
+          kind: 'notebook-code',
+          data: { label: 'My_Label' },
+          identifier: 'abc-123',
+          html_id: 'abc-123',
+        },
         [u('code', 'x = 1'), u('outputs', [u('output', 'a')])],
       ),
     ]) as any;

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -65,12 +65,19 @@ export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
       delete block.data.class;
     }
 
+    // Pull out the stashed nbformat cell id (set by the notebook reader) before
+    // the empty-data cleanup so it never leaks into the output AST.
+    const jupyterCellId =
+      typeof block.data?._jupyterCellId === 'string' ? block.data._jupyterCellId : undefined;
+    if (block.data && '_jupyterCellId' in block.data) delete block.data._jupyterCellId;
+
     // Minor cleanup
     if (block.data && Object.keys(block.data).length === 0) delete block.data;
 
-    const label = block.data?.label ?? block.data?.id;
-    if (typeof label === 'string') {
-      const normalized = normalizeLabel(label);
+    const explicitLabel = block.data?.label ?? block.data?.id;
+    const hasExplicitLabel = typeof explicitLabel === 'string';
+    if (typeof explicitLabel === 'string') {
+      const normalized = normalizeLabel(explicitLabel);
       if (normalized) {
         // TODO: raise error if the node is already labelled
         block.identifier = normalized.identifier;
@@ -78,8 +85,21 @@ export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
         block.html_id = normalized.html_id;
         delete block.data.label;
       }
+    } else if (jupyterCellId && !block.identifier) {
+      // Provenance-gated fallback: promote a real .ipynb cell id to a durable
+      // anchor. An author-supplied label always wins (handled above). The
+      // html_id is kept verbatim so a copied deep link equals the nbformat cell
+      // id; the identifier is normalized so `[](#<id>)` resolves like a label.
+      const normalized = normalizeLabel(jupyterCellId);
+      if (normalized) {
+        block.identifier = normalized.identifier;
+        block.html_id = jupyterCellId;
+      }
     }
-    if (block.identifier) {
+    // Only labelled cells propagate identifiers to their input/outputs. Auto cell
+    // ids anchor the cell (block) only: the cell container encloses the input, and
+    // we never fabricate per-output ids under the cell id.
+    if (block.identifier && hasExplicitLabel) {
       const codeNode = select('code', block) as any as Code | null;
       if (codeNode !== null && !codeNode.identifier) {
         codeNode.identifier = `${block.identifier}-code`;

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -65,8 +65,8 @@ export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
       delete block.data.class;
     }
 
-    // Pull out the stashed nbformat cell id (set by the notebook reader) before
-    // the empty-data cleanup so it never leaks into the output AST.
+    // Pull out the stashed nbformat cell id before the empty-data cleanup 
+    // so it never leaks into the output AST.
     const jupyterCellId =
       typeof block.data?._jupyterCellId === 'string' ? block.data._jupyterCellId : undefined;
     if (block.data && '_jupyterCellId' in block.data) delete block.data._jupyterCellId;

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -65,19 +65,12 @@ export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
       delete block.data.class;
     }
 
-    // Pull out the stashed nbformat cell id before the empty-data cleanup
-    // so it never leaks into the output AST.
-    const jupyterCellId =
-      typeof block.data?._jupyterCellId === 'string' ? block.data._jupyterCellId : undefined;
-    if (block.data && '_jupyterCellId' in block.data) delete block.data._jupyterCellId;
-
     // Minor cleanup
     if (block.data && Object.keys(block.data).length === 0) delete block.data;
 
-    const explicitLabel = block.data?.label ?? block.data?.id;
-    const hasExplicitLabel = typeof explicitLabel === 'string';
-    if (typeof explicitLabel === 'string') {
-      const normalized = normalizeLabel(explicitLabel);
+    const label = block.data?.label ?? block.data?.id;
+    if (typeof label === 'string') {
+      const normalized = normalizeLabel(label);
       if (normalized) {
         // TODO: raise error if the node is already labelled
         block.identifier = normalized.identifier;
@@ -85,21 +78,8 @@ export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
         block.html_id = normalized.html_id;
         delete block.data.label;
       }
-    } else if (jupyterCellId && !block.identifier) {
-      // Provenance-gated fallback: promote a real .ipynb cell id to a durable
-      // anchor. An author-supplied label always wins (handled above). The
-      // html_id is kept verbatim so a copied deep link equals the nbformat cell
-      // id; the identifier is normalized so `[](#<id>)` resolves like a label.
-      const normalized = normalizeLabel(jupyterCellId);
-      if (normalized) {
-        block.identifier = normalized.identifier;
-        block.html_id = jupyterCellId;
-      }
     }
-    // Only labelled cells propagate identifiers to their input/outputs. Auto cell
-    // ids anchor the cell (block) only: the cell container encloses the input, and
-    // we never fabricate per-output ids under the cell id.
-    if (block.identifier && hasExplicitLabel) {
+    if (block.identifier) {
       const codeNode = select('code', block) as any as Code | null;
       if (codeNode !== null && !codeNode.identifier) {
         codeNode.identifier = `${block.identifier}-code`;

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -68,7 +68,8 @@ export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
     // Minor cleanup
     if (block.data && Object.keys(block.data).length === 0) delete block.data;
 
-    const label = block.data?.label ?? block.data?.id;
+    // Manual label set from cell metadata
+    const label = block.data?.label;
     if (typeof label === 'string') {
       const normalized = normalizeLabel(label);
       if (normalized) {

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -65,7 +65,7 @@ export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
       delete block.data.class;
     }
 
-    // Pull out the stashed nbformat cell id before the empty-data cleanup 
+    // Pull out the stashed nbformat cell id before the empty-data cleanup
     // so it never leaks into the output AST.
     const jupyterCellId =
       typeof block.data?._jupyterCellId === 'string' ? block.data._jupyterCellId : undefined;

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -70,6 +70,7 @@ export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
 
     // Manual label set from cell metadata
     const label = block.data?.label;
+
     if (typeof label === 'string') {
       const normalized = normalizeLabel(label);
       if (normalized) {
@@ -80,7 +81,11 @@ export function blockMetadataTransform(mdast: GenericParent, file: VFile) {
         delete block.data.label;
       }
     }
-    if (block.identifier) {
+
+    // Did the user set a label? Choose to only propagate IDs if so.
+    const hasExplicitLabel = typeof block.label === 'string';
+
+    if (block.identifier && hasExplicitLabel) {
       const codeNode = select('code', block) as any as Code | null;
       if (codeNode !== null && !codeNode.identifier) {
         codeNode.identifier = `${block.identifier}-code`;


### PR DESCRIPTION
## Fixes #518 

### Description
Right now, deep-linking to notebook cells is unreliable. We were discarding the nbformat cell id and falling back to a random nanoid, so `#<id>` links changed on every build.

This PR promotes notebook cell ids to stable anchors:

- `notebook.ts` preserves `cell.id` when reading `.ipynb` files.
- `blocks.ts` maps it to `identifier` (normalized) and `html_id` (verbatim).
- `myst-to-html` emits the anchor on block containers, so static HTML exports
  get stable links too.