### PR TITLE
Improve LaTeX citations

### DIFF
--- a/.changeset/six-words-watch.md
+++ b/.changeset/six-words-watch.md
@@ -1,0 +1,5 @@
+---
+'myst-to-tex': patch
+---
+
+Improve LaTeX citation handling

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -403,29 +403,71 @@ const handlers: Record<string, Handler> = {
     state.write(text.replace(/%s/g, `\\ref{${id}}`));
   },
   citeGroup(node, state) {
-    if (state.options.citestyle === 'numerical-only') {
-      state.write('\\cite{');
-    } else if (state.options.bibliography === 'biblatex') {
-      const command = node.kind === 'narrative' ? 'textcite' : 'parencite';
-      state.write(`\\${command}{`);
-    } else {
-      const tp = node.kind === 'narrative' ? 't' : 'p';
-      state.write(`\\cite${tp}{`);
-    }
     state.renderChildren(node, true, ', ');
-    state.write('}');
   },
   cite(node, state, parent) {
-    if (!state.options.bibliography) {
+    if (!state.options.bibliography || state.options.bibliography === 'natbib') {
       state.usePackages('natbib');
       // Don't include biblatex in the package list
     }
-    if (parent.type === 'citeGroup') {
-      state.write(node.label);
-    } else if (state.options.bibliography === 'biblatex') {
-      state.write(`\\textcite{${node.label}}`);
-    } else {
-      state.write(`\\cite{${node.label}}`);
+
+    const standalone = parent.type !== 'citeGroup';
+    const firstSibling = parent.children?.[0];
+    const lastSibling = parent.children?.[parent.children.length - 1];
+
+    if (standalone || node === firstSibling) {
+      // Write the command if this is a standalone citation or the first
+      // citation of a group
+      if (state.options.citestyle === 'numerical-only') {
+        state.write('\\cite');
+      } else if (state.options.bibliography === 'biblatex') {
+        if (node.kind === 'narrative') {
+          if (node.partial === 'year') {
+            state.write('\\cite*');
+          } else {
+            state.write('\\textcite');
+          }
+        } else {
+          state.write('\\parencite');
+          if (node.partial === 'year') {
+            state.write('*');
+          }
+        }
+      } else {
+        if (node.partial === 'author') {
+          state.write('\\citeauthor');
+        } else if (node.partial === 'year') {
+          if (node.kind === 'parenthetical') {
+            state.write('\\citeyearpar');
+          } else {
+            state.write('\\citeyear');
+          }
+        } else if (node.kind === 'parenthetical') {
+          state.write('\\citep');
+        } else {
+          state.write('\\citet');
+        }
+      }
+
+      if (node.prefix) {
+        state.write(`[${node.prefix}]`);
+        if ((standalone && !node.suffix) || (!standalone && !lastSibling?.suffix)) {
+          state.write('[]');
+        }
+      }
+
+      if (standalone && node.suffix) {
+        state.write(`[${node.suffix}]`);
+      } else if (!standalone && lastSibling.suffix) {
+        state.write(`[${lastSibling.suffix}]`);
+      }
+
+      state.write('{');
+    }
+
+    state.write(node.label);
+    if (standalone || node === lastSibling) {
+      state.write('}');
     }
   },
   embed(node, state) {

--- a/packages/myst-to-tex/tests/citations_biblatex.yml
+++ b/packages/myst-to-tex/tests/citations_biblatex.yml
@@ -1,0 +1,190 @@
+title: Biblatex citation style examples
+options:
+  bibliography: biblatex
+cases:
+  - title: Narrative citation
+    imports: []
+    myst: |-
+      @jon90
+    mdast:
+      type: root
+      children:
+        - type: cite
+          label: jon90
+          kind: narrative
+    latex: |-
+      \textcite{jon90}
+
+  - title: Narrative citation in a citeGroup
+    # myst: ??
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: narrative
+          children:
+            - type: cite
+              label: jon90
+              kind: narrative
+    latex: |-
+      \textcite{jon90}
+
+  - title: Narrative citation with suffix
+    myst: |-
+      @jon90 [chap. 2]
+    mdast:
+      type: root
+      children:
+        - type: cite
+          label: jon90
+          kind: narrative
+          suffix: chap. 2
+    latex: |-
+      \textcite[chap. 2]{jon90}
+
+  - title: Parenthetical citation
+    myst: |-
+      [@jon90]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+    latex: |-
+      \parencite{jon90}
+
+  - title: Parenthetical citation with suffix
+    myst: |-
+      [@jon90, chap. 2]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              suffix: chap. 2
+    latex: |-
+      \parencite[chap. 2]{jon90}
+
+  - title: Parenthetical citation with prefix
+    myst: |-
+      [see @jon90]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              prefix: see
+    latex: |-
+      \parencite[see][]{jon90}
+
+  - title: Parenthetical citation with prefix and suffix
+    myst: |-
+      [see @jon90, chap. 2]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              prefix: see
+              suffix: chap. 2
+    latex: |-
+      \parencite[see][chap. 2]{jon90}
+
+  - title: Multiple narrative citations
+    # myst: ??
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: narrative
+          children:
+            - type: cite
+              label: jon90
+              kind: narrative
+            - type: cite
+              label: jam91
+              kind: narrative
+    latex: |-
+      \textcite{jon90, jam91}
+
+  - title: Multiple parenthetical citations
+    myst: |-
+      [@jon90; @jam91]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+            - type: cite
+              label: jam91
+              kind: parenthetical
+    latex: |-
+      \parencite{jon90, jam91}
+
+  - title: Multiple parenthetical citations with prefix and suffix
+    myst: |-
+      [cf. @jon90; @jam91, among others]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              prefix: cf.
+            - type: cite
+              label: jam91
+              kind: parenthetical
+              suffix: among others
+    latex: |-
+      \parencite[cf.][among others]{jon90, jam91}
+
+  - title: Partial citation (only year, narrative)
+    # myst: ??
+    mdast:
+      type: root
+      children:
+        - type: cite
+          label: jon90
+          kind: narrative
+          partial: year
+    latex: |-
+      \cite*{jon90}
+
+  - title: Partial citation (only year, parenthetical)
+    myst: |-
+      [-@jon90]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              partial: year
+    latex: |-
+      \parencite*{jon90}

--- a/packages/myst-to-tex/tests/citations_natbib.yml
+++ b/packages/myst-to-tex/tests/citations_natbib.yml
@@ -1,0 +1,204 @@
+title: NatBib citation style examples
+cases:
+  - title: Narrative citation
+    imports:
+      - natbib
+    myst: |-
+      @jon90
+    mdast:
+      type: root
+      children:
+        - type: cite
+          label: jon90
+          kind: narrative
+    latex: |-
+      \citet{jon90}
+
+  - title: Narrative citation in a citeGroup
+    # myst: ??
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: narrative
+          children:
+            - type: cite
+              label: jon90
+              kind: narrative
+    latex: |-
+      \citet{jon90}
+
+  - title: Narrative citation with suffix
+    myst: |-
+      @jon90 [chap. 2]
+    mdast:
+      type: root
+      children:
+        - type: cite
+          label: jon90
+          kind: narrative
+          suffix: chap. 2
+    latex: |-
+      \citet[chap. 2]{jon90}
+
+  - title: Parenthetical citation
+    myst: |-
+      [@jon90]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+    latex: |-
+      \citep{jon90}
+
+  - title: Parenthetical citation with suffix
+    myst: |-
+      [@jon90, chap. 2]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              suffix: chap. 2
+    latex: |-
+      \citep[chap. 2]{jon90}
+
+  - title: Parenthetical citation with prefix
+    myst: |-
+      [see @jon90]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              prefix: see
+    latex: |-
+      \citep[see][]{jon90}
+
+  - title: Parenthetical citation with prefix and suffix
+    myst: |-
+      [see @jon90, chap. 2]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              prefix: see
+              suffix: chap. 2
+    latex: |-
+      \citep[see][chap. 2]{jon90}
+
+  - title: Multiple narrative citations
+    # myst: ??
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: narrative
+          children:
+            - type: cite
+              label: jon90
+              kind: narrative
+            - type: cite
+              label: jam91
+              kind: narrative
+    latex: |-
+      \citet{jon90, jam91}
+
+  - title: Multiple parenthetical citations
+    myst: |-
+      [@jon90; @jam91]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+            - type: cite
+              label: jam91
+              kind: parenthetical
+    latex: |-
+      \citep{jon90, jam91}
+
+  - title: Multiple parenthetical citations with prefix and suffix
+    myst: |-
+      [cf. @jon90; @jam91, among others]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              prefix: cf.
+            - type: cite
+              label: jam91
+              kind: parenthetical
+              suffix: among others
+    latex: |-
+      \citep[cf.][among others]{jon90, jam91}
+
+  - title: Partial citation (only author)
+    # myst: ??
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              partial: author
+    latex: |-
+      \citeauthor{jon90}
+
+  - title: Partial citation (only year, narrative)
+    # myst: ??
+    mdast:
+      type: root
+      children:
+        - type: cite
+          label: jon90
+          kind: narrative
+          partial: year
+    latex: |-
+      \citeyear{jon90}
+
+  - title: Partial citation (only year, parenthetical)
+    myst: |-
+      [-@jon90]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              partial: year
+    latex: |-
+      \citeyearpar{jon90}

--- a/packages/myst-to-tex/tests/citations_numerical.yml
+++ b/packages/myst-to-tex/tests/citations_numerical.yml
@@ -1,0 +1,161 @@
+title: Numerical only citation style examples
+options:
+  citestyle: numerical-only
+cases:
+  - title: Narrative citation
+    myst: |-
+      @jon90
+    mdast:
+      type: root
+      children:
+        - type: cite
+          label: jon90
+          kind: narrative
+    latex: |-
+      \cite{jon90}
+
+  - title: Narrative citation in a citeGroup
+    # myst: ??
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: narrative
+          children:
+            - type: cite
+              label: jon90
+              kind: narrative
+    latex: |-
+      \cite{jon90}
+
+  - title: Narrative citation with suffix
+    myst: |-
+      @jon90 [chap. 2]
+    mdast:
+      type: root
+      children:
+        - type: cite
+          label: jon90
+          kind: narrative
+          suffix: chap. 2
+    latex: |-
+      \cite[chap. 2]{jon90}
+
+  - title: Parenthetical citation
+    myst: |-
+      [@jon90]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+    latex: |-
+      \cite{jon90}
+
+  - title: Parenthetical citation with suffix
+    myst: |-
+      [@jon90, chap. 2]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              suffix: chap. 2
+    latex: |-
+      \cite[chap. 2]{jon90}
+
+  - title: Parenthetical citation with prefix
+    myst: |-
+      [see @jon90]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              prefix: see
+    latex: |-
+      \cite[see][]{jon90}
+
+  - title: Parenthetical citation with prefix and suffix
+    myst: |-
+      [see @jon90, chap. 2]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              prefix: see
+              suffix: chap. 2
+    latex: |-
+      \cite[see][chap. 2]{jon90}
+
+  - title: Multiple narrative citations
+    # myst: ??
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: narrative
+          children:
+            - type: cite
+              label: jon90
+              kind: narrative
+            - type: cite
+              label: jam91
+              kind: narrative
+    latex: |-
+      \cite{jon90, jam91}
+
+  - title: Multiple parenthetical citations
+    myst: |-
+      [@jon90; @jam91]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+            - type: cite
+              label: jam91
+              kind: parenthetical
+    latex: |-
+      \cite{jon90, jam91}
+
+  - title: Multiple parenthetical citations with prefix and suffix
+    myst: |-
+      [cf. @jon90; @jam91, among others]
+    mdast:
+      type: root
+      children:
+        - type: citeGroup
+          kind: parenthetical
+          children:
+            - type: cite
+              label: jon90
+              kind: parenthetical
+              prefix: cf.
+            - type: cite
+              label: jam91
+              kind: parenthetical
+              suffix: among others
+    latex: |-
+      \cite[cf.][among others]{jon90, jam91}

--- a/packages/myst-to-tex/tests/run.spec.ts
+++ b/packages/myst-to-tex/tests/run.spec.ts
@@ -3,18 +3,20 @@ import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
 import { unified } from 'unified';
-import type { LatexResult } from '../src';
+import type { LatexResult, Options } from '../src';
 import mystToTex from '../src';
 
 type TestCase = {
   title: string;
   latex: string;
   mdast: Record<string, any>;
+  imports?: string[];
 };
 
 type TestCases = {
   title: string;
   cases: TestCase[];
+  options?: Options;
 };
 
 const excludedYml = ['glossaries.yml'];
@@ -28,13 +30,18 @@ const casesList: TestCases[] = fs
     return yaml.load(content) as TestCases;
   });
 
-casesList.forEach(({ title, cases }) => {
+casesList.forEach(({ title, cases, options }) => {
   describe(title, () => {
-    test.each(cases.map((c): [string, TestCase] => [c.title, c]))('%s', (_, { latex, mdast }) => {
-      const pipe = unified().use(mystToTex);
-      pipe.runSync(mdast as any);
-      const file = pipe.stringify(mdast as any);
-      expect((file.result as LatexResult).value).toEqual(latex);
-    });
+    test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
+      '%s',
+      (_, { latex, mdast, imports }) => {
+        const pipe = unified().use(mystToTex, options);
+        pipe.runSync(mdast as any);
+        const file = pipe.stringify(mdast as any);
+        const result = file.result as LatexResult;
+        expect(result.value).toEqual(latex);
+        if (imports) expect(result.imports).toEqual(imports);
+      },
+    );
   });
 });


### PR DESCRIPTION
This PR aims to improve the handling of citations in LaTeX, both for standard natbib and for biblatex. I based the testcases on the list provided in #858, so it now correctly handles narrative and parenthetical citations, with partial citations where supported and prefixes and suffixes for all configurations.

I included a few cases that are representable in the AST, but for which I could not find a valid syntax. This includes multiple narrative citations (`\citet{jon90, jam91}`), partial author citations and partial year citations in narrative form. These cases are marked with `# myst: ??` in the testcases.

I decided to move all logic to the `cite` handler and let `citeGroup` be a simple pass-through to all children, to avoid a duplication of logic in both. The downside is that the `cite` node changes behaviour not only based on its parent (which was already the case), but also based on its siblings. Overall I think I prefer this over extracting some of the logic and then using that in both the `citeGroup` and in `cite`. An alternative could be to enforce that `cite`s are always in a `citeGroup`, but given that most of the relevant properties are on `cite`, I don't think that option makes much sense.

Fixes #858 