### PR TITLE
Fix numbered cross references in exports

### DIFF
--- a/.changeset/olive-jars-repeat.md
+++ b/.changeset/olive-jars-repeat.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Keep the boolean numbering shorthand when filling frontmatter

--- a/.changeset/quick-pandas-invite.md
+++ b/.changeset/quick-pandas-invite.md
@@ -1,0 +1,6 @@
+---
+'myst-transforms': patch
+'myst-cli': patch
+---
+
+Number headings in single article exports so numbered cross references resolve

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -178,6 +178,8 @@ export async function transformMdast(
     if (frontmatter.numbering.title.offset == null) frontmatter.numbering.title.offset = offset;
   }
   await addEditUrl(session, frontmatter, file);
+  // Depth of the first content heading; single-article exports start at depth 1
+  const firstDepth = Math.max(1, (titleDepth ?? 1) + (frontmatter.content_includes_title ? 0 : 1));
   const references: References = {
     cite: { order: [], data: {} },
   };
@@ -215,7 +217,7 @@ export async function transformMdast(
     .use(htmlPlugin, { htmlHandlers }) // Some of the HTML plugins need to operate on the transformed html, e.g. figure caption transforms
     .use(basicTransformationsPlugin, {
       parser: (content: string) => parseMyst(session, content, file),
-      firstDepth: (titleDepth ?? 1) + (frontmatter.content_includes_title ? 0 : 1),
+      firstDepth,
     })
     .use(inlineMathSimplificationPlugin, { replaceSymbol: false })
     .use(mathPlugin, { macros: frontmatter.math });
@@ -291,6 +293,7 @@ export async function transformMdast(
     references,
     identifiers,
     widgets,
+    firstDepth,
   } as any;
   const cachedMdast = cache.$getMdast(file);
   if (cachedMdast) cachedMdast.post = data;

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -355,7 +355,8 @@ export function selectPageReferenceStates(
   let previousCounts: TargetCounts | undefined;
   const pageReferenceStates: ReferenceState[] = pages
     .map(({ file, hidden }: { file: string; hidden?: boolean }) => {
-      const { frontmatter, identifiers, mdast, kind } = cache.$getMdast(file)?.post ?? {};
+      const { frontmatter, identifiers, mdast, kind, firstDepth } =
+        cache.$getMdast(file)?.post ?? {};
       const vfile = new VFile();
       vfile.path = file;
 
@@ -368,6 +369,7 @@ export function selectPageReferenceStates(
         previousCounts,
         vfile,
         hidden,
+        firstDepth,
       });
       if (frontmatter && !frontmatter.enumerator) {
         frontmatter.enumerator = state.enumerator;

--- a/packages/myst-cli/src/transforms/types.ts
+++ b/packages/myst-cli/src/transforms/types.ts
@@ -19,6 +19,8 @@ export type RendererData = PreRendererData & {
   frontmatter: PageFrontmatter;
   references: References;
   dependencies: Dependency[];
+  /** Depth of the first content heading; defaults to 2, below the page title */
+  firstDepth?: number;
 };
 
 export type SingleCitationRenderer = {

--- a/packages/myst-frontmatter/src/numbering/numbering.spec.ts
+++ b/packages/myst-frontmatter/src/numbering/numbering.spec.ts
@@ -11,6 +11,15 @@ describe('fillNumbering', () => {
   it('boolean filler is kept', async () => {
     expect(fillNumbering({}, true as any)).toEqual({ all: { enabled: true } });
   });
+  it('boolean false is kept', async () => {
+    expect(fillNumbering(false as any, {})).toEqual({ all: { enabled: false } });
+  });
+  it('string boolean shorthand is coerced', async () => {
+    // isBoolean accepts 'true'/'false', so the shorthand must be coerced rather
+    // than passed through - the string 'false' is truthy.
+    expect(fillNumbering('false' as any, {})).toEqual({ all: { enabled: false } });
+    expect(fillNumbering('true' as any, {})).toEqual({ all: { enabled: true } });
+  });
   it('base numberings return base', async () => {
     expect(
       fillNumbering(

--- a/packages/myst-frontmatter/src/numbering/numbering.spec.ts
+++ b/packages/myst-frontmatter/src/numbering/numbering.spec.ts
@@ -5,6 +5,12 @@ describe('fillNumbering', () => {
   it('empty numberings return empty', async () => {
     expect(fillNumbering({}, {})).toEqual({});
   });
+  it('boolean base is kept', async () => {
+    expect(fillNumbering(true as any, {})).toEqual({ all: { enabled: true } });
+  });
+  it('boolean filler is kept', async () => {
+    expect(fillNumbering({}, true as any)).toEqual({ all: { enabled: true } });
+  });
   it('base numberings return base', async () => {
     expect(
       fillNumbering(

--- a/packages/myst-frontmatter/src/numbering/validators.ts
+++ b/packages/myst-frontmatter/src/numbering/validators.ts
@@ -248,7 +248,18 @@ export function validateNumbering(input: any, opts: ValidationOptions): Numberin
   return output;
 }
 
+/**
+ * Numbering may still be the boolean shorthand, for example when filling raw page
+ * frontmatter before validation. Spreading a boolean silently discards it.
+ */
+function normalizeNumberingShorthand(value?: Numbering) {
+  if (!isBoolean(value)) return value;
+  return { all: { enabled: `${value}`.toLowerCase() === 'true' } } as Numbering;
+}
+
 export function fillNumbering(base?: Numbering, filler?: Numbering) {
+  base = normalizeNumberingShorthand(base);
+  filler = normalizeNumberingShorthand(filler);
   const output: Numbering = { ...filler, ...base };
   Object.entries(filler ?? {})
     .filter(([key]) => !NUMBERING_OPTIONS.includes(key))

--- a/packages/myst-transforms/src/enumerate.spec.ts
+++ b/packages/myst-transforms/src/enumerate.spec.ts
@@ -101,6 +101,22 @@ describe('enumeration', () => {
     expect(state.getTarget('h2')?.node.enumerator).toBe('1.1');
     expect(state.getTarget('h3')?.node.enumerator).toBe('2');
   });
+  test('headers starting at depth one', () => {
+    const tree = u('root', [
+      u('heading', { identifier: 'h1', depth: 1 }),
+      u('heading', { identifier: 'h2', depth: 2 }),
+      u('heading', { identifier: 'h3', depth: 1 }),
+    ]);
+    const state = new ReferenceState('my-file.md', {
+      frontmatter: { numbering: { heading_1: { enabled: true }, heading_2: { enabled: true } } },
+      firstDepth: 1,
+      vfile: new VFile(),
+    });
+    enumerateTargetsTransform(tree, { state });
+    expect(state.getTarget('h1')?.node.enumerator).toBe('1');
+    expect(state.getTarget('h2')?.node.enumerator).toBe('1.1');
+    expect(state.getTarget('h3')?.node.enumerator).toBe('2');
+  });
   test('sub-figures', () => {
     const tree = u('root', [
       u('container', { identifier: 'fig:1', kind: 'figure' }, [

--- a/packages/myst-transforms/src/enumerate.ts
+++ b/packages/myst-transforms/src/enumerate.ts
@@ -79,20 +79,31 @@ function getDefaultNamedReferenceTemplate(
   }
 }
 
+/**
+ * Heading numbering level for a heading at the given mdast depth
+ *
+ * Content headings normally start at depth 2, below the page title; single-article
+ * exports start them at depth 1. depthOffset accounts for that difference and is
+ * zero when headings start at the usual depth.
+ */
+function headingNumber(depth: number, numbering: Numbering, offset?: number, depthOffset?: number) {
+  return depth - (numbering?.title?.enabled ? 0 : 1) + (offset ?? 0) + (depthOffset ?? 0);
+}
+
 function getReferenceTemplate(
   target: Target,
   numbering: Numbering,
   numbered: boolean,
   hasTitle: boolean,
   offset?: number,
+  depthOffset?: number,
 ) {
   const { kind, node } = target;
   let template: string | undefined;
   if (numbered) {
     if (kind === TargetKind.heading && node.type === 'heading') {
       template =
-        numbering[`heading_${node.depth - (numbering?.title?.enabled ? 0 : 1) + (offset ?? 0)}`]
-          ?.template;
+        numbering[`heading_${headingNumber(node.depth, numbering, offset, depthOffset)}`]?.template;
     } else if (node.subcontainer) {
       template = numbering.subfigure?.template;
     } else {
@@ -212,14 +223,15 @@ function shouldEnumerateNode(
   kind: TargetKind | string,
   numbering: Numbering,
   offset?: number,
+  depthOffset?: number,
 ): boolean {
   // Node may override enumeration from numbering frontmatter
   if (node.enumerated != null) return node.enumerated;
   const enabledDefault = numbering.all?.enabled ?? false;
   if (kind === 'heading' && node.type === 'heading') {
     return (
-      numbering[`heading_${node.depth - (numbering?.title?.enabled ? 0 : 1) + (offset ?? 0)}`]
-        ?.enabled ?? enabledDefault
+      numbering[`heading_${headingNumber(node.depth, numbering, offset, depthOffset)}`]?.enabled ??
+      enabledDefault
     );
   }
   if (node.subcontainer) return numbering.subfigure?.enabled ?? enabledDefault;
@@ -337,6 +349,7 @@ export class ReferenceState implements IReferenceStateResolver {
   identifiers: string[];
   enumerator?: string;
   offset: number;
+  depthOffset: number;
 
   constructor(
     filePath: string,
@@ -348,10 +361,13 @@ export class ReferenceState implements IReferenceStateResolver {
       identifiers?: string[];
       vfile: VFile;
       hidden?: boolean;
+      /** Depth of the first content heading; defaults to 2, below the page title */
+      firstDepth?: number;
     },
   ) {
     this.numbering = fillNumbering(opts?.frontmatter?.numbering, DEFAULT_NUMBERING);
     this.offset = this.numbering?.title?.offset ?? 0;
+    this.depthOffset = 2 - (opts?.firstDepth ?? 2);
     this.targetCounts = initializeTargetCounts(this.numbering, opts?.previousCounts, this.offset);
     if (
       !opts?.hidden &&
@@ -380,7 +396,8 @@ export class ReferenceState implements IReferenceStateResolver {
   addTarget(node: TargetNodes, hidden?: boolean) {
     if (!isTargetIdentifierNode(node)) return;
     const kind = kindFromNode(node);
-    const numberNode = !hidden && shouldEnumerateNode(node, kind, this.numbering, this.offset);
+    const numberNode =
+      !hidden && shouldEnumerateNode(node, kind, this.numbering, this.offset, this.depthOffset);
     if (numberNode) {
       this.incrementCount(node, kind as TargetKind);
     }
@@ -425,15 +442,12 @@ export class ReferenceState implements IReferenceStateResolver {
     }
     let enumerator: string | number;
     if (kind === TargetKind.heading && node.type === 'heading') {
-      this.targetCounts.heading = incrementHeadingCounts(
-        node.depth - (this.numbering?.title?.enabled ? 0 : 1) + this.offset,
-        this.targetCounts.heading,
-      );
+      const headingLevel = headingNumber(node.depth, this.numbering, this.offset, this.depthOffset);
+      this.targetCounts.heading = incrementHeadingCounts(headingLevel, this.targetCounts.heading);
       enumerator = formatHeadingEnumerator(
         this.targetCounts.heading,
-        this.numbering[
-          `heading_${node.depth - (this.numbering?.title?.enabled ? 0 : 1) + this.offset}`
-        ]?.enumerator ?? this.numbering.enumerator?.enumerator,
+        this.numbering[`heading_${headingLevel}`]?.enumerator ??
+          this.numbering.enumerator?.enumerator,
       );
       node.enumerator = enumerator;
       return enumerator;
@@ -515,7 +529,14 @@ export class ReferenceState implements IReferenceStateResolver {
     }
     // Put the kind on the node so we can use that later
     node.kind = target.kind;
-    addChildrenFromTargetNode(node, target.node, this.numbering, this.vfile, this.offset);
+    addChildrenFromTargetNode(
+      node,
+      target.node,
+      this.numbering,
+      this.vfile,
+      this.offset,
+      this.depthOffset,
+    );
   }
 }
 
@@ -525,18 +546,27 @@ export function addChildrenFromTargetNode(
   numbering?: Numbering,
   vfile?: VFile,
   offset?: number,
+  depthOffset?: number,
 ) {
   numbering = fillNumbering(numbering, DEFAULT_NUMBERING);
   const kind = kindFromNode(targetNode);
   const noNodeChildren = !node.children?.length;
   if (kind === TargetKind.heading) {
-    const numberHeading = shouldEnumerateNode(targetNode, TargetKind.heading, numbering);
+    // offset is deliberately not passed here, matching the existing behaviour
+    const numberHeading = shouldEnumerateNode(
+      targetNode,
+      TargetKind.heading,
+      numbering,
+      undefined,
+      depthOffset,
+    );
     const template = getReferenceTemplate(
       { node: targetNode, kind },
       numbering,
       numberHeading,
       true,
       offset,
+      depthOffset,
     );
     fillReferenceEnumerators(
       vfile,

--- a/packages/mystmd/tests/exports.yml
+++ b/packages/mystmd/tests/exports.yml
@@ -581,7 +581,7 @@ cases:
       MYST_TEST_SLEEP_MS: 4000
       MYST_TEST_DELAY_MS: 2000
     # Used to be 15000, increased due to CI slowness
-    # NOTE that the full test suite has a timeout here too: 
+    # NOTE that the full test suite has a timeout here too:
     # mystmd/packages/mystmd/tests/endToEnd.spec.ts
     timeout: 30000
     outputs:
@@ -603,3 +603,9 @@ cases:
         content: extend-part-plugin/outputs/index.json
       - path: extend-part-plugin/_build/site/config.json
         content: extend-part-plugin/outputs/config.json
+  - title: Numbered heading cross references resolve in single article exports
+    cwd: numbered-heading-xref
+    command: myst build --tex
+    outputs:
+      - path: numbered-heading-xref/_build/out.tex
+        content: outputs/numbered-heading-xref.tex

--- a/packages/mystmd/tests/numbered-heading-xref/input.md
+++ b/packages/mystmd/tests/numbered-heading-xref/input.md
@@ -1,0 +1,12 @@
+---
+title: Numbered cross references
+numbering: true
+---
+
+# Introduction
+
+See [Sec %s](#resources).
+
+(resources)=
+
+# Resources

--- a/packages/mystmd/tests/numbered-heading-xref/myst.yml
+++ b/packages/mystmd/tests/numbered-heading-xref/myst.yml
@@ -1,0 +1,7 @@
+version: 1
+project:
+  export:
+    format: tex
+    template: null
+    output: _build/out.tex
+    article: input.md

--- a/packages/mystmd/tests/outputs/numbered-heading-xref.tex
+++ b/packages/mystmd/tests/outputs/numbered-heading-xref.tex
@@ -1,0 +1,5 @@
+\section{Introduction}
+
+See Section~\ref{resources}.
+
+\section{Resources}\label{resources}


### PR DESCRIPTION
Closes #1924

`[Sec %s](#label)` renders `Sec ??` in exports while the site build renders it correctly. There are two independent causes, one commit each.

**Heading numbering is switched off for single article exports.** A single article export sets the article level to 0 so the first section is a `\section`. That makes the first content heading depth 1, and the numbering lookup computes `heading_${depth - 1}` = `heading_0`, a key no configuration can enable. This passes the first heading depth through to `ReferenceState`; the added term is zero when headings start at the usual depth, so the expression is unchanged elsewhere.

**`numbering: true` is discarded from page frontmatter.** Page frontmatter is merged before validation, so numbering may still be the boolean shorthand when `fillNumbering` runs. Its first line spreads it, and spreading a boolean yields `{}`. Object forms such as `numbering: {headings: true}` survive, which is why only the boolean form was affected.

Covered by unit tests in `myst-transforms` and `myst-frontmatter`, plus an end-to-end fixture using the exact configuration from the report. Existing numbering tests, single page and multi page, pass unchanged.

One note: page scope `heading_1: true` still has no effect (use `headings: true`). That looks like separate, possibly intended behaviour, so I left it alone.
