### PR TITLE
Respect heading numbering offsets in references

### DIFF
--- a/.changeset/calm-headings-count.md
+++ b/.changeset/calm-headings-count.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Respect heading numbering offsets in cross-references

--- a/packages/myst-transforms/src/enumerate.spec.ts
+++ b/packages/myst-transforms/src/enumerate.spec.ts
@@ -101,6 +101,33 @@ describe('enumeration', () => {
     expect(state.getTarget('h2')?.node.enumerator).toBe('1.1');
     expect(state.getTarget('h3')?.node.enumerator).toBe('2');
   });
+  test('heading references respect the numbering offset', () => {
+    const tree = u('root', [
+      u('heading', { identifier: 'h1', depth: 2 }, [u('text', 'First')]),
+      u('heading', { identifier: 'h2', depth: 3 }, [u('text', 'Second')]),
+    ]);
+    const state = new ReferenceState('my-file.md', {
+      frontmatter: {
+        numbering: {
+          title: { offset: 1 },
+          heading_2: { enabled: true, template: 'First %s' },
+          heading_3: { enabled: true, template: 'Second %s' },
+        },
+      },
+      vfile: new VFile(),
+    });
+    enumerateTargetsTransform(tree, { state });
+    const references = ['h1', 'h2'].map((identifier) => u('crossReference', { identifier }));
+    references.forEach((reference) => state.resolveReferenceContent(reference as any));
+    expect(references).toMatchObject([
+      { enumerator: '1', template: 'First %s', children: [{ value: 'First ' }, { value: '1' }] },
+      {
+        enumerator: '1.1',
+        template: 'Second %s',
+        children: [{ value: 'Second ' }, { value: '1.1' }],
+      },
+    ]);
+  });
   test('sub-figures', () => {
     const tree = u('root', [
       u('container', { identifier: 'fig:1', kind: 'figure' }, [

--- a/packages/myst-transforms/src/enumerate.ts
+++ b/packages/myst-transforms/src/enumerate.ts
@@ -530,7 +530,7 @@ export function addChildrenFromTargetNode(
   const kind = kindFromNode(targetNode);
   const noNodeChildren = !node.children?.length;
   if (kind === TargetKind.heading) {
-    const numberHeading = shouldEnumerateNode(targetNode, TargetKind.heading, numbering);
+    const numberHeading = shouldEnumerateNode(targetNode, TargetKind.heading, numbering, offset);
     const template = getReferenceTemplate(
       { node: targetNode, kind },
       numbering,


### PR DESCRIPTION
## Summary

- Forward the existing heading numbering offset into the reference enumeration decision.
- Add a regression covering shifted first- and second-level heading templates.
- Add the required `myst-transforms` patch changeset.

Fixes #2998

## Validation

Preserved exact-SHA evidence for the unchanged two-file implementation patch:
- pre-fix focused regression: 1 failed as expected
- focused regression: 1 passed
- adjacent enumeration suites: 36 passed
- full `myst-transforms` package: 320 passed
- dependency-aware target build: 8/8 tasks passed
- package lint: 0 errors (6 unrelated existing warnings)
- touched-file formatting and `git diff --check`: passed

The current no-install checkout has no `node_modules`, so no fresh dependency-backed rerun was claimed. No dependencies or lockfiles were changed.

## AI assistance

This Draft PR was prepared with OpenAI Codex. Automated root-cause analysis, patching, and validation evidence were used; no human self-review is claimed. It remains a draft for maintainer and user review.