### PR TITLE
🏷️ Include only files in public manifest

### DIFF
--- a/.changeset/nine-onions-arrive.md
+++ b/.changeset/nine-onions-arrive.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Only include files in public manifest

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -168,6 +168,9 @@ export async function writePublicJson(session: ISession) {
   const publicPath = session.publicPath();
   const dir = await opendir(publicPath, { recursive: true });
   for await (const path of dir) {
+    if (!path.isFile()) {
+      continue;
+    }
     const subPath = relative(publicPath, join(path.parentPath, path.name));
     paths.push(`/${subPath}`);
   }


### PR DESCRIPTION
The public manifest will be used by themes to be able to close over the manifest of a site without having access to the file system.

However, the current implementation that generates this file includes folders. These folders are not clearly typed, and it would be a mistake to try to fetch them. We should rather only include files, and therefore only allow non-empty directories.