### PR TITLE
Fix: normalize kernel path with forward slashes (Windows)

### DIFF
--- a/packages/myst-execute/src/kernel.ts
+++ b/packages/myst-execute/src/kernel.ts
@@ -27,8 +27,13 @@ export async function createKernelConnection(
   vfile: VFile,
   log?: Logger,
 ): Promise<ISessionConnectionWithKernel | undefined> {
+  // Jupyter Server API paths are `/`-delimited, but `path.relative` returns
+  // native separators (backslashes on Windows).
+  // With a windows path, jupyter_server silently fall back to the server root.
+  // Normalize to a forward-slash path so kernels start in same location on all platforms.
+  const sessionPath = path.relative(basePath, vfile.path).split(path.sep).join('/');
   const sessionOpts = {
-    path: path.relative(basePath, vfile.path),
+    path: sessionPath,
     name: path.basename(vfile.path),
     type: 'console',
     kernel: {


### PR DESCRIPTION
# References and Relevant Issues

Closes #3010

# Description

When executing notebooks on Windows, the kernel starts from the root rather than the notebook's directory. On Unix systems, the kernel starts from the notebook's directory. This is because `path.relative` returns native separators (backslashes on Windows), and Jupyter Server API paths are `/`-delimited. With a Windows path, Jupyter Server silently falls back to the server root.

[Jupyter server docs explaining the path resolution](https://jupyter-server.readthedocs.io/en/latest/developers/contents.html#api-paths)
And I think this is the actual [juypter-server forward-slash code](https://github.com/jupyter-server/jupyter_server/blob/main/jupyter_server/services/contents/filemanager.py#L1150-L1156) being executed by myst-execute.

I made https://github.com/TimMonko/myst-cwd-repro to demonstrate the issue -- and building with bun (my first time) and running this repo works with the fix.

I'm not sure if I can demonstrate this with a regression test because CI is only Linux it appears, so I guess you could mock the Windows path? Anyways, it's why I left a thorough comment in the code.

I used Deepseek to help me navigate mystmd. To be honest, I've never looked at typescript in my life so please be honest with me.

