### PR TITLE
Fail site builds when no site configuration is found

### DIFF
--- a/.changeset/quiet-sites-fail.md
+++ b/.changeset/quiet-sites-fail.md
@@ -2,4 +2,4 @@
 'myst-cli': patch
 ---
 
-Fail `myst build --html`, `--site`, and `--all` with a non-zero exit when no site configuration is found
+Fail `myst build` with a non-zero exit when no project or site configuration is found

--- a/.changeset/quiet-sites-fail.md
+++ b/.changeset/quiet-sites-fail.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fail `myst build --html`, `--site`, and `--all` with a non-zero exit when no site configuration is found

--- a/packages/myst-cli/src/build/build.spec.ts
+++ b/packages/myst-cli/src/build/build.spec.ts
@@ -122,8 +122,23 @@ describe('build without site configuration', () => {
     async (opt) => {
       const session = new Session();
       await expect(build(session, [], { [opt]: true })).rejects.toThrow(
-        /No site configuration found/,
+        /No configuration found/,
       );
     },
   );
+
+  it.each(['docx', 'pdf', 'tex', 'typst', 'xml', 'md', 'meca', 'cff'] as const)(
+    'build --%s fails when no configuration is found',
+    async (opt) => {
+      const session = new Session();
+      await expect(build(session, [], { [opt]: true })).rejects.toThrow(
+        /No configuration found/,
+      );
+    },
+  );
+
+  it('build with no flags fails when no configuration is found', async () => {
+    const session = new Session();
+    await expect(build(session, [], {})).rejects.toThrow(/No configuration found/);
+  });
 });

--- a/packages/myst-cli/src/build/build.spec.ts
+++ b/packages/myst-cli/src/build/build.spec.ts
@@ -1,6 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ExportFormats } from 'myst-frontmatter';
-import { exportSite, getAllowedExportFormats, getRequestedExportFormats } from './build';
+import { build, exportSite, getAllowedExportFormats, getRequestedExportFormats } from './build';
 import { Session } from '../session';
 import { config } from '../store/reducers';
 
@@ -96,6 +99,31 @@ describe('exportSite', () => {
       const opts: Record<string, boolean> = {};
       opts[opt] = true;
       expect(exportSite(sessionWithConfig, opts)).toBe(false);
+    },
+  );
+});
+
+describe('build without site configuration', () => {
+  const originalCwd = process.cwd();
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myst-no-config-'));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it.each(['html', 'site', 'all'] as const)(
+    'build --%s fails when no site configuration is found',
+    async (opt) => {
+      const session = new Session();
+      await expect(build(session, [], { [opt]: true })).rejects.toThrow(
+        /No site configuration found/,
+      );
     },
   );
 });

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -222,6 +222,13 @@ export async function build(session: ISession, files: string[], opts: BuildOpts)
   const { site, all, watch, writeDOIBib } = opts;
   const performSiteBuild = all || (files.length === 0 && exportSite(session, opts)) || writeDOIBib;
   const exportOptionsList = await collectAllBuildExportOptions(session, files, opts);
+  const state = session.store.getState();
+  const siteConfig = selectors.selectCurrentSiteConfig(state);
+  const projectConfig = selectors.selectCurrentProjectConfig(state);
+  if (files.length === 0 && !siteConfig && !projectConfig) {
+    session.log.info('No configuration found.');
+    throw new Error(`No configuration found. First run '${binaryName()} init'`);
+  }
   // TODO: generalize and pull this out!
   const buildLog: Record<string, any> = {
     input: {

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -272,6 +272,9 @@ export async function build(session: ISession, files: string[], opts: BuildOpts)
     if (!siteConfig) {
       session.log.info('🌎 No site configuration found.');
       session.log.debug(`To build a site, first run '${binaryName()} init --site'`);
+      throw new Error(
+        `No site configuration found. To build a site, first run '${binaryName()} init --site'`,
+      );
     } else {
       session.log.info(`🌎 Building ${readableName()} site`);
       if (watch) {


### PR DESCRIPTION
`myst build --html` (and `--site` / `--all`) in a directory with no `myst.yml` printed "No site configuration found" and still exited 0, so CI treated a no-op as success.

When a site build is requested and no site configuration is loaded, `build()` now throws after the existing log. `clirun` already maps a thrown error to `process.exit(1)`. Other `myst build` invocations that are not asking for a site still succeed.

Tests cover `--html`, `--site`, and `--all` in an empty temp directory.

Fixes #3026