### PR TITLE
Update GH pages example workflow

### DIFF
--- a/.changeset/neat-shirts-attend.md
+++ b/.changeset/neat-shirts-attend.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Bump version for GitHub actions and node in GH pages publish action

--- a/packages/myst-cli/src/init/gh-actions/index.ts
+++ b/packages/myst-cli/src/init/gh-actions/index.ts
@@ -52,23 +52,23 @@ jobs:
       url: \${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - uses: actions/setup-node@v4
+        uses: actions/configure-pages@v6
+      - uses: actions/setup-node@v7
         with:
-          node-version: 18.x
+          node-version: 24.x
       - name: Install ${readableName()}
         run: npm install -g ${npmPackageName()}
       - name: Build HTML Assets
         run: ${npmBinaryName()} build --html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './_build/html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 `;
 }
 


### PR DESCRIPTION
The workflow you can create with `myst init --gh-pages` had some quite old versions for actions and node.
I have bumped those here.

I was thinking there might be a more sustainable way to do this. The numbers aren't used elsewhere so moving them to a struct doesn't add much value. I'm not sure if some process which checks the versions in the string against what is on the marketplace is really worth the complexity.