### PR TITLE
Fix documentation plugins

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,26 @@
         "vitest": "^3.2.4",
       },
     },
+    "docs": {
+      "name": "mystmd-docs",
+      "version": "0.0.0",
+      "dependencies": {
+        "myst-common": "workspace:*",
+        "myst-directives": "workspace:*",
+        "myst-ext-button": "workspace:*",
+        "myst-ext-card": "workspace:*",
+        "myst-ext-exercise": "workspace:*",
+        "myst-ext-grid": "workspace:*",
+        "myst-ext-proof": "workspace:*",
+        "myst-ext-tabs": "workspace:*",
+        "myst-migrate": "workspace:*",
+        "myst-parser": "workspace:*",
+        "myst-roles": "workspace:*",
+        "tex-to-myst": "workspace:*",
+        "unist-builder": "^3.0.0",
+        "unist-util-select": "^4.0.3",
+      },
+    },
     "packages/citation-js-utils": {
       "name": "citation-js-utils",
       "version": "1.2.8",
@@ -2126,6 +2146,8 @@
     "myst-transforms": ["myst-transforms@workspace:packages/myst-transforms"],
 
     "mystmd": ["mystmd@workspace:packages/mystmd"],
+
+    "mystmd-docs": ["mystmd-docs@workspace:docs"],
 
     "nanoid": ["nanoid@5.1.6", "", { "bin": "bin/nanoid.js" }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 

--- a/docs/contribute-docs.md
+++ b/docs/contribute-docs.md
@@ -27,28 +27,33 @@ Alternatively, you can use the [**`github.dev` web-based editor**](https://docs.
 
 ## How to build the MyST guide documentation locally
 
+The documentation in `docs/` uses its own MyST plugins (`docs/*.mjs`) that require an install and build of the packages, so previewing it requires the full local development setup rather than a globally installed `myst`.
+
 To build the MyST guide documentation:
 
-1. Clone this repository:
+1. Clone this repository and build:
 
    ```
    git clone https://github.com/jupyter-book/mystmd
+   cd mystmd
+   bun install
+   bun run build
+   bun run link  # install this version of mystmd globally
    ```
 
-2. [Install MyST Markdown by following these instructions](https://mystmd.org/guide/quickstart)
-3. Navigate to the docs folder:
+2. Navigate to the docs folder:
 
    ```
-   cd docs/
+   cd docs
    ```
 
-4. Start a MyST server to preview the documentation:
+3. Start a MyST server to preview the documentation:
 
    ```
    myst start
    ```
 
-This will build the documentation locally so that you can preview what your changes will look like.
+The `bun run docs` command is a shorthand for steps 2 and 3 (see [the developer guide](#local-docs-workflows)).
 
 ### Build with executable content
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -315,6 +315,8 @@ The build process uses unix commands that might not work properly on Windows.
 When building on Windows, use either WSL or a unix-like shell (such as Git Bash or MSYS2).
 ```
 
+(local-docs-workflows)=
+
 ### Local docs workflows (preview/build)
 
 To run a MyST server with your local changes and a preview of the documentation, run:
@@ -322,6 +324,10 @@ To run a MyST server with your local changes and a preview of the documentation,
 ```shell
 $ bun run docs
 ```
+
+This builds the `mystmd` packages, and starts a live-reloading preview server.
+
+The `docs/` plugins import several `myst-*` packages as `workspace:*` dependencies, so that they build against the source versions in this repository (not against npm). If you only change the plugins in `docs/*.mjs`, you will need to rebuild the packages and restart the server.
 
 ## Local development: myst-theme
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mystmd-docs",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "myst-common": "workspace:*",
+    "myst-directives": "workspace:*",
+    "myst-ext-button": "workspace:*",
+    "myst-ext-card": "workspace:*",
+    "myst-ext-exercise": "workspace:*",
+    "myst-ext-grid": "workspace:*",
+    "myst-ext-proof": "workspace:*",
+    "myst-ext-tabs": "workspace:*",
+    "myst-migrate": "workspace:*",
+    "myst-parser": "workspace:*",
+    "myst-roles": "workspace:*",
+    "tex-to-myst": "workspace:*",
+    "unist-builder": "^3.0.0",
+    "unist-util-select": "^4.0.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "mystmd",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "docs"
   ],
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
We used to rely on hoisting of dependencies from the root of this
repo, but that broke when switching bun to standalone mode.

This PR declares explicit dependencies for the docs (by name, not version---we simply use the versions in the root repo), and adds a plugin build step to the docs build.

We could, with some shenanigans, get away without the build step, but I think (a) it is cleaner and (b) better to eat our own dogfood the way a user would have to.

Closes #2993 