### PR TITLE
Include citations from frontmatter parts in the exported bibliography

### DIFF
--- a/.changeset/fuzzy-mangos-repeat.md
+++ b/.changeset/fuzzy-mangos-repeat.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Include citations from frontmatter parts in the exported bibliography

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -31,7 +31,10 @@ import { getFileContent } from '../utils/getFileContent.js';
 import { addWarningForFile } from '../../utils/addWarningForFile.js';
 import { cleanOutput } from '../utils/cleanOutput.js';
 import { createTempFolder } from '../../utils/createTempFolder.js';
-import { resolveFrontmatterParts } from '../../utils/resolveFrontmatterParts.js';
+import {
+  resolveFrontmatterParts,
+  resolveFrontmatterPartsReferences,
+} from '../../utils/resolveFrontmatterParts.js';
 import type { ExportWithOutput, ExportResults, ExportFnOptions } from '../types.js';
 import { writeBibtexFromCitationRenderers } from '../utils/bibtex.js';
 
@@ -216,7 +219,12 @@ export async function localArticleToTexTemplated(
   const bibtexWritten = writeBibtexFromCitationRenderers(
     session,
     path.join(path.dirname(output), DEFAULT_BIB_FILENAME),
-    content,
+    [
+      ...content,
+      ...content.flatMap(({ frontmatter }) =>
+        resolveFrontmatterPartsReferences(session, frontmatter),
+      ),
+    ],
   );
 
   const warningLogFn = (message: string) => {

--- a/packages/myst-cli/src/build/typst.ts
+++ b/packages/myst-cli/src/build/typst.ts
@@ -32,7 +32,10 @@ import { logMessagesFromVFile } from '../utils/logging.js';
 import { getFileContent } from './utils/getFileContent.js';
 import { addWarningForFile } from '../utils/addWarningForFile.js';
 import { createTempFolder } from '../utils/createTempFolder.js';
-import { resolveFrontmatterParts } from '../utils/resolveFrontmatterParts.js';
+import {
+  resolveFrontmatterParts,
+  resolveFrontmatterPartsReferences,
+} from '../utils/resolveFrontmatterParts.js';
 import version from '../version.js';
 import { cleanOutput } from './utils/cleanOutput.js';
 import type { ExportWithOutput, ExportResults, ExportFnOptions } from './types.js';
@@ -239,7 +242,12 @@ export async function localArticleToTypstTemplated(
   const bibtexWritten = writeBibtexFromCitationRenderers(
     session,
     path.join(path.dirname(output), DEFAULT_BIB_FILENAME),
-    content,
+    [
+      ...content,
+      ...content.flatMap(({ frontmatter }) =>
+        resolveFrontmatterPartsReferences(session, frontmatter),
+      ),
+    ],
   );
 
   const warningLogFn = (message: string) => {

--- a/packages/myst-cli/src/utils/resolveFrontmatterParts.spec.ts
+++ b/packages/myst-cli/src/utils/resolveFrontmatterParts.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { Session } from '../session/session';
+import { castSession } from '../session/cache';
+import { resolveFrontmatterPartsReferences } from './resolveFrontmatterParts';
+
+function sessionWithPart(file: string, order: string[]) {
+  const session = new Session();
+  castSession(session).$setMdast(file, {
+    pre: { kind: 'Part', file, mdast: { type: 'root', children: [] }, location: `/${file}` },
+    post: {
+      kind: 'Part',
+      file,
+      location: `/${file}`,
+      sha256: 'abc',
+      frontmatter: {},
+      mdast: { type: 'root', children: [] },
+      references: { cite: { order, data: {} } },
+      dependencies: [],
+    },
+  } as any);
+  return session;
+}
+
+describe('resolveFrontmatterPartsReferences', () => {
+  it('returns references from a frontmatter part file', () => {
+    const session = sessionWithPart('abstract.md', ['inabstract2021']);
+    const result = resolveFrontmatterPartsReferences(session, {
+      parts: { abstract: ['abstract.md'] },
+    } as any);
+    expect(result).toEqual([{ references: { cite: { order: ['inabstract2021'], data: {} } } }]);
+  });
+
+  it('returns an empty list when frontmatter has no parts', () => {
+    const session = sessionWithPart('abstract.md', ['inabstract2021']);
+    expect(resolveFrontmatterPartsReferences(session, {} as any)).toEqual([]);
+  });
+});

--- a/packages/myst-cli/src/utils/resolveFrontmatterParts.spec.ts
+++ b/packages/myst-cli/src/utils/resolveFrontmatterParts.spec.ts
@@ -3,8 +3,7 @@ import { Session } from '../session/session';
 import { castSession } from '../session/cache';
 import { resolveFrontmatterPartsReferences } from './resolveFrontmatterParts';
 
-function sessionWithPart(file: string, order: string[]) {
-  const session = new Session();
+function sessionWithPart(file: string, order: string[], session = new Session()) {
   castSession(session).$setMdast(file, {
     pre: { kind: 'Part', file, mdast: { type: 'root', children: [] }, location: `/${file}` },
     post: {
@@ -33,5 +32,20 @@ describe('resolveFrontmatterPartsReferences', () => {
   it('returns an empty list when frontmatter has no parts', () => {
     const session = sessionWithPart('abstract.md', ['inabstract2021']);
     expect(resolveFrontmatterPartsReferences(session, {} as any)).toEqual([]);
+  });
+
+  it('ignores parts with multiple files, matching resolveFrontmatterParts', () => {
+    const session = sessionWithPart(
+      'appendix-b.md',
+      ['inb2021'],
+      sessionWithPart('appendix-a.md', ['ina2021']),
+    );
+    // resolveFrontmatterParts does not render these, so their citations must not
+    // be harvested either - the bibliography follows what is rendered.
+    expect(
+      resolveFrontmatterPartsReferences(session, {
+        parts: { appendix: ['appendix-a.md', 'appendix-b.md'] },
+      } as any),
+    ).toEqual([]);
   });
 });

--- a/packages/myst-cli/src/utils/resolveFrontmatterParts.ts
+++ b/packages/myst-cli/src/utils/resolveFrontmatterParts.ts
@@ -1,4 +1,4 @@
-import type { FrontmatterParts } from 'myst-common';
+import type { FrontmatterParts, References } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
 import { castSession } from '../session/cache.js';
 import type { ISession } from '../session/types.js';
@@ -19,4 +19,25 @@ export function resolveFrontmatterParts(
     if (mdast) partsMdast[part] = { mdast, frontmatter };
   });
   return partsMdast;
+}
+
+/**
+ * Load references from frontmatter part files
+ *
+ * Part content is rendered into exports, so citations that only appear in a
+ * part must still reach the exported bibliography.
+ */
+export function resolveFrontmatterPartsReferences(
+  session: ISession,
+  pageFrontmatter?: PageFrontmatter,
+): { references: References }[] {
+  const { parts } = pageFrontmatter ?? {};
+  if (!parts || Object.keys(parts).length === 0) return [];
+  const partsReferences: { references: References }[] = [];
+  Object.values(parts).forEach((content) => {
+    if (content.length !== 1) return;
+    const { references } = castSession(session).$getMdast(content[0])?.post ?? {};
+    if (references) partsReferences.push({ references });
+  });
+  return partsReferences;
 }

--- a/packages/mystmd/tests/exports.yml
+++ b/packages/mystmd/tests/exports.yml
@@ -603,3 +603,9 @@ cases:
         content: extend-part-plugin/outputs/index.json
       - path: extend-part-plugin/_build/site/config.json
         content: extend-part-plugin/outputs/config.json
+  - title: Citations in frontmatter parts reach the exported bibliography
+    cwd: part-citations
+    command: myst build --tex --ci
+    outputs:
+      - path: part-citations/_build/main.bib
+        content: outputs/part-citations.bib

--- a/packages/mystmd/tests/outputs/part-citations.bib
+++ b/packages/mystmd/tests/outputs/part-citations.bib
@@ -1,0 +1,15 @@
+@article{body2020,
+	author = {Body, Alice},
+	journal = {Journal of Bodies},
+	year = {2020},
+	title = {Cited {From} {The} {Body}},
+}
+
+
+@article{abstract2021,
+	author = {Abstract, Bob},
+	journal = {Journal of Abstracts},
+	year = {2021},
+	title = {Cited {Only} {From} {The} {Abstract}},
+}
+

--- a/packages/mystmd/tests/part-citations/abstract.md
+++ b/packages/mystmd/tests/part-citations/abstract.md
@@ -1,0 +1,1 @@
+This abstract cites @abstract2021.

--- a/packages/mystmd/tests/part-citations/input.md
+++ b/packages/mystmd/tests/part-citations/input.md
@@ -1,0 +1,8 @@
+---
+title: Part citations
+abstract: abstract.md
+---
+
+# Introduction
+
+The body cites @body2020.

--- a/packages/mystmd/tests/part-citations/myst.yml
+++ b/packages/mystmd/tests/part-citations/myst.yml
@@ -1,0 +1,9 @@
+version: 1
+project:
+  bibliography:
+    - refs.bib
+  export:
+    format: tex
+    template: ../templates/tex
+    output: _build/out.tex
+    article: input.md

--- a/packages/mystmd/tests/part-citations/refs.bib
+++ b/packages/mystmd/tests/part-citations/refs.bib
@@ -1,0 +1,12 @@
+@article{body2020,
+  title = {Cited From The Body},
+  author = {Body, Alice},
+  journal = {Journal of Bodies},
+  year = {2020}
+}
+@article{abstract2021,
+  title = {Cited Only From The Abstract},
+  author = {Abstract, Bob},
+  journal = {Journal of Abstracts},
+  year = {2021}
+}


### PR DESCRIPTION
Closes #3032

Part content is rendered into exports, but `resolveFrontmatterParts` discarded the part's `references`, so a citation appearing only in a part reached the `.tex` while its bibliography entry did not. BibTeX then dropped the reference.

Adds `resolveFrontmatterPartsReferences` and includes part references when writing the bibliography for the `tex` and `typst` exports, with unit coverage for the new helper.
