### PR TITLE
Change execution session type to console

### DIFF
--- a/.changeset/fifty-waves-smile.md
+++ b/.changeset/fifty-waves-smile.md
@@ -1,0 +1,5 @@
+---
+'myst-execute': patch
+---
+
+Set type to console for execution options

--- a/packages/myst-execute/src/kernel.ts
+++ b/packages/myst-execute/src/kernel.ts
@@ -28,9 +28,9 @@ export async function createKernelConnection(
   log?: Logger,
 ): Promise<ISessionConnectionWithKernel | undefined> {
   const sessionOpts = {
-    type: 'notebook',
     path: path.relative(basePath, vfile.path),
     name: path.basename(vfile.path),
+    type: 'console',
     kernel: {
       name: kernelspec.name,
     },


### PR DESCRIPTION
`jupyter-server-documents` complains about being unable to open the file associated with a MyST kernel (when using a remote kernel). This is because MyST expects to drive the execution, whereas JSD wants to execute notebooks locally.

This PR changes the type to console, which indicates avoids this error condition.