### PR TITLE
docs: Correctly use complementary instead of complimentary

### DIFF
--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -189,7 +189,7 @@ project:
 
 ## Titles
 
-There are several fields to title MyST projects and pages. Primary page and project titles can be specified simply as `title`. Pages and projects also both have `short_title`; this should provide a summarized title in less than 40 characters. It is used where space is limited, for example a site navigation panel, running-head titles in an static export, etc. You may specify `subtitle`; this conveys complimentary information to the title and may be displayed below the title.
+There are several fields to title MyST projects and pages. Primary page and project titles can be specified simply as `title`. Pages and projects also both have `short_title`; this should provide a summarized title in less than 40 characters. It is used where space is limited, for example a site navigation panel, running-head titles in an static export, etc. You may specify `subtitle`; this conveys complementary information to the title and may be displayed below the title.
 
 ````{note} Defining Page Title in Markdown
 


### PR DESCRIPTION
Currently, https://mystmd.org/guide/frontmatter#titles uses the word “complimentary” incorrectly:

> You may specify subtitle; this conveys **complimentary** information
> to the title and may be displayed below the title.

But “complimentary” is a form of praise or admiration for someone or something. The word “complementary” should be used here, which means subtitle adds, gives extra information and “complements” (not compliments) the title.