### PR TITLE
🪪 Point CC0, CC-PDM and CC-SA license URLs at the pages Creative Commons serves

### DIFF
--- a/.changeset/great-pandas-relate.md
+++ b/.changeset/great-pandas-relate.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Point CC0, CC-PDM and CC-SA license URLs at the pages Creative Commons actually serves

--- a/packages/myst-frontmatter/src/licenses/licenses.spec.ts
+++ b/packages/myst-frontmatter/src/licenses/licenses.spec.ts
@@ -43,6 +43,30 @@ describe('licenses are upto date with SPDX', () => {
     );
     expect(licenses).toEqual(onlineLicenses);
   });
+
+  it('creative commons urls match the SPDX seeAlso links', async () => {
+    const data: any = await (await fetch('https://spdx.org/licenses/licenses.json')).json();
+    // SPDX points at the legalcode page, and creativecommons.org serves the
+    // jurisdiction suffix case-insensitively
+    const clean = (url: string) =>
+      url
+        .toLowerCase()
+        .replace(/legalcode.*$/, '')
+        .replace(/\/+$/, '');
+    const mismatched = (data.licenses as any[])
+      .filter((l) => !l.isDeprecatedLicenseId && l.licenseId.startsWith('CC'))
+      .map((l) => {
+        const seeAlso = (l.seeAlso as string[])
+          .filter((url) => url.includes('creativecommons.org'))
+          .map(clean);
+        if (!seeAlso.length) return undefined;
+        const url = validateLicense(l.licenseId, opts)?.url;
+        if (url && seeAlso.includes(clean(url))) return undefined;
+        return `${l.licenseId}: ${url}`;
+      })
+      .filter(Boolean);
+    expect(mismatched).toEqual([]);
+  });
 });
 
 describe('validateLicense', () => {

--- a/packages/myst-frontmatter/src/licenses/validators.ts
+++ b/packages/myst-frontmatter/src/licenses/validators.ts
@@ -29,33 +29,40 @@ function createURL(id: string, cc?: boolean, osi?: boolean): string {
     const kind = match[1].toUpperCase();
     const version = match[2] ?? '4.0';
     const extra = match[3] ?? '';
+    // The public domain tools do not live under /licenses/, so this is the whole
+    // path rather than the part after /licenses.
     let link = '';
     switch (kind) {
       case 'CC-BY':
-        link = `/by/${version}/`;
+        link = `/licenses/by/${version}/`;
         break;
       case 'CC-BY-SA':
-        link = `/by-sa/${version}/`;
+        link = `/licenses/by-sa/${version}/`;
         break;
       case 'CC-BY-NC':
-        link = `/by-nc/${version}/`;
+        link = `/licenses/by-nc/${version}/`;
         break;
       case 'CC-BY-NC-SA':
-        link = `/by-nc-sa/${version}/`;
+        link = `/licenses/by-nc-sa/${version}/`;
         break;
       case 'CC-BY-ND':
-        link = `/by-nd/${version}/`;
+        link = `/licenses/by-nd/${version}/`;
         break;
       case 'CC-BY-NC-ND':
-        link = `/by-nc-nd/${version}/`;
+        // version 1.0 is served under the historical "by-nd-nc" ordering
+        link =
+          version === '1.0' ? `/licenses/by-nd-nc/${version}/` : `/licenses/by-nc-nd/${version}/`;
+        break;
+      case 'CC-SA':
+        link = `/licenses/sa/${version}/`;
         break;
       case 'CC-ZERO':
       case 'CC-0':
       case 'CC0':
-        link = '/zero/1.0/';
+        link = '/publicdomain/zero/1.0/';
         break;
       case 'CC-PDDC':
-        link = '/publicdomain/';
+        link = '/licenses/publicdomain/';
         break;
       case 'CC-PDM':
         link = '/publicdomain/mark/1.0/';
@@ -64,7 +71,7 @@ function createURL(id: string, cc?: boolean, osi?: boolean): string {
         break;
     }
     if (extra) link += `${extra}/`;
-    return `https://creativecommons.org/licenses${link}`;
+    return `https://creativecommons.org${link}`;
   }
   if (osi) {
     return `https://opensource.org/licenses/${id.replace(/(-or-later)|(-only)$/, '')}`;


### PR DESCRIPTION
`createURL` (`packages/myst-frontmatter/src/licenses/validators.ts:23`) builds every Creative
Commons URL as `https://creativecommons.org/licenses` + a path. The public domain tools are not
served under `/licenses/`, and `CC-SA` has no `case` at all, so it falls through `default: break`
and returns the bare base.

Measured with `curl -I`, today:

| license | url on `main` | status |
|---|---|---|
| `CC0-1.0` | `.../licenses/zero/1.0/` | **404** |
| `CC-PDM-1.0` | `.../licenses/publicdomain/mark/1.0/` | 301 to `publicdomain/certification/1.0/us`, a different licence |
| `CC-SA-1.0` | `https://creativecommons.org/licenses` | 301 to the licence index |

Second-order, reproduced against the built package: because `URL_ID_LOOKUP` is derived from these
same strings, `license: https://creativecommons.org/publicdomain/zero/1.0/` — the real CC0 URL —
does **not** resolve, it comes back as `{url: ...}` with no id, name or `CC`. And
`license: https://creativecommons.org/licenses` resolves to `CC-SA-1.0`.

`CC-BY-NC-ND-1.0` is also included: creativecommons.org serves version 1.0 under the historical
`by-nd-nc` ordering and 301s the other way. Cosmetic, but it lets the new test run with no
exception list.

Why nothing caught it: `licenses.spec.ts` already compares the table against
`spdx.org/licenses/licenses.json`, but it rebuilds each entry from `name`, `isOsiApproved`,
`isFsfLibre` and the `CC` prefix and **drops `seeAlso`**, which is the field that carries the URL.
The three URLs asserted elsewhere in that file are `CC-BY-4.0`, `CC-BY-3.0` and `CC-BY-ND-4.0` —
all shapes the switch already handles. This adds a second `it` comparing the derived URL against
SPDX's `seeAlso`.

Matched pair, `npx vitest run` in `packages/myst-frontmatter`, same command and env:
**495 passed / 0 failed before → 496 passed / 0 failed after.** Two mutants, source marker asserted
and printed before each measurement:

* revert `validators.ts`, keep the test → 1 failed / 495 passed, listing all four ids;
* fix only the two public-domain paths (the ones that visibly 404) → still 1 failed / 495 passed,
  listing `CC-SA-1.0` and `CC-BY-NC-ND-1.0`. That is what shows the silent `default` branch is part
  of the bug and the test catches the class rather than the one instance.

Not tested / disclosed:

* the jurisdiction suffix is still emitted uppercase (`.../by/3.0/IGO/`) where SPDX and
  creativecommons.org use lowercase. It 301s correctly, and lowercasing it would change 20 URLs and
  break reverse lookup for anyone who already wrote the uppercase form, so I left it and made the
  test case-insensitive instead. Happy to change that if you'd rather.
* the new test needs network, like the existing SPDX test next to it.
* `bun run test` at the repo root also fails `myst-execute` here, before and after, because this
  machine has no `python` on `PATH` (`python not found in PATH; install it to run myst-execute
  tests`). Nothing else in the repo imports `createURL`.
* I have not claimed CI is green — nothing has run upstream yet.

Changeset added (`myst-frontmatter`: patch). Written with AI assistance (Claude); the measurements
above were run locally on this branch.
