### PR TITLE
Properly discard glob entries that are explicitly enumerated in ToC

### DIFF
--- a/.changeset/eighty-dots-train.md
+++ b/.changeset/eighty-dots-train.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': minor
+---
+
+effectively discard files matched by pattern if already mentioned

--- a/.changeset/eighty-dots-train.md
+++ b/.changeset/eighty-dots-train.md
@@ -1,5 +1,5 @@
 ---
-'myst-cli': minor
+'myst-cli': patch
 ---
 
 effectively discard files matched by pattern if already mentioned

--- a/packages/myst-cli/src/project/fromTOC.ts
+++ b/packages/myst-cli/src/project/fromTOC.ts
@@ -120,7 +120,8 @@ export function patternsToFileEntries(
         const { pattern, sort, ...leftover } = entry as PatternEntry;
         // Glob matches, relative to `path`, ordered naturally
         let matches = globSync(pattern, { cwd: path, nodir: true, ...opts })
-          .filter((item) => !ignore || !ignore.includes(item))
+          // ignore contains resolved entries, so we need to search for item resolved
+          .filter((item) => !ignore || !ignore.includes(resolve(path, item)))
           .sort(comparePaths);
         // Reverse order if descending sort is requested
         if (sort === 'descending') {

--- a/packages/myst-cli/src/project/toc.pattern.spec.ts
+++ b/packages/myst-cli/src/project/toc.pattern.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { resolve } from 'node:path';
 import memfs from 'memfs';
 import { Session } from '../session';
 import { listExplicitFiles, patternsToFileEntries } from './fromTOC';
@@ -140,6 +141,21 @@ describe('patternsToFileEntries', () => {
       { file: 'meetings/2026-02-01.md', implicit: true },
       { file: 'meetings/2026-01-01.md', implicit: true },
     ]);
+  });
+  it('explicitly listed files are excluded from subsequent glob patterns', () => {
+    memfs.vol.fromJSON({
+      'index.md': '',
+      'test1.md': '',
+      'test2.md': '',
+    });
+    // Simulate ignore list built from explicit file entries (absolute paths, as listExplicitFiles returns)
+    const cwd = '.';
+    const ignore = [resolve(cwd, 'index.md'), resolve(cwd, 'test1.md')];
+    expect(
+      patternsToFileEntries(session, [{ pattern: '*.md' }], cwd, ignore, '/tmp/warn.txt', {
+        fs: memfs,
+      }),
+    ).toEqual([{ file: 'test2.md', implicit: true }]);
   });
 });
 


### PR DESCRIPTION
fixes issue #2973

the 'ignore' context that carries already met file entries contains resolved entries, so we need to resolve the item in consideration if we want to find it in that collection