### PR TITLE
Add public manifest to site builds

### DIFF
--- a/.changeset/grumpy-lions-push.md
+++ b/.changeset/grumpy-lions-push.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add public.json file manifest

--- a/docs/theme-developer.md
+++ b/docs/theme-developer.md
@@ -44,6 +44,7 @@ It then produces `_build/site/config.json`, validates it against your `doc`/`opt
 - Reference and search files at `/objects.inv`, `/myst.xref.json`, `/myst.search.json`.
 - Static assets from `/` and a `/socket` websocket for `LOG` and `RELOAD` events.
 Your start script receives `HOST`, `CONTENT_CDN_PORT`, `PORT`, `MODE` (set to `static` for `myst build --html`), and optional `BASE_URL`; any framework or server is fine as long as it reads these and fetches content from the endpoints above.
+- An index of known static files is included in `public.json`, to enable the theme to retrieve _all_ static files without access to the file-system of the content server.
 
 ## Building HTML
 

--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -234,6 +234,7 @@ export async function buildHtml(session: ISession, opts: StartOptions) {
     copyStaticFiles(session, projectConfig?.static_files ?? [], htmlDir, proj.path);
   }
   fs.copySync(path.join(session.sitePath(), 'config.json'), path.join(htmlDir, 'config.json'));
+  fs.copySync(path.join(session.sitePath(), 'public.json'), path.join(htmlDir, 'public.json'));
   fs.copySync(path.join(session.sitePath(), 'objects.inv'), path.join(htmlDir, 'objects.inv'));
 
   // NOTE: HTML static output needs to patch the contents, this is done on the fly by the server

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -83,6 +83,7 @@ export async function startContentServer(session: ISession, opts?: ServerOptions
   app.use('/', express.static(session.publicPath()));
   app.use('/content', express.static(session.contentPath()));
   app.use('/config.json', express.static(join(session.sitePath(), 'config.json')));
+  app.use('/public.json', express.static(join(session.sitePath(), 'public.json')));
   app.use('/objects.inv', express.static(join(session.sitePath(), 'objects.inv')));
   app.use('/myst.xref.json', express.static(join(session.sitePath(), 'myst.xref.json')));
   app.use('/myst.search.json', express.static(join(session.sitePath(), 'myst.search.json')));

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import { basename, extname, join } from 'node:path';
+import { basename, extname, join, relative } from 'node:path';
 import fs from 'fs-extra';
 import chalk from 'chalk';
 import { Inventory, Domains } from 'intersphinx';
@@ -49,6 +49,7 @@ import { finalizeMdast, postProcessMdast, transformMdast } from './mdast.js';
 import { toSectionedParts, buildHierarchy, sectionToHeadingLevel } from './search.js';
 import { SPEC_VERSION } from '../spec-version.js';
 import { cpus } from 'node:os';
+import { opendir } from 'node:fs/promises';
 
 const WEB_IMAGE_EXTENSIONS = [
   ImageExtensions.mp4,
@@ -160,6 +161,19 @@ export async function writeMystXRefJson(session: ISession, states: ReferenceStat
   const filename = join(session.sitePath(), 'myst.xref.json');
   session.log.debug(`Writing myst.xref.json file: ${filename}`);
   writeFileToFolder(filename, JSON.stringify(mystXRefs));
+}
+
+export async function writePublicJson(session: ISession) {
+  const paths = [];
+  const publicPath = session.publicPath();
+  const dir = await opendir(publicPath, { recursive: true });
+  for await (const path of dir) {
+    const subPath = relative(publicPath, join(path.parentPath, path.name));
+    paths.push(`/${subPath}`);
+  }
+
+  const filename = join(session.sitePath(), 'public.json');
+  writeFileToFolder(filename, JSON.stringify(paths));
 }
 
 export async function writeMystSearchJson(session: ISession, pages: LocalProjectPage[]) {
@@ -741,6 +755,7 @@ export async function processSite(session: ISession, opts?: ProcessSiteOptions):
     await writeMystXRefJson(session, states);
     // Search does not include parts
     await writeMystSearchJson(session, allPages);
+    await writePublicJson(session);
   }
   return true;
 }


### PR DESCRIPTION
Themes that wish to build static sites from site builds do not have enough information to do so without having file-system access to the CDN directory. Namely, they do not have any way to determine the set of files under `public/`.

For example, see https://github.com/jupyter-book/mystmd/issues/3003

This PR adds a simple `public.json` JSON list of paths under public.

Closes https://github.com/jupyter-book/mystmd/issues/3003