### PR TITLE
Render algorithm, assumption, criterion and property in LaTeX export

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+'myst-to-tex': patch
+---
+
+Render algorithm, assumption, criterion, and property proof kinds in LaTeX export

--- a/docs/proofs-and-theorems.md
+++ b/docs/proofs-and-theorems.md
@@ -48,7 +48,7 @@ The vector $\hat y$ is called the **orthogonal projection** of $y$ onto $S$.
   - `proof:axiom`
   - `proof:conjecture`
 * - `proof:corollary`
-  - `proof:criteria`
+  - `proof:criterion`
   - `proof:definition`
 * - `proof:example`
   - `proof:lemma`

--- a/packages/myst-to-tex/src/proof.ts
+++ b/packages/myst-to-tex/src/proof.ts
@@ -31,6 +31,14 @@ function kindToEnvironment(kind: ProofKind): string {
       return 'observation';
     case 'corollary':
       return 'corollary';
+    case 'algorithm':
+      return 'algorithm';
+    case 'assumption':
+      return 'assumption';
+    case 'criterion':
+      return 'criterion';
+    case 'property':
+      return 'property';
     default:
       return '';
   }
@@ -99,6 +107,10 @@ export class TexProofSerializer {
       '\\newtheorem{axiom}{Axiom}[section]',
       '\\newtheorem{conjecture}{Conjecture}[section]',
       '\\newtheorem{observation}{Observation}[section]',
+      '\\newtheorem{algorithm}{Algorithm}[section]',
+      '\\newtheorem{assumption}{Assumption}[section]',
+      '\\newtheorem{criterion}{Criterion}[section]',
+      '\\newtheorem{property}{Property}[section]',
     ];
     const block = writeTexLabelledComment(
       'theorem',

--- a/packages/myst-to-tex/tests/proofs.spec.ts
+++ b/packages/myst-to-tex/tests/proofs.spec.ts
@@ -1,0 +1,12 @@
+import { describe, test, expect } from 'vitest';
+import { TexProofSerializer } from '../src/proof';
+
+describe('TexProofSerializer preamble', () => {
+  test.each(['algorithm', 'assumption', 'criterion', 'property'])(
+    'declares a \\newtheorem environment for %s',
+    (env) => {
+      const { preamble } = new TexProofSerializer();
+      expect(preamble).toContain(`\\newtheorem{${env}}`);
+    },
+  );
+});

--- a/packages/myst-to-tex/tests/proofs.yml
+++ b/packages/myst-to-tex/tests/proofs.yml
@@ -207,3 +207,83 @@ cases:
       Some text before an observation
 
       \begin{observation}\label{obs-t1}This is it.\end{observation}
+  - title: algorithm after paragraph
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'Some text before an algorithm'
+        - type: proof
+          kind: algorithm
+          label: alg-t1
+          identifier: alg-t1
+          enumerated: true
+          children:
+            - type: text
+              value: 'Do this, then that.'
+    latex: |-
+      Some text before an algorithm
+
+      \begin{algorithm}\label{alg-t1}Do this, then that.\end{algorithm}
+  - title: assumption after paragraph
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'Some text before an assumption'
+        - type: proof
+          kind: assumption
+          label: asm-t1
+          identifier: asm-t1
+          enumerated: true
+          children:
+            - type: text
+              value: 'Assume this holds.'
+    latex: |-
+      Some text before an assumption
+
+      \begin{assumption}\label{asm-t1}Assume this holds.\end{assumption}
+  - title: criterion after paragraph
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'Some text before a criterion'
+        - type: proof
+          kind: criterion
+          label: crit-t1
+          identifier: crit-t1
+          enumerated: true
+          children:
+            - type: text
+              value: 'This is the criterion.'
+    latex: |-
+      Some text before a criterion
+
+      \begin{criterion}\label{crit-t1}This is the criterion.\end{criterion}
+  - title: property after paragraph
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'Some text before a property'
+        - type: proof
+          kind: property
+          label: prop-p1
+          identifier: prop-p1
+          enumerated: true
+          children:
+            - type: text
+              value: 'This property holds.'
+    latex: |-
+      Some text before a property
+
+      \begin{property}\label{prop-p1}This property holds.\end{property}


### PR DESCRIPTION
Closes #3030
Closes #2680

`kindToEnvironment` mapped 11 of the 15 `PROOF_KINDS`. The other four matched no case, so they were dropped from the export along with their labels.

Adds the four cases, their `\newtheorem` declarations, and fixture coverage for each. Also corrects `proof:criteria` to `proof:criterion` in the proof-kinds table, since the registered kind is `criterion` and the example further down the same page uses it.

One note: `\newtheorem{algorithm}` clashes with `\usepackage{algorithm}` if a template loads it. No bundled template does, and the current behaviour for those users is silent content loss, but I am happy to guard the declarations instead if you prefer.
