### PR TITLE
Update Node.js version to 24.x in GitHub Pages setup example

### DIFF
--- a/docs/deployment-github-pages.md
+++ b/docs/deployment-github-pages.md
@@ -77,7 +77,7 @@ jobs:
         uses: actions/configure-pages@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24.x
       - name: Install MyST Markdown
         run: npm install -g mystmd
       - name: Build HTML Assets


### PR DESCRIPTION
Thanks for creating and maintaining this great software. I was already happy with JBv1, now working to migrate some publications to JB2 stack: 

The "GitHub Action Example" is no longer correct:

node-version: 18.x is depreciated on GitHub.

Regards!

